### PR TITLE
GOVUKAPP-691 onboarding GA events fired for intermediary screens

### DIFF
--- a/feature/onboarding/src/main/kotlin/uk/govuk/app/onboarding/ui/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/uk/govuk/app/onboarding/ui/OnboardingScreen.kt
@@ -1,6 +1,5 @@
 package uk.govuk.app.onboarding.ui
 
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -114,9 +113,8 @@ private fun OnboardingScreen(
         val coroutineScope = rememberCoroutineScope()
         val changePage: (Int) -> Unit = { pageIndex ->
             coroutineScope.launch {
-                pagerState.animateScrollToPage(
-                    pageIndex,
-                    animationSpec = tween(500)
+                pagerState.scrollToPage(
+                    pageIndex
                 )
             }
         }


### PR DESCRIPTION
# onboarding module - GA events being fired for intermediary screens

**What is happening**

When the user is on the onboarding screens and chooses to move from the first screen to the last (or vice versa) - thereby skipping any intermediary screens - Google Analytics (GA) page view events are still fired for those intermediary screens - as if they were viewed. This effectively skews our GA results and we are unable to know that a skip has happened.

For example (given 3 screens)…

- The user is on Screen 1 and wishes to go to Screen 3. GA events for Screen 2 and Screen 3 occur.
- The user is on Screen 3 and wishes to go to Screen 1. GA events for Screen 2 and Screen 1 occur.
- Moving from Screen 1 or Screen 3 to Screen 2 only fires a single GA event form Screen 2 as expected.

**What should happen** 

- The user is on Screen 1 and wishes to go to Screen 3. A single GA event for Screen 3 occurs.
- The user is on Screen 3 and wishes to go to Screen 1. A single GA event for Screen 1 occurs.
- Moving from Screen 1 or Screen 3 to Screen 2 only fires a single GA event form Screen 2 as above.

**Fix**

We are using the [Android HorizontalPager](https://developer.android.com/develop/ui/compose/layouts/pager#horizontalpager) to navigate between the various onboarding screens. This only [appears to have two methods](https://developer.android.com/develop/ui/compose/layouts/pager#scroll-to-item) - `PagerState#scrollToPage()` and `PagerState#animateScrollToPage()` - that allow the user to navigate from one page to another within the pager.

We are currently using the `PagerState#animateScrollToPage()` method and this appears not to 'snap' from one page to another, but scroll (via intermediary pages) via a smooth animation. It is this method that is causing the issue. So, we switch to `PagerState#scrollToPage()` instead.

## JIRA ticket(s)
  - [GOVAPP-691](https://govukverify.atlassian.net/browse/GOVUKAPP-691)

## Videos

| Before | After |
|---|---|
| https://github.com/user-attachments/assets/5e04adc9-62f3-454c-b934-7d3ceb27c2c6 | https://github.com/user-attachments/assets/b853c923-1208-428f-96da-f96f8e207881 |