### PR TITLE
GOVUKAPP 673, 675 & 677 Settings

### DIFF
--- a/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -15,6 +17,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import uk.govuk.app.design.R
 import uk.govuk.app.design.ui.theme.GovUkTheme
@@ -53,5 +57,32 @@ fun SearchHeader(
             )
         }
         ListDivider()
+    }
+}
+
+@Composable
+fun BaseHeader(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth()
+            .padding(GovUkTheme.spacing.medium)
+            .height(64.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Title2BoldLabel(
+            text = text,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BaseHeaderPreview() {
+    GovUkTheme {
+        BaseHeader("Heading text")
     }
 }

--- a/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
@@ -61,7 +61,7 @@ fun SearchHeader(
 }
 
 @Composable
-fun BaseHeader(
+fun Header(
     text: String,
     modifier: Modifier = Modifier,
 ) {
@@ -74,38 +74,15 @@ fun BaseHeader(
         Title2BoldLabel(
             text = text,
             textAlign = TextAlign.Center,
-            modifier = Modifier.weight(1f)
+            modifier = modifier.weight(1f)
         )
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun BaseHeaderPreview() {
+private fun HeaderPreview() {
     GovUkTheme {
-        BaseHeader("Heading text")
-    }
-}
-
-@Composable
-fun SettingsHeader(
-    text: String,
-    modifier: Modifier = Modifier,
-) {
-    Title3BoldLabel(
-        text = text,
-        modifier = Modifier.padding(
-            top = GovUkTheme.spacing.medium,
-            start = GovUkTheme.spacing.extraLarge,
-            end = GovUkTheme.spacing.medium
-        )
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun SettingsHeaderPreview() {
-    GovUkTheme {
-        SettingsHeader("Settings text")
+        Header("Heading text")
     }
 }

--- a/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
@@ -86,3 +86,26 @@ private fun BaseHeaderPreview() {
         BaseHeader("Heading text")
     }
 }
+
+@Composable
+fun SettingsHeader(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Title3BoldLabel(
+        text = text,
+        modifier = Modifier.padding(
+            top = GovUkTheme.spacing.medium,
+            start = GovUkTheme.spacing.extraLarge,
+            end = GovUkTheme.spacing.medium
+        )
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingsHeaderPreview() {
+    GovUkTheme {
+        SettingsHeader("Settings text")
+    }
+}

--- a/design/src/main/kotlin/uk/govuk/app/design/ui/component/Label.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/component/Label.kt
@@ -1,5 +1,6 @@
 package uk.govuk.app.design.ui.component
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -314,6 +315,21 @@ fun CaptionRegularLabel(
     )
 }
 
+@Composable
+fun ListHeadingLabel(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Title3BoldLabel(
+        text = text,
+        modifier = modifier.padding(
+            top = GovUkTheme.spacing.medium,
+            start = GovUkTheme.spacing.extraLarge,
+            end = GovUkTheme.spacing.medium
+        )
+    )
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun LargeTitleBold() {
@@ -455,5 +471,13 @@ private fun CaptionBold() {
 private fun CaptionRegular() {
     GovUkTheme {
         CaptionRegularLabel("Caption Regular Label")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ListHeadingLabelPreview() {
+    GovUkTheme {
+        ListHeadingLabel("Settings text")
     }
 }

--- a/design/src/main/kotlin/uk/govuk/app/design/ui/component/Switch.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/component/Switch.kt
@@ -1,0 +1,44 @@
+package uk.govuk.app.design.ui.component
+
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import uk.govuk.app.design.ui.theme.GovUkTheme
+
+@Composable
+fun ToggleSwitch(
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var checked by remember { mutableStateOf(true) }
+
+    Switch(
+        checked = checked,
+        onCheckedChange = {
+            onCheckedChange(it)
+            checked = it
+        },
+        colors = SwitchDefaults.colors(
+            checkedThumbColor = GovUkTheme.colourScheme.surfaces.toggleHandle,
+            checkedTrackColor = GovUkTheme.colourScheme.surfaces.toggleEnabled,
+            checkedBorderColor = GovUkTheme.colourScheme.surfaces.toggleBorder,
+            uncheckedThumbColor = GovUkTheme.colourScheme.surfaces.toggleHandle,
+            uncheckedTrackColor = GovUkTheme.colourScheme.surfaces.toggleDisabled,
+            uncheckedBorderColor = GovUkTheme.colourScheme.surfaces.toggleBorder,
+        )
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ToggleSwitchPreview() {
+    GovUkTheme {
+        ToggleSwitch(onCheckedChange = {})
+    }
+}

--- a/design/src/main/kotlin/uk/govuk/app/design/ui/component/Switch.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/component/Switch.kt
@@ -31,7 +31,8 @@ fun ToggleSwitch(
             uncheckedThumbColor = GovUkTheme.colourScheme.surfaces.toggleHandle,
             uncheckedTrackColor = GovUkTheme.colourScheme.surfaces.toggleDisabled,
             uncheckedBorderColor = GovUkTheme.colourScheme.surfaces.toggleBorder,
-        )
+        ),
+        modifier = modifier
     )
 }
 

--- a/design/src/main/kotlin/uk/govuk/app/design/ui/theme/Color.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/theme/Color.kt
@@ -68,7 +68,11 @@ data class GovUkColourScheme(
         val buttonSecondaryHighlight: Color,
         val buttonSecondaryDisabled: Color,
         val buttonSecondaryFocused: Color,
-        val searchBox: Color
+        val searchBox: Color,
+        val toggleEnabled: Color,
+        val toggleDisabled: Color,
+        val toggleHandle: Color,
+        val toggleBorder: Color
     )
 
     data class Strokes(
@@ -106,7 +110,11 @@ val LightColorScheme = GovUkColourScheme(
         buttonSecondaryHighlight = Grey50,
         buttonSecondaryDisabled = Grey50,
         buttonSecondaryFocused = Yellow,
-        searchBox = Grey60
+        searchBox = Grey60,
+        toggleEnabled = Blue1,
+        toggleDisabled = Grey300,
+        toggleHandle = White,
+        toggleBorder = White
     ),
     strokes = Strokes(
         container = BlackAlpha30,
@@ -143,7 +151,11 @@ val DarkColorScheme = GovUkColourScheme(
         buttonSecondaryHighlight = Black,
         buttonSecondaryDisabled = Black,
         buttonSecondaryFocused = Yellow,
-        searchBox = Grey700
+        searchBox = Grey700,
+        toggleEnabled = Blue2,
+        toggleDisabled = Grey600,
+        toggleHandle = White,
+        toggleBorder = Grey800
     ),
     strokes = Strokes(
         container = WhiteAlpha30,
@@ -181,7 +193,11 @@ val LocalColourScheme = staticCompositionLocalOf {
             buttonSecondaryHighlight = Color.Unspecified,
             buttonSecondaryDisabled = Color.Unspecified,
             buttonSecondaryFocused = Color.Unspecified,
-            searchBox = Color.Unspecified
+            searchBox = Color.Unspecified,
+            toggleEnabled = Color.Unspecified,
+            toggleDisabled = Color.Unspecified,
+            toggleHandle = Color.Unspecified,
+            toggleBorder = Color.Unspecified
         ),
         strokes = Strokes(
             container = Color.Unspecified,

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.hilt.android)
+    implementation(project(":design"))
 
     ksp(libs.hilt.compiler)
 

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -33,13 +33,13 @@ android {
 
 dependencies {
     implementation(projects.analytics)
+    implementation(projects.design)
 
     implementation(libs.androidx.navigation.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.material3)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.hilt.android)
-    implementation(project(":design"))
 
     ksp(libs.hilt.compiler)
 

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -50,6 +52,7 @@ private fun SettingsScreen(
     Column(modifier) {
         BaseHeader("Settings")
         AboutTheApp(onButtonClick)
+        PrivacyAndLegal()
     }
 }
 
@@ -104,6 +107,43 @@ private fun AboutTheApp(
             )
 
             BodyRegularLabel(text = "1.0")
+        }
+    }
+}
+
+@Composable
+private fun PrivacyAndLegal(
+    modifier: Modifier = Modifier
+) {
+    SettingsHeader("Privacy and legal")
+
+    OutlinedCard(
+        colors = CardDefaults.cardColors(
+            containerColor = GovUkTheme.colourScheme.surfaces.card
+        ),
+        modifier = Modifier.fillMaxWidth()
+            .padding(GovUkTheme.spacing.medium)
+    ) {
+        Row(
+            Modifier.padding(GovUkTheme.spacing.medium),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            BodyRegularLabel(
+                text = "Share app usage statistics",
+                modifier = Modifier.weight(1f),
+            )
+
+            Switch(
+                checked = true,
+                onCheckedChange = {},
+
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = GovUkTheme.colourScheme.textAndIcons.buttonPrimaryHighlight,
+                    checkedTrackColor = GovUkTheme.colourScheme.surfaces.primary,
+                    uncheckedThumbColor = GovUkTheme.colourScheme.textAndIcons.buttonPrimaryDisabled,
+                    uncheckedTrackColor = GovUkTheme.colourScheme.surfaces.buttonPrimaryDisabled,
+                )
+            )
         }
     }
 }

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.govuk.app.design.ui.component.BaseHeader
 import uk.govuk.app.design.ui.component.BodyRegularLabel
+import uk.govuk.app.design.ui.component.CaptionRegularLabel
 import uk.govuk.app.design.ui.component.ListDivider
 import uk.govuk.app.design.ui.component.SettingsHeader
 import uk.govuk.app.design.ui.component.ToggleSwitch
@@ -146,5 +147,34 @@ private fun PrivacyAndLegal(
 
             ToggleSwitch(onCheckedChange = {})
         }
+    }
+
+    Row(
+        Modifier.padding(
+            top = 1.dp,
+            start = GovUkTheme.spacing.extraLarge,
+            end = GovUkTheme.spacing.extraLarge,
+            bottom = 1.dp
+        ),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CaptionRegularLabel(
+            text = stringResource(R.string.privacy_description)
+        )
+    }
+
+    Row(
+        Modifier.padding(
+            top = 1.dp,
+            start = GovUkTheme.spacing.extraLarge,
+            end = GovUkTheme.spacing.extraLarge,
+            bottom = GovUkTheme.spacing.medium
+        ),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CaptionRegularLabel(
+            text = stringResource(R.string.privacy_read_more),
+            color = GovUkTheme.colourScheme.textAndIcons.link,
+        )
     }
 }

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -1,12 +1,11 @@
 package uk.govuk.app.settings.ui
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import uk.govuk.app.design.ui.component.BaseHeader
 import uk.govuk.app.settings.SettingsViewModel
 
 @Composable
@@ -34,9 +33,9 @@ private fun SettingsScreen(
     }
 
     Column(modifier) {
-        Text("Settings Screen")
-        Button(onClick = onButtonClick) {
-            Text("Click me!")
-        }
+        BaseHeader("Settings", modifier)
+//        Button(onClick = onButtonClick) {
+//            Text("Click me!")
+//        }
     }
 }

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -20,11 +20,11 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import uk.govuk.app.design.ui.component.BaseHeader
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.CaptionRegularLabel
+import uk.govuk.app.design.ui.component.Header
 import uk.govuk.app.design.ui.component.ListDivider
-import uk.govuk.app.design.ui.component.SettingsHeader
+import uk.govuk.app.design.ui.component.ListHeadingLabel
 import uk.govuk.app.design.ui.component.ToggleSwitch
 import uk.govuk.app.design.ui.theme.GovUkTheme
 import uk.govuk.app.settings.R
@@ -54,8 +54,10 @@ private fun SettingsScreen(
         onPageView()
     }
 
-    Column {
-        BaseHeader(stringResource(R.string.screen_title))
+    Column(
+        modifier = modifier
+    ) {
+        Header(stringResource(R.string.screen_title))
         Column(
             modifier = Modifier.verticalScroll(rememberScrollState())
         ) {
@@ -71,54 +73,61 @@ private fun AboutTheApp(
     onButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    SettingsHeader(stringResource(R.string.about_title))
-
-    // We might want to make this a component when
-    // we understand the various use cases better
-    OutlinedCard(
-        colors = CardDefaults.cardColors(
-            containerColor = GovUkTheme.colourScheme.surfaces.card
-        ),
-        modifier = Modifier.fillMaxWidth()
-            .padding(GovUkTheme.spacing.medium)
+    Column(
+        modifier = modifier
     ) {
-        Row(
-            Modifier.padding(GovUkTheme.spacing.medium),
-            verticalAlignment = Alignment.CenterVertically
+        ListHeadingLabel(stringResource(R.string.about_title))
+
+        // We might want to make this a component when
+        // we understand the various use cases better
+        OutlinedCard(
+            colors = CardDefaults.cardColors(
+                containerColor = GovUkTheme.colourScheme.surfaces.card
+            ),
+            modifier = Modifier.fillMaxWidth()
+                .padding(GovUkTheme.spacing.medium)
         ) {
-            BodyRegularLabel(
-                text = stringResource(R.string.help_setting),
-                modifier = Modifier.weight(1f),
-                color = GovUkTheme.colourScheme.textAndIcons.link,
+            Row(
+                Modifier.padding(GovUkTheme.spacing.medium),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BodyRegularLabel(
+                    text = stringResource(R.string.help_setting),
+                    modifier = Modifier.weight(1f),
+                    color = GovUkTheme.colourScheme.textAndIcons.link,
+                )
+
+                Icon(
+                    painter = painterResource(
+                        uk.govuk.app.design.R.drawable.baseline_open_in_new_24
+                    ),
+                    contentDescription = "",
+                    tint = GovUkTheme.colourScheme.textAndIcons.link,
+                    modifier = Modifier.clickable(onClick = onButtonClick)
+                )
+            }
+
+            ListDivider(
+                Modifier.padding(
+                    top = 1.dp,
+                    bottom = 1.dp,
+                    start = GovUkTheme.spacing.medium,
+                    end = GovUkTheme.spacing.medium
+                )
             )
 
-            Icon(
-                painter = painterResource(R.drawable.baseline_open_in_new_24),
-                contentDescription = "",
-                tint = GovUkTheme.colourScheme.textAndIcons.link,
-                modifier = Modifier.clickable(onClick = onButtonClick)
-            )
-        }
+            Row(
+                Modifier.fillMaxWidth()
+                    .padding(GovUkTheme.spacing.medium),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BodyRegularLabel(
+                    text = stringResource(R.string.version_setting),
+                    modifier = Modifier.weight(1f)
+                )
 
-        ListDivider(Modifier.padding(
-                top = 1.dp,
-                bottom = 1.dp,
-                start = GovUkTheme.spacing.medium,
-                end = GovUkTheme.spacing.medium
-            )
-        )
-
-        Row(
-            Modifier.fillMaxWidth()
-                .padding(GovUkTheme.spacing.medium),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            BodyRegularLabel(
-                text = stringResource(R.string.version_setting),
-                modifier = Modifier.weight(1f)
-            )
-
-            BodyRegularLabel(text = "1.0")
+                BodyRegularLabel(text = "1.0")
+            }
         }
     }
 }
@@ -127,54 +136,58 @@ private fun AboutTheApp(
 private fun PrivacyAndLegal(
     modifier: Modifier = Modifier
 ) {
-    SettingsHeader(stringResource(R.string.privacy_title))
-
-    OutlinedCard(
-        colors = CardDefaults.cardColors(
-            containerColor = GovUkTheme.colourScheme.surfaces.card
-        ),
-        modifier = Modifier.fillMaxWidth()
-            .padding(GovUkTheme.spacing.medium)
+    Column(
+        modifier = modifier
     ) {
+        ListHeadingLabel(stringResource(R.string.privacy_title))
+
+        OutlinedCard(
+            colors = CardDefaults.cardColors(
+                containerColor = GovUkTheme.colourScheme.surfaces.card
+            ),
+            modifier = Modifier.fillMaxWidth()
+                .padding(GovUkTheme.spacing.medium)
+        ) {
+            Row(
+                Modifier.padding(GovUkTheme.spacing.medium),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BodyRegularLabel(
+                    text = stringResource(R.string.share_setting),
+                    modifier = Modifier.weight(1f),
+                )
+
+                ToggleSwitch(onCheckedChange = {})
+            }
+        }
+
         Row(
-            Modifier.padding(GovUkTheme.spacing.medium),
+            Modifier.padding(
+                top = 1.dp,
+                start = GovUkTheme.spacing.extraLarge,
+                end = GovUkTheme.spacing.extraLarge,
+                bottom = 1.dp
+            ),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            BodyRegularLabel(
-                text = stringResource(R.string.share_setting),
-                modifier = Modifier.weight(1f),
+            CaptionRegularLabel(
+                text = stringResource(R.string.privacy_description)
             )
-
-            ToggleSwitch(onCheckedChange = {})
         }
-    }
 
-    Row(
-        Modifier.padding(
-            top = 1.dp,
-            start = GovUkTheme.spacing.extraLarge,
-            end = GovUkTheme.spacing.extraLarge,
-            bottom = 1.dp
-        ),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        CaptionRegularLabel(
-            text = stringResource(R.string.privacy_description)
-        )
-    }
-
-    Row(
-        Modifier.padding(
-            top = 1.dp,
-            start = GovUkTheme.spacing.extraLarge,
-            end = GovUkTheme.spacing.extraLarge,
-            bottom = GovUkTheme.spacing.medium
-        ),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        CaptionRegularLabel(
-            text = stringResource(R.string.privacy_read_more),
-            color = GovUkTheme.colourScheme.textAndIcons.link,
-        )
+        Row(
+            Modifier.padding(
+                top = 1.dp,
+                start = GovUkTheme.spacing.extraLarge,
+                end = GovUkTheme.spacing.extraLarge,
+                bottom = GovUkTheme.spacing.medium
+            ),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            CaptionRegularLabel(
+                text = stringResource(R.string.privacy_read_more),
+                color = GovUkTheme.colourScheme.textAndIcons.link,
+            )
+        }
     }
 }

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -3,8 +3,12 @@ package uk.govuk.app.settings.ui
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedCard
@@ -49,10 +53,15 @@ private fun SettingsScreen(
         onPageView()
     }
 
-    Column(modifier) {
+    Column {
         BaseHeader("Settings")
-        AboutTheApp(onButtonClick)
-        PrivacyAndLegal()
+        Column(
+            modifier = Modifier.verticalScroll(rememberScrollState())
+        ) {
+            AboutTheApp(onButtonClick)
+            PrivacyAndLegal()
+            Spacer(Modifier.height(100.dp))
+        }
     }
 }
 

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.govuk.app.design.ui.component.BaseHeader
@@ -54,7 +55,7 @@ private fun SettingsScreen(
     }
 
     Column {
-        BaseHeader("Settings")
+        BaseHeader(stringResource(R.string.screen_title))
         Column(
             modifier = Modifier.verticalScroll(rememberScrollState())
         ) {
@@ -70,7 +71,7 @@ private fun AboutTheApp(
     onButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    SettingsHeader("About the app")
+    SettingsHeader(stringResource(R.string.about_title))
 
     OutlinedCard(
         colors = CardDefaults.cardColors(
@@ -84,7 +85,7 @@ private fun AboutTheApp(
             verticalAlignment = Alignment.CenterVertically
         ) {
             BodyRegularLabel(
-                text = "Help and feedback",
+                text = stringResource(R.string.help_setting),
                 modifier = Modifier.weight(1f),
                 color = GovUkTheme.colourScheme.textAndIcons.link,
             )
@@ -111,7 +112,7 @@ private fun AboutTheApp(
             verticalAlignment = Alignment.CenterVertically
         ) {
             BodyRegularLabel(
-                text = "App version number",
+                text = stringResource(R.string.version_setting),
                 modifier = Modifier.weight(1f)
             )
 
@@ -124,7 +125,7 @@ private fun AboutTheApp(
 private fun PrivacyAndLegal(
     modifier: Modifier = Modifier
 ) {
-    SettingsHeader("Privacy and legal")
+    SettingsHeader(stringResource(R.string.privacy_title))
 
     OutlinedCard(
         colors = CardDefaults.cardColors(
@@ -138,7 +139,7 @@ private fun PrivacyAndLegal(
             verticalAlignment = Alignment.CenterVertically
         ) {
             BodyRegularLabel(
-                text = "Share app usage statistics",
+                text = stringResource(R.string.share_setting),
                 modifier = Modifier.weight(1f),
             )
 

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedCard
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -26,6 +24,7 @@ import uk.govuk.app.design.ui.component.BaseHeader
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.ListDivider
 import uk.govuk.app.design.ui.component.SettingsHeader
+import uk.govuk.app.design.ui.component.ToggleSwitch
 import uk.govuk.app.design.ui.theme.GovUkTheme
 import uk.govuk.app.settings.R
 import uk.govuk.app.settings.SettingsViewModel
@@ -73,6 +72,8 @@ private fun AboutTheApp(
 ) {
     SettingsHeader(stringResource(R.string.about_title))
 
+    // We might want to make this a component when
+    // we understand the various use cases better
     OutlinedCard(
         colors = CardDefaults.cardColors(
             containerColor = GovUkTheme.colourScheme.surfaces.card
@@ -143,17 +144,7 @@ private fun PrivacyAndLegal(
                 modifier = Modifier.weight(1f),
             )
 
-            Switch(
-                checked = true,
-                onCheckedChange = {},
-
-                colors = SwitchDefaults.colors(
-                    checkedThumbColor = GovUkTheme.colourScheme.textAndIcons.buttonPrimaryHighlight,
-                    checkedTrackColor = GovUkTheme.colourScheme.surfaces.primary,
-                    uncheckedThumbColor = GovUkTheme.colourScheme.textAndIcons.buttonPrimaryDisabled,
-                    uncheckedTrackColor = GovUkTheme.colourScheme.surfaces.buttonPrimaryDisabled,
-                )
-            )
+            ToggleSwitch(onCheckedChange = {})
         }
     }
 }

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -1,11 +1,26 @@
 package uk.govuk.app.settings.ui
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.govuk.app.design.ui.component.BaseHeader
+import uk.govuk.app.design.ui.component.BodyRegularLabel
+import uk.govuk.app.design.ui.component.ListDivider
+import uk.govuk.app.design.ui.component.SettingsHeader
+import uk.govuk.app.design.ui.theme.GovUkTheme
+import uk.govuk.app.settings.R
 import uk.govuk.app.settings.SettingsViewModel
 
 @Composable
@@ -33,9 +48,62 @@ private fun SettingsScreen(
     }
 
     Column(modifier) {
-        BaseHeader("Settings", modifier)
-//        Button(onClick = onButtonClick) {
-//            Text("Click me!")
-//        }
+        BaseHeader("Settings")
+        AboutTheApp(onButtonClick)
+    }
+}
+
+@Composable
+private fun AboutTheApp(
+    onButtonClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    SettingsHeader("About the app")
+
+    OutlinedCard(
+        colors = CardDefaults.cardColors(
+            containerColor = GovUkTheme.colourScheme.surfaces.card
+        ),
+        modifier = Modifier.fillMaxWidth()
+            .padding(GovUkTheme.spacing.medium)
+    ) {
+        Row(
+            Modifier.padding(GovUkTheme.spacing.medium),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            BodyRegularLabel(
+                text = "Help and feedback",
+                modifier = Modifier.weight(1f),
+                color = GovUkTheme.colourScheme.textAndIcons.link,
+            )
+
+            Icon(
+                painter = painterResource(R.drawable.baseline_open_in_new_24),
+                contentDescription = "",
+                tint = GovUkTheme.colourScheme.textAndIcons.link,
+                modifier = Modifier.clickable(onClick = onButtonClick)
+            )
+        }
+
+        ListDivider(Modifier.padding(
+                top = 1.dp,
+                bottom = 1.dp,
+                start = GovUkTheme.spacing.medium,
+                end = GovUkTheme.spacing.medium
+            )
+        )
+
+        Row(
+            Modifier.fillMaxWidth()
+                .padding(GovUkTheme.spacing.medium),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            BodyRegularLabel(
+                text = "App version number",
+                modifier = Modifier.weight(1f)
+            )
+
+            BodyRegularLabel(text = "1.0")
+        }
     }
 }

--- a/feature/settings/src/main/res/drawable/baseline_open_in_new_24.xml
+++ b/feature/settings/src/main/res/drawable/baseline_open_in_new_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19,19H5V5h7V3H5c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2v-7h-2v7zM14,3v2h3.59l-9.83,9.83 1.41,1.41L19,6.41V10h2V3h-7z"/>
+    
+</vector>

--- a/feature/settings/src/main/res/drawable/baseline_open_in_new_24.xml
+++ b/feature/settings/src/main/res/drawable/baseline_open_in_new_24.xml
@@ -1,5 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
-      
-    <path android:fillColor="@android:color/white" android:pathData="M19,19H5V5h7V3H5c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2v-7h-2v7zM14,3v2h3.59l-9.83,9.83 1.41,1.41L19,6.41V10h2V3h-7z"/>
-    
-</vector>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -5,5 +5,12 @@
   <string name="help_setting">Help and feedback</string>
   <string name="version_setting">App version number</string>
   <string name="privacy_title">Privacy and legal</string>
+  <string name="privacy_description">
+    You can share statistics with the GOV.UK app team about
+    how you use the app so they can make improvements to it.
+    These statistics are anonymous and don’t contain any of
+    your personal information.
+  </string>
+  <string name="privacy_read_more">Read more about this in the privacy policy.</string>
   <string name="share_setting">Share app usage statistics</string>
 </resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="screen_title">Settings</string>
+  <string name="about_title">About the app</string>
+  <string name="help_setting">Help and feedback</string>
+  <string name="version_setting">App version number</string>
+  <string name="privacy_title">Privacy and legal</string>
+  <string name="share_setting">Share app usage statistics</string>
+</resources>


### PR DESCRIPTION
# Settings

Does the following:

- Creates the Settings page, with title.
- Adds the app version information to the Settings page.
- Adds a switch to the settings page which shows, and can be used to change, the user’s permission on gathering and sending app usage statistics.

## JIRA ticket(s)
  - [GOVAPP-673](https://govukverify.atlassian.net/browse/GOVUKAPP-673)
  - [GOVUKAPP-675](https://govukverify.atlassian.net/browse/GOVUKAPP-675)
  - [GOVUKAPP-677](https://govukverify.atlassian.net/browse/GOVUKAPP-677)

## Figma
  - [Figma board](https://www.figma.com/design/N4v2GPQhwZ7DwhqucyJqlu/GOV.UK-Apps-and-notifications?node-id=9290-29532&node-type=CANVAS&t=R8Yq9VtOatjez6vV-0)
  - [Switch component designs](https://www.figma.com/design/siD3CH5hRhIAmVTQ10xkjb/GOV.UK-app-library?node-id=0-1&node-type=CANVAS&t=CvNanANcXkEg0Eut-0)

## Screen shots

| Light Mode | Dark Mode |
|---|---|
| ![Screenshot_20240905_152739](https://github.com/user-attachments/assets/fbf5af36-ca70-42d8-840a-8a6ef8c58644) | ![Screenshot_20240905_152808](https://github.com/user-attachments/assets/a21120ff-b515-4eaa-8cab-7c83a81ceea0) |
| ![Screenshot_20240905_152752](https://github.com/user-attachments/assets/139bbfb6-9a74-4648-b036-deaa2c9eceeb) | ![Screenshot_20240905_152820](https://github.com/user-attachments/assets/c2d5ab85-b7e7-4973-b04b-71bff2d7e295) |

[GOVUKAPP-675]: https://govukverify.atlassian.net/browse/GOVUKAPP-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GOVUKAPP-677]: https://govukverify.atlassian.net/browse/GOVUKAPP-677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ