### PR TITLE
Fix alignment issue on splash screen

### DIFF
--- a/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -108,7 +109,8 @@ private fun SplashScreen(
             .fillMaxHeight()
             .fillMaxWidth()
             .background(GovUkTheme.colourScheme.surfaces.primary),
-        verticalArrangement = Arrangement.Center
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         val composition by rememberLottieComposition(
             LottieCompositionSpec.RawRes(R.raw.app_splash)


### PR DESCRIPTION
# Fix alignment issue on Splash Screen

Missing horizontal alignment.

## Screen shots

| Before | After |
|---|---|
| ![before-portrait](https://github.com/user-attachments/assets/a18a6239-3af3-4389-b912-417ca6d56576) | ![after-portrait](https://github.com/user-attachments/assets/37c925ff-13fb-4427-8d2a-f787fe464874) |
| ![before-landscape](https://github.com/user-attachments/assets/0e112b2c-7934-462f-9b74-f50de960fcc6) | ![after-landscape](https://github.com/user-attachments/assets/ddad910c-968b-4eee-b7f4-ad4e0df6cce9) |

| Difficult to see in portrait |
| --- |
| <img width="1420" alt="Screenshot 2024-07-18 at 13 57 01" src="https://github.com/user-attachments/assets/0d55c765-eb19-4f26-bdce-bfc4fd248962"> |

| Much easier in landscape |
| --- |
| ![Screenshot 2024-07-18 at 14 00 36](https://github.com/user-attachments/assets/8fae1a6d-b85c-466e-b704-1d093ef39ea5) |


