### PR TITLE
GOVUKAPP-766 - Alt text for clear search button

### DIFF
--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="search_bar_text">Search</string>
     <string name="content_desc_back">Back</string>
-    <string name="content_desc_clear">Clear</string>
+    <string name="content_desc_clear">Clear search</string>
     <string name="gov_uk">GOV.UK</string>
     <string name="gov_uk_alt_text">GOV dot UK</string>
     <string name="opens_in_web_browser">Opens in web browser</string>


### PR DESCRIPTION
# GOVUKAPP-766 - Alt text for clear search button

When TalkBack is turned on the `X` Clear button incorrectly reads `Clear, Window GOV.UK`. It should read `Clear search`.

The word `search` has been appended to `Clear` to give the correct initial phrase.

However, controlling the second part of what is read, i.e. `Window GOV.UK`, is much more of an issue. On investigation, it seems this is read only on the first time that the user navigates to this screen - all subsequent times the correct phrase `Clear search` is read out. This can be tested by clicking on the back button first `<` then the `X` button. By doing this both back and clear button phrases are correct.

Normally, something like `Window...` is read when the app is first loaded, but not once navigation to a child screen occurs. It is unclear why it is happening here.

I have searched the codebase and there are no instances of the phrase `Window GOV.UK`. Additionally, windows/screens are not named in Android - like they are on the web for example. This leads me to surmise that controlling when and what is said here is not possible and is part of the standard Android API.

## JIRA ticket(s)
  - [GOVAPP-766](https://govukverify.atlassian.net/browse/GOVUKAPP-766)
