### PR TITLE
GOVUKAPP-679: display open source licences

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.androidApplication)
+    id("com.google.android.gms.oss-licenses-plugin")
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.compose)
     alias(libs.plugins.hilt)
@@ -104,6 +105,7 @@ dependencies {
     implementation(libs.androidx.datastore.preferences)
 
     implementation(libs.lottie.compose)
+    implementation(libs.play.services.oss.licenses)
 
     ksp(libs.hilt.compiler)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,13 @@
             </intent-filter>
         </activity>
 
+        <activity
+          android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+          android:theme="@style/Theme.AppCompat" />
+        <activity
+          android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
+          android:theme="@style/Theme.AppCompat" />
+
         <meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="false" />
         <meta-data android:name="firebase_analytics_collection_enabled" android:value="false" />
         <meta-data android:name="firebase_crashlytics_collection_enabled" android:value="false" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,10 +31,10 @@
 
         <activity
           android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
-          android:theme="@style/Theme.AppCompat" />
+          android:theme="@style/LicensesTheme" />
         <activity
           android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
-          android:theme="@style/Theme.AppCompat" />
+          android:theme="@style/LicensesTheme" />
 
         <meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="false" />
         <meta-data android:name="firebase_analytics_collection_enabled" android:value="false" />

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -3,4 +3,11 @@
     <color name="background">#FF000000</color>
 
     <bool name="lightStatusBar">false</bool>
+
+    <color name="colorPrimary">#FF000000</color>
+    <color name="colorPrimaryDark">#FF000000</color>
+    <color name="colorAccent">#FF259AFF</color>
+    <color name="textColorPrimary">#FFFFFFFF</color>
+    <color name="titleTextColor">#FFFFFFFF</color>
+    <color name="tint">#FF259AFF</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,11 @@
     <color name="background">#FFFAFAFA</color>
 
     <bool name="lightStatusBar">true</bool>
+
+    <color name="colorPrimary">#FFFAFAFA</color>
+    <color name="colorPrimaryDark">#FFFAFAFA</color>
+    <color name="colorAccent">#FF1D70B8</color>
+    <color name="textColorPrimary">#FF000000</color>
+    <color name="titleTextColor">#FF000000</color>
+    <color name="tint">#FF1D70B8</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <style name="LicensesTheme" parent="Theme.AppCompat.DayNight">
+    <item name="colorPrimary">@color/colorPrimary</item>
+    <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+    <item name="colorAccent">@color/colorAccent</item>
+    <item name="android:textColorPrimary">@color/textColorPrimary</item>
+    <item name="titleTextColor">@color/titleTextColor</item>
+    <item name="tint">@color/tint</item>
+  </style>
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,11 +15,8 @@ plugins {
 }
 
 buildscript {
-    repositories {
-        google()
-    }
     dependencies {
-        classpath(libs.oss.licenses.plugin)
+        classpath(libs.oss.licenses)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,15 @@ plugins {
     alias(libs.plugins.sonarqube)
 }
 
+buildscript {
+    repositories {
+        google()
+    }
+    dependencies {
+        classpath(libs.oss.licenses.plugin)
+    }
+}
+
 subprojects {
     if (!projectDir.endsWith("feature")) {
         apply(plugin = "org.sonarqube")

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.hilt.android)
     implementation(libs.play.services.oss.licenses)
+    implementation(libs.play.services.measurement.api)
 
     ksp(libs.hilt.compiler)
 

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.hilt.android)
+    implementation(libs.play.services.oss.licenses)
 
     ksp(libs.hilt.compiler)
 

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/SettingsViewModel.kt
@@ -43,6 +43,16 @@ internal class SettingsViewModel @Inject constructor(
         )
     }
 
+    fun onLicenseView() {
+        val eventText = "OpenSourceLicenses"
+
+        analytics.screenView(
+            screenClass = eventText,
+            screenName = eventText,
+            title = eventText
+        )
+    }
+
     fun onAnalyticsConsentChanged(enabled: Boolean) {
         viewModelScope.launch {
             if (enabled) {

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/navigation/SettingsNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navDeepLink
 import androidx.navigation.navigation
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import uk.govuk.app.settings.ui.SettingsRoute
 import uk.govuk.app.settings.ui.SettingsSubRoute
 
@@ -43,6 +44,10 @@ fun NavGraphBuilder.settingsGraph(
                 onPrivacyPolicyClick = {
                     val intent = Intent(Intent.ACTION_VIEW)
                     intent.data = Uri.parse(privacyPolicyUrl)
+                    context.startActivity(intent)
+                },
+                onOpenSourceLicenseClick = {
+                    val intent = Intent(context, OssLicensesMenuActivity::class.java)
                     context.startActivity(intent)
                 },
                 modifier = modifier

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -52,6 +52,7 @@ internal fun SettingsRoute(
             appVersion = appVersion,
             isAnalyticsEnabled = it.isAnalyticsEnabled,
             onPageView = { viewModel.onPageView() },
+            onLicenseView = { viewModel.onLicenseView() },
             onHelpClick = onHelpClick,
             onAnalyticsConsentChange = { enabled -> viewModel.onAnalyticsConsentChanged(enabled) },
             onPrivacyPolicyClick = onPrivacyPolicyClick,
@@ -65,6 +66,7 @@ private fun SettingsScreen(
     appVersion: String,
     isAnalyticsEnabled: Boolean,
     onPageView: () -> Unit,
+    onLicenseView: () -> Unit,
     onHelpClick: () -> Unit,
     onAnalyticsConsentChange: (Boolean) -> Unit,
     onPrivacyPolicyClick: () -> Unit,
@@ -90,7 +92,7 @@ private fun SettingsScreen(
                 onAnalyticsConsentChange = onAnalyticsConsentChange,
                 onPrivacyPolicyClick = onPrivacyPolicyClick
             )
-            OpenSourceLicenses()
+            OpenSourceLicenses(onLicenseView)
             Spacer(Modifier.height(100.dp))
         }
     }
@@ -246,6 +248,7 @@ private fun PrivacyAndLegal(
 
 @Composable
 private fun OpenSourceLicenses(
+    onLicenseView: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -264,6 +267,7 @@ private fun OpenSourceLicenses(
             Row(
                 Modifier
                     .clickable(onClick = {
+                        onLicenseView()
                         context.startActivity(
                             Intent(
                                 context,

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package uk.govuk.app.settings.ui
 
-import android.content.Intent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,14 +18,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.CaptionRegularLabel
 import uk.govuk.app.design.ui.component.ListDivider
@@ -42,6 +39,7 @@ internal fun SettingsRoute(
     appVersion: String,
     onHelpClick: () -> Unit,
     onPrivacyPolicyClick: () -> Unit,
+    onOpenSourceLicenseClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val viewModel: SettingsViewModel = hiltViewModel()
@@ -56,6 +54,7 @@ internal fun SettingsRoute(
             onHelpClick = onHelpClick,
             onAnalyticsConsentChange = { enabled -> viewModel.onAnalyticsConsentChanged(enabled) },
             onPrivacyPolicyClick = onPrivacyPolicyClick,
+            onOpenSourceLicenseClick = onOpenSourceLicenseClick,
             modifier = modifier
         )
     }
@@ -70,6 +69,7 @@ private fun SettingsScreen(
     onHelpClick: () -> Unit,
     onAnalyticsConsentChange: (Boolean) -> Unit,
     onPrivacyPolicyClick: () -> Unit,
+    onOpenSourceLicenseClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     LaunchedEffect(Unit) {
@@ -92,7 +92,7 @@ private fun SettingsScreen(
                 onAnalyticsConsentChange = onAnalyticsConsentChange,
                 onPrivacyPolicyClick = onPrivacyPolicyClick
             )
-            OpenSourceLicenses(onLicenseView)
+            OpenSourceLicenses(onLicenseView, onOpenSourceLicenseClick)
             Spacer(Modifier.height(100.dp))
         }
     }
@@ -249,10 +249,9 @@ private fun PrivacyAndLegal(
 @Composable
 private fun OpenSourceLicenses(
     onLicenseView: () -> Unit,
+    onOpenSourceLicenseClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val context = LocalContext.current
-
     Column(
         modifier = modifier
     ) {
@@ -266,15 +265,12 @@ private fun OpenSourceLicenses(
         ) {
             Row(
                 Modifier
-                    .clickable(onClick = {
-                        onLicenseView()
-                        context.startActivity(
-                            Intent(
-                                context,
-                                OssLicensesMenuActivity::class.java
-                            )
-                        )
-                    })
+                    .clickable(
+                        onClick = {
+                            onLicenseView()
+                            onOpenSourceLicenseClick()
+                        }
+                    )
                     .padding(GovUkTheme.spacing.medium),
                 verticalAlignment = Alignment.CenterVertically
             ) {

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package uk.govuk.app.settings.ui
 
+import android.content.Intent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,12 +19,14 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.CaptionRegularLabel
 import uk.govuk.app.design.ui.component.ListDivider
@@ -87,6 +90,7 @@ private fun SettingsScreen(
                 onAnalyticsConsentChange = onAnalyticsConsentChange,
                 onPrivacyPolicyClick = onPrivacyPolicyClick
             )
+            OpenSourceLicenses()
             Spacer(Modifier.height(100.dp))
         }
     }
@@ -109,7 +113,8 @@ private fun AboutTheApp(
             colors = CardDefaults.cardColors(
                 containerColor = GovUkTheme.colourScheme.surfaces.card
             ),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
                 .padding(GovUkTheme.spacing.medium)
         ) {
             Row(
@@ -143,7 +148,8 @@ private fun AboutTheApp(
             )
 
             Row(
-                Modifier.fillMaxWidth()
+                Modifier
+                    .fillMaxWidth()
                     .padding(GovUkTheme.spacing.medium),
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -174,7 +180,8 @@ private fun PrivacyAndLegal(
             colors = CardDefaults.cardColors(
                 containerColor = GovUkTheme.colourScheme.surfaces.card
             ),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
                 .padding(GovUkTheme.spacing.medium)
         ) {
             Row(
@@ -213,7 +220,8 @@ private fun PrivacyAndLegal(
         }
 
         Row(
-            Modifier.padding(
+            Modifier
+                .padding(
                     top = 1.dp,
                     start = GovUkTheme.spacing.extraLarge,
                     end = GovUkTheme.spacing.extraLarge,
@@ -223,7 +231,7 @@ private fun PrivacyAndLegal(
             verticalAlignment = Alignment.CenterVertically
         ) {
             val altText = "${stringResource(R.string.privacy_read_more)} " +
-                    stringResource(id = R.string.link_opens_in)
+                stringResource(id = R.string.link_opens_in)
 
             CaptionRegularLabel(
                 text = stringResource(R.string.privacy_read_more),
@@ -232,6 +240,46 @@ private fun PrivacyAndLegal(
                 },
                 color = GovUkTheme.colourScheme.textAndIcons.link,
             )
+        }
+    }
+}
+
+@Composable
+private fun OpenSourceLicenses(
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+
+    Column(
+        modifier = modifier
+    ) {
+        OutlinedCard(
+            colors = CardDefaults.cardColors(
+                containerColor = GovUkTheme.colourScheme.surfaces.card
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(GovUkTheme.spacing.medium)
+        ) {
+            Row(
+                Modifier
+                    .clickable(onClick = {
+                        context.startActivity(
+                            Intent(
+                                context,
+                                OssLicensesMenuActivity::class.java
+                            )
+                        )
+                    })
+                    .padding(GovUkTheme.spacing.medium),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BodyRegularLabel(
+                    text = stringResource(R.string.oss_licenses_title),
+                    modifier = Modifier.weight(1f),
+                    color = GovUkTheme.colourScheme.textAndIcons.link,
+                )
+            }
         }
     }
 }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -14,4 +14,5 @@
   <string name="privacy_read_more">Read more about this in the privacy policy.</string>
   <string name="share_setting">Share app usage statistics</string>
   <string name="link_opens_in">Opens in web browser</string>
+  <string name="oss_licenses_title">Open source licenses</string>
 </resources>

--- a/feature/settings/src/test/kotlin/uk/govuk/app/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/uk/govuk/app/settings/SettingsViewModelTest.kt
@@ -104,4 +104,20 @@ class SettingsViewModelTest {
             }
         }
     }
+
+    @Test
+    fun `Given a license page view, then log analytics`() {
+        val viewModel = SettingsViewModel(analytics)
+        val eventText = "OpenSourceLicenses"
+
+        viewModel.onLicenseView()
+
+        verify {
+            analytics.screenView(
+                screenClass = eventText,
+                screenName = eventText,
+                title = eventText
+            )
+        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ coroutineTest = "1.8.1"
 firebaseAppDistribution = "5.0.0"
 kover = "0.8.3"
 sonarqube = "5.0.0.4638"
+playServicesMeasurementApi = "22.0.2"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -63,6 +64,7 @@ retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit
 retrofit-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 retrofit-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
 realm-base = { group = "io.realm.kotlin", name = "library-base", version.ref = "realm"}
+play-services-measurement-api = { group = "com.google.android.gms", name = "play-services-measurement-api", version.ref = "playServicesMeasurementApi" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,8 +16,7 @@ datastorePreferences = "1.1.1"
 googlePlayServices = "4.4.2"
 crashlytics = "3.0.2"
 
-ossLicensesPlugin = "0.10.6"
-playServicesOssLicenses = "17.1.0"
+ossLicenses = "0.10.6"
 retrofit = "2.11.0"
 
 gov-logging = "0.4.4"
@@ -31,6 +30,7 @@ firebaseAppDistribution = "5.0.0"
 kover = "0.8.3"
 sonarqube = "5.0.0.4638"
 playServicesMeasurementApi = "22.0.2"
+playServicesOssLicenses = "17.1.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -58,13 +58,13 @@ firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashly
 
 mockk = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 coroutine-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutineTest" }
-oss-licenses-plugin = { module = "com.google.android.gms:oss-licenses-plugin", version.ref = "ossLicensesPlugin" }
-play-services-oss-licenses = { module = "com.google.android.gms:play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 retrofit-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
 realm-base = { group = "io.realm.kotlin", name = "library-base", version.ref = "realm"}
 play-services-measurement-api = { group = "com.google.android.gms", name = "play-services-measurement-api", version.ref = "playServicesMeasurementApi" }
+play-services-oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
+oss-licenses = { group = "com.google.android.gms", name = "oss-licenses-plugin", version.ref = "ossLicenses" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ datastorePreferences = "1.1.1"
 googlePlayServices = "4.4.2"
 crashlytics = "3.0.2"
 
+ossLicensesPlugin = "0.10.6"
+playServicesOssLicenses = "17.1.0"
 retrofit = "2.11.0"
 
 gov-logging = "0.4.4"
@@ -55,6 +57,8 @@ firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashly
 
 mockk = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 coroutine-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutineTest" }
+oss-licenses-plugin = { module = "com.google.android.gms:oss-licenses-plugin", version.ref = "ossLicensesPlugin" }
+play-services-oss-licenses = { module = "com.google.android.gms:play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 retrofit-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }


### PR DESCRIPTION
# GOVUKAPP-679: display open source licences

We need a solution to display the app's dependency licences - in-app - with relevant developer information and outward links, which doesn’t require manual population or administration.

Added as per the instructions here:

- https://github.com/google/play-services-plugins/tree/main/oss-licenses-plugin
- https://developers.google.com/android/guides/opensource

## JIRA ticket(s)
  - [GOVAPP-679](https://govukverify.atlassian.net/browse/GOVUKAPP-679)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-82977&node-type=canvas&t=bE8WW67KarKR6IY8-0)

## Screenshots

| Light Mode | Dark Mode |
| --- | --- |
| ![light-screen-1](https://github.com/user-attachments/assets/84b6ca83-8986-46dc-9ea1-6432a733de4a) | ![dark-screen-1](https://github.com/user-attachments/assets/3606c378-4d9e-4184-ab7d-60b8cdb37cf1) |
| ![light-screen-2](https://github.com/user-attachments/assets/e286867f-f60d-4544-92f5-6d1de13e2e9a) | ![dark-screen-2](https://github.com/user-attachments/assets/d35c6159-a646-4704-ae6a-a7f87ab56820) |
