### PR TITLE
Settings screen: post amigo changes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     packaging {

--- a/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
@@ -27,6 +27,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import uk.govuk.app.AppViewModel
+import uk.govuk.app.BuildConfig
 import uk.govuk.app.design.ui.theme.GovUkTheme
 import uk.govuk.app.home.navigation.HOME_GRAPH_ROUTE
 import uk.govuk.app.home.navigation.HOME_GRAPH_START_DESTINATION
@@ -159,6 +160,7 @@ private fun BottomNavScaffold(
                     modifier = Modifier.padding(paddingValues)
                 )
                 settingsGraph(
+                    appVersion = BuildConfig.VERSION_NAME,
                     navController = navController,
                     modifier = Modifier.padding(paddingValues)
                 )

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/navigation/SettingsNavigation.kt
@@ -15,6 +15,7 @@ private const val SETTINGS_ROUTE = "settings_route"
 private const val SETTINGS_SUB_ROUTE = "settings_sub_route"
 
 fun NavGraphBuilder.settingsGraph(
+    appVersion: String,
     navController: NavController,
     modifier: Modifier = Modifier
 ) {
@@ -32,6 +33,7 @@ fun NavGraphBuilder.settingsGraph(
             )
         ) {
             SettingsRoute(
+                appVersion = appVersion,
                 onButtonClick = { navController.navigateToSettingsSubScreen() },
                 modifier = modifier
             )

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -88,7 +88,8 @@ private fun AboutTheApp(
                 .padding(GovUkTheme.spacing.medium)
         ) {
             Row(
-                Modifier.padding(GovUkTheme.spacing.medium),
+                Modifier.padding(GovUkTheme.spacing.medium)
+                    .clickable(onClick = onButtonClick),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 BodyRegularLabel(
@@ -102,8 +103,7 @@ private fun AboutTheApp(
                         uk.govuk.app.design.R.drawable.baseline_open_in_new_24
                     ),
                     contentDescription = "",
-                    tint = GovUkTheme.colourScheme.textAndIcons.link,
-                    modifier = Modifier.clickable(onClick = onButtonClick)
+                    tint = GovUkTheme.colourScheme.textAndIcons.link
                 )
             }
 

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -149,7 +149,12 @@ private fun PrivacyAndLegal(
                 .padding(GovUkTheme.spacing.medium)
         ) {
             Row(
-                Modifier.padding(GovUkTheme.spacing.medium),
+                modifier.padding(
+                    top = GovUkTheme.spacing.small,
+                    bottom = GovUkTheme.spacing.small,
+                    start = GovUkTheme.spacing.medium,
+                    end = GovUkTheme.spacing.medium
+                ),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 BodyRegularLabel(
@@ -157,7 +162,10 @@ private fun PrivacyAndLegal(
                     modifier = Modifier.weight(1f),
                 )
 
-                ToggleSwitch(onCheckedChange = {})
+                ToggleSwitch(
+                    onCheckedChange = {},
+                    modifier = modifier
+                )
             }
         }
 

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.govuk.app.design.ui.component.BodyRegularLabel
@@ -102,7 +104,7 @@ private fun AboutTheApp(
                     painter = painterResource(
                         uk.govuk.app.design.R.drawable.baseline_open_in_new_24
                     ),
-                    contentDescription = "",
+                    contentDescription = stringResource(R.string.link_opens_in),
                     tint = GovUkTheme.colourScheme.textAndIcons.link
                 )
             }
@@ -184,6 +186,8 @@ private fun PrivacyAndLegal(
             )
         }
 
+        val altText: String = stringResource(id = R.string.link_opens_in)
+
         Row(
             Modifier.padding(
                     top = 1.dp,
@@ -191,7 +195,8 @@ private fun PrivacyAndLegal(
                     end = GovUkTheme.spacing.extraLarge,
                     bottom = GovUkTheme.spacing.medium
                 )
-                .clickable(onClick = onButtonClick),
+                .clickable(onClick = onButtonClick)
+                .semantics { contentDescription = altText },
             verticalAlignment = Alignment.CenterVertically
         ) {
             CaptionRegularLabel(

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -62,7 +62,7 @@ private fun SettingsScreen(
             modifier = Modifier.verticalScroll(rememberScrollState())
         ) {
             AboutTheApp(onButtonClick)
-            PrivacyAndLegal()
+            PrivacyAndLegal(onButtonClick)
             Spacer(Modifier.height(100.dp))
         }
     }
@@ -134,6 +134,7 @@ private fun AboutTheApp(
 
 @Composable
 private fun PrivacyAndLegal(
+    onButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -185,11 +186,12 @@ private fun PrivacyAndLegal(
 
         Row(
             Modifier.padding(
-                top = 1.dp,
-                start = GovUkTheme.spacing.extraLarge,
-                end = GovUkTheme.spacing.extraLarge,
-                bottom = GovUkTheme.spacing.medium
-            ),
+                    top = 1.dp,
+                    start = GovUkTheme.spacing.extraLarge,
+                    end = GovUkTheme.spacing.extraLarge,
+                    bottom = GovUkTheme.spacing.medium
+                )
+                .clickable(onClick = onButtonClick),
             verticalAlignment = Alignment.CenterVertically
         ) {
             CaptionRegularLabel(

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -34,12 +34,14 @@ import uk.govuk.app.settings.SettingsViewModel
 
 @Composable
 internal fun SettingsRoute(
+    appVersion: String,
     onButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val viewModel: SettingsViewModel = hiltViewModel()
 
     SettingsScreen(
+        appVersion = appVersion,
         onPageView = { viewModel.onPageView() },
         onButtonClick = onButtonClick,
         modifier = modifier
@@ -48,6 +50,7 @@ internal fun SettingsRoute(
 
 @Composable
 private fun SettingsScreen(
+    appVersion: String,
     onPageView: () -> Unit,
     onButtonClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -63,7 +66,7 @@ private fun SettingsScreen(
         Column(
             modifier = Modifier.verticalScroll(rememberScrollState())
         ) {
-            AboutTheApp(onButtonClick)
+            AboutTheApp(appVersion,onButtonClick)
             PrivacyAndLegal(onButtonClick)
             Spacer(Modifier.height(100.dp))
         }
@@ -72,6 +75,7 @@ private fun SettingsScreen(
 
 @Composable
 private fun AboutTheApp(
+    appVersion: String,
     onButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -128,7 +132,7 @@ private fun AboutTheApp(
                     modifier = Modifier.weight(1f)
                 )
 
-                BodyRegularLabel(text = "1.0")
+                BodyRegularLabel(text = appVersion)
             }
         }
     }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -13,5 +13,5 @@
   </string>
   <string name="privacy_read_more">Read more about this in the privacy policy.</string>
   <string name="share_setting">Share app usage statistics</string>
-  <string name="link_opens_in">Open in browser</string>
+  <string name="link_opens_in">Opens in browser</string>
 </resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
   </string>
   <string name="privacy_read_more">Read more about this in the privacy policy.</string>
   <string name="share_setting">Share app usage statistics</string>
+  <string name="link_opens_in">Open in browser</string>
 </resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -13,5 +13,5 @@
   </string>
   <string name="privacy_read_more">Read more about this in the privacy policy.</string>
   <string name="share_setting">Share app usage statistics</string>
-  <string name="link_opens_in">Opens in browser</string>
+  <string name="link_opens_in">Opens in web browser</string>
 </resources>


### PR DESCRIPTION
# Settings screen: post amigo changes

Requested changes:

- [X] Whole cell clickable
- [ ] Analytics consent setting ON / OFF working 📔 TBD as a separate PR
- [X] Spacing of analytics cell
- [X] [Version number pulled from app](https://govukverify.atlassian.net/browse/GOVUKAPP-675)
- [X] Make Privacy `Read more about...` text  clickable. Takes user to settings sub-screen for now.
- [X] Add alt text for Help and feedback icon and Read more... privacy text link

## Screen shots

| Before | After |
|---|---|
| ![Screenshot_20240906_145246](https://github.com/user-attachments/assets/d69a4b96-49f5-41fc-9f15-7c94ab706fab) | ![Screenshot_20240906_145137](https://github.com/user-attachments/assets/bcf6e550-f297-4b8f-aaf1-fd9211c88c59) |
