### PR TITLE
Bug fix - animations setting causing the app to crash

### DIFF
--- a/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
@@ -220,7 +220,7 @@ private fun BottomNavScaffold() {
     }
 }
 
-private fun areAnimationsDisabled(context: Context): Boolean {
+fun areAnimationsDisabled(context: Context): Boolean {
     val animatorDurationScale = Settings.Global.getFloat(
         context.contentResolver,
         Settings.Global.ANIMATOR_DURATION_SCALE,

--- a/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
@@ -1,6 +1,7 @@
 package uk.govuk.app.ui
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.provider.Settings
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -118,12 +119,14 @@ private fun SplashScreen(
 
         var state = animateLottieCompositionAsState(composition = composition)
 
-        if (Settings.Global.getFloat(LocalContext.current.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE) == 0f) {
+        // Handle cases where animation is disabled...
+        if (areAnimationsDisabled(LocalContext.current)) {
             state = animateLottieCompositionAsState(composition = composition, isPlaying = false)
             GlobalScope.launch {
                 delay(6000) // wait for 6 seconds
                 onSplashDone()
             }
+        // Animations are enabled...
         } else {
             LaunchedEffect(state.progress) {
                 if (state.progress == 1f) {
@@ -215,4 +218,13 @@ private fun BottomNavScaffold() {
             }
         }
     }
+}
+
+private fun areAnimationsDisabled(context: Context): Boolean {
+    val animatorDurationScale = Settings.Global.getFloat(
+        context.contentResolver,
+        Settings.Global.ANIMATOR_DURATION_SCALE,
+        1f
+    )
+    return animatorDurationScale == 0f
 }

--- a/app/src/test/kotlin/uk/govuk/app/launch/RemoveAnimationsSettingTest.kt
+++ b/app/src/test/kotlin/uk/govuk/app/launch/RemoveAnimationsSettingTest.kt
@@ -1,0 +1,46 @@
+package uk.govuk.app.launch
+
+import android.content.ContentResolver
+import android.content.Context
+import android.provider.Settings
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import uk.govuk.app.ui.areAnimationsDisabled
+
+class RemoveAnimationsSettingTest {
+    private val context = mockk<Context>()
+
+    @Before
+    fun setup() {
+        mockkStatic(Settings.Global::class)
+        every { context.contentResolver } returns mockk()
+    }
+
+    @Test
+    fun `Given animations are allowed, then animations will not be disabled`() {
+        every {
+            Settings.Global.getFloat(any<ContentResolver>(), Settings.Global.ANIMATOR_DURATION_SCALE, any<Float>())
+        } returns 1f
+
+        runTest {
+            assertFalse(areAnimationsDisabled(context))
+        }
+    }
+
+    @Test
+    fun `Given animations are not allowed, then animations will be disabled`() {
+        every {
+            Settings.Global.getFloat(any<ContentResolver>(), Settings.Global.ANIMATOR_DURATION_SCALE, any<Float>())
+        } returns 0f
+
+        runTest {
+            assertTrue(areAnimationsDisabled(context))
+        }
+    }
+}


### PR DESCRIPTION
# Bug fix - animations setting causing the app to crash

The app is crashing with a RuntimeException.

On investigation, it was discovered that the `ANIMATOR_DURATION_SCALE` [setting](https://developer.android.com/reference/android/provider/Settings.Global#ANIMATOR_DURATION_SCALE) was returning null when attempting to get it via the `getFloat()` [method](https://developer.android.com/reference/android/provider/Settings.Global#getFloat(android.content.ContentResolver,%20java.lang.String)) as recommended, which of course cannot be tested for equality against another Float.

While this setting is stored as a String, it is actually a Float under-the-covers, with a value of 0.0f or 1.0f. In theory, `getFloat()` should be fine with these values. But clearly isn't under some circumstances! Precisely what those circumstances are is unclear. 

We therefore change to using the alternate implementation of the `getFloat()` [method](https://developer.android.com/reference/android/provider/Settings.Global#getFloat(android.content.ContentResolver,%20java.lang.String,%20float)) which takes an additional - `default` return value - parameter. This resolves the issue.

I've added tests, which makes me feel slightly uncomfortable as they're really only testing the `getFloat()` method. Not ideal and frankly shouldn't be necessary!

Testing the splash screen doesn't feel like the correct approach here either, and to be honest, I couldn't quite figure out how to do it in a nice way due to animation timing issues.

So, these tests are there simply as an early warning system should the API cease to perform as expected.

## JIRA ticket(s)
  - [GOVAPP-614](https://govukverify.atlassian.net/browse/GOVUKAPP-614)
