### PR TITLE
Update trailing icon colour to be in-line with primary text

### DIFF
--- a/design/src/main/kotlin/uk/govuk/app/design/ui/theme/Color.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/theme/Color.kt
@@ -91,7 +91,7 @@ val LightColorScheme = GovUkColourScheme(
         buttonSecondaryHighlight = Blue5,
         buttonSecondaryDisabled = Grey700,
         buttonSecondaryFocused = Black,
-        trailingIcon = Grey300
+        trailingIcon = Black
     ),
     surfaces = Surfaces(
         background = Grey50,
@@ -128,7 +128,7 @@ val DarkColorScheme = GovUkColourScheme(
         buttonSecondaryHighlight = Blue6,
         buttonSecondaryDisabled = Grey300,
         buttonSecondaryFocused = Black,
-        trailingIcon = Grey500
+        trailingIcon = White
     ),
     surfaces = Surfaces(
         background = Black,


### PR DESCRIPTION
# Update trailing icon colour to be in-line with primary text

## JIRA ticket(s)
  - [GOVAPP-681](https://govukverify.atlassian.net/browse/GOVUKAPP-681)

## Figma
  - [Figma board](https://www.figma.com/design/N4v2GPQhwZ7DwhqucyJqlu/GOV.UK-Apps-and-notifications?node-id=9290-29532&t=osxlMej2WD4DEiOP-0)

## Screen shots

### Before

| Light Mode | Dark Mode |
|---|---|
| ![Screenshot_20240821_135053](https://github.com/user-attachments/assets/69ba95ae-3a2e-4066-9e30-f1ca2254b97f) | ![Screenshot_20240821_134906](https://github.com/user-attachments/assets/b599aac6-7293-47b0-931a-70f9b441c21f) |

### After

| Light Mode | Dark Mode |
|---|---|
| ![Screenshot_20240821_135146](https://github.com/user-attachments/assets/d705def8-5bc5-4e68-ad85-8bffbadb889f) | ![Screenshot_20240821_135012](https://github.com/user-attachments/assets/b87c471a-92b3-4f17-89fb-4333974e9d33) |
