### PR TITLE
Add Sonar projectName property

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,7 @@ android {
 
 sonar {
     properties {
+        property("sonar.projectName", "govuk-mobile-android-app")
         property("sonar.projectKey", "alphagov_govuk-mobile-android-app")
         property("sonar.organization", "alphagov")
         property("sonar.host.url", "https://sonarcloud.io")


### PR DESCRIPTION
# Fix Sonar project name

Currently, SonarCloud has set the default app name to be `app`. This is because, you need to set the name deliberately as a property.

To fix this we just need to tell SonarCloud what we want the name to be.
