### PR TITLE
Add app modules from develop branch via JitPack

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsKotlinAndroid)
     id("org.sonarqube") version "4.4.1.3373"
+    id("maven-publish")
 }
 
 sonar {
@@ -73,8 +74,9 @@ android {
     }
 }
 
-dependencies {
+val moduleBranch = "develop-SNAPSHOT"
 
+dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
@@ -83,11 +85,17 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation("com.github.alphagov:govuk-mobile-android-onboarding:$moduleBranch")
+    implementation("com.github.alphagov:govuk-mobile-android-services:$moduleBranch")
+    implementation("com.github.alphagov:govuk-mobile-android-homepage:$moduleBranch")
+
     testImplementation(libs.junit)
+
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
+
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/app/src/main/java/uk/govuk/app/MainActivity.kt
+++ b/app/src/main/java/uk/govuk/app/MainActivity.kt
@@ -3,6 +3,7 @@ package uk.govuk.app
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -11,6 +12,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import uk.govuk.app.ui.theme.GovukmobileandroidappTheme
+import uk.govuk.homepage.HomepageStart
+import uk.govuk.onboarding.OnboardingStart
+import uk.govuk.services.ServicesStart
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -23,7 +27,12 @@ class MainActivity : ComponentActivity() {
                             .fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    Greeting("GOV.UK Android App")
+                    Column {
+                        Greeting("GOV.UK Android App")
+                        OnboardingStart()
+                        HomepageStart()
+                        ServicesStart()
+                    }
                 }
             }
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,9 +16,11 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://jitpack.io")
+        }
     }
 }
 
 rootProject.name = "govuk-mobile-android-app"
 include(":app")
- 


### PR DESCRIPTION
# Add app modules from develop branch via JitPack

Pulls in the app modules from [JitPack](jitpack.io). Currently, using the latest `SNAPSHOT` from the `develop` branch. 

## JIRA ticket(s)
  - [GOVAPP-455](https://govukverify.atlassian.net/jira/software/projects/GOVAPP/boards/405?selectedIssue=GOVAPP-455)

## Screen shots

| Before | After |
|---|---|
| ![Screenshot_20240513_152459](https://github.com/alphagov/govuk-mobile-android-app/assets/44037625/9253d421-c4d0-4788-a119-40724be53a8c) | ![Screenshot_20240513_152406](https://github.com/alphagov/govuk-mobile-android-app/assets/44037625/4af3d770-d386-4042-8c05-51aa9a5cd96d) |

[GOVAPP-455]: https://govukverify.atlassian.net/browse/GOVAPP-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ