### PR TITLE
GOVUKAPP-648 : visited items - create list view

### DIFF
--- a/analytics/src/main/kotlin/uk/govuk/app/analytics/Analytics.kt
+++ b/analytics/src/main/kotlin/uk/govuk/app/analytics/Analytics.kt
@@ -13,5 +13,6 @@ interface Analytics {
     fun widgetClick(text: String)
     fun search(searchTerm: String)
     fun searchResultClick(text: String, url: String)
+    fun visitedItemClick(text: String, url: String)
     fun toggleFunction(text: String, section: String, action: String)
 }

--- a/analytics/src/main/kotlin/uk/govuk/app/analytics/AnalyticsClient.kt
+++ b/analytics/src/main/kotlin/uk/govuk/app/analytics/AnalyticsClient.kt
@@ -81,6 +81,11 @@ class AnalyticsClient @Inject constructor(
         navigation(text = text, type = "SearchResult", url = url, external = true)
     }
 
+    override fun visitedItemClick(text: String, url: String) {
+        // external as these links will be opened in the device browser
+        navigation(text = text, type = "VisitedItem", url = url, external = true)
+    }
+
     override fun toggleFunction(text: String, section: String, action: String) {
         val parameters = mutableMapOf(
             "text" to text,

--- a/analytics/src/test/kotlin/uk/govuk/app/analytics/AnalyticsClientTest.kt
+++ b/analytics/src/test/kotlin/uk/govuk/app/analytics/AnalyticsClientTest.kt
@@ -183,6 +183,28 @@ class AnalyticsClientTest {
     }
 
     @Test
+    fun `Given a visited item click, then log event`() {
+        val analyticsClient = AnalyticsClient(analyticsLogger, analyticsRepo)
+        analyticsClient.visitedItemClick("visited item title", "visited item link")
+
+        verify {
+            analyticsLogger.logEvent(
+                true,
+                AnalyticsEvent(
+                    eventType = "Navigation",
+                    parameters = mapOf(
+                        "type" to "VisitedItem",
+                        "external" to true,
+                        "language" to Locale.getDefault().language,
+                        "text" to "visited item title",
+                        "url" to "visited item link"
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
     fun `Given a tab click, then log event`() {
         val analyticsClient = AnalyticsClient(analyticsLogger, analyticsRepo)
         analyticsClient.tabClick("text")

--- a/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
@@ -53,6 +53,8 @@ import uk.govuk.app.topics.navigation.navigateToTopic
 import uk.govuk.app.topics.navigation.navigateToTopicsEdit
 import uk.govuk.app.topics.navigation.topicsGraph
 import uk.govuk.app.topics.ui.widget.TopicsWidget
+import uk.govuk.app.visited.navigation.VISITED_GRAPH_ROUTE
+import uk.govuk.app.visited.navigation.visitedGraph
 import uk.govuk.app.visited.ui.widget.VisitedWidget
 
 @Composable
@@ -224,6 +226,7 @@ private fun BottomNavScaffold(
                     navController = navController,
                     modifier = Modifier.padding(paddingValues)
                 )
+                visitedGraph(navController)
             }
         }
     }
@@ -248,7 +251,13 @@ private fun homeScreenWidgets(
             }
         },
         { modifier ->
-            VisitedWidget(modifier)
+            VisitedWidget(
+                onClick = { text ->
+                    onClick(text)
+                    navController.navigate(VISITED_GRAPH_ROUTE)
+                },
+                modifier = modifier
+            )
         },
         { modifier ->
             if (isTopicsEnabled) {

--- a/feature/visited/build.gradle.kts
+++ b/feature/visited/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 
     defaultConfig {
         minSdk = Version.MIN_SDK
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     compileOptions {
@@ -29,6 +30,7 @@ dependencies {
     implementation(projects.design)
     implementation(projects.analytics)
 
+    implementation(libs.androidx.navigation.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.material3)
     implementation(libs.androidx.hilt.navigation.compose)
@@ -38,6 +40,7 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
+    testImplementation(libs.coroutine.test)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/VisitedViewModel.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/VisitedViewModel.kt
@@ -1,0 +1,63 @@
+package uk.govuk.app.visited
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import uk.govuk.app.analytics.Analytics
+import javax.inject.Inject
+
+internal data class VisitedUiState(
+    val visited: List<VisitedUi>
+)
+
+internal data class VisitedUi(
+    val title: String,
+    val url: String,
+    val lastVisited: String,
+)
+
+@HiltViewModel
+internal class VisitedViewModel @Inject constructor(
+    private val analytics: Analytics
+): ViewModel() {
+
+    companion object {
+        private const val SCREEN_CLASS = "VisitedScreen"
+        private const val SCREEN_NAME = "Pages you've visited"
+        private const val SCREEN_TITLE = "Pages you've visited"
+    }
+
+    private val _uiState: MutableStateFlow<VisitedUiState?> = MutableStateFlow(null)
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _uiState.value =
+                VisitedUiState(
+                    listOf(
+                        VisitedUi("GOV.UK", "https://www.gov.uk", "24 July 2024"),
+                        VisitedUi("Amazon UK", "https://www.amazon.co.uk", "24 July 2024"),
+                        VisitedUi("BBC", "https://www.bbc.co.uk", "10 July 2024"),
+                        VisitedUi("Slack", "https://slack.com", "2 October 2023"),
+                        VisitedUi("Trello", "https://trello.com", "1 October 2023"),
+                        VisitedUi("Google", "https://google.com", "1 October 2023")
+                    )
+                )
+        }
+    }
+
+    fun onPageView() {
+        analytics.screenView(
+            screenClass = SCREEN_CLASS,
+            screenName = SCREEN_NAME,
+            title = SCREEN_TITLE
+        )
+    }
+
+    fun onVisitedItemClicked(title: String, url: String) {
+        analytics.visitedItemClick(text = title, url = url)
+    }
+}

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/VisitedViewModel.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/VisitedViewModel.kt
@@ -33,23 +33,14 @@ internal class VisitedViewModel @Inject constructor(
     private val _uiState: MutableStateFlow<VisitedUiState?> = MutableStateFlow(null)
     val uiState = _uiState.asStateFlow()
 
-    init {
+    private fun loadVisitedItems() {
         viewModelScope.launch {
-            _uiState.value =
-                VisitedUiState(
-                    listOf(
-                        VisitedUi("GOV.UK", "https://www.gov.uk", "24 July 2024"),
-                        VisitedUi("Amazon UK", "https://www.amazon.co.uk", "24 July 2024"),
-                        VisitedUi("BBC", "https://www.bbc.co.uk", "10 July 2024"),
-                        VisitedUi("Slack", "https://slack.com", "2 October 2023"),
-                        VisitedUi("Trello", "https://trello.com", "1 October 2023"),
-                        VisitedUi("Google", "https://google.com", "1 October 2023")
-                    )
-                )
+            _uiState.value = VisitedUiState(visited = emptyList())
         }
     }
 
     fun onPageView() {
+        loadVisitedItems()
         analytics.screenView(
             screenClass = SCREEN_CLASS,
             screenName = SCREEN_NAME,

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/navigation/VisitedNavigation.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/navigation/VisitedNavigation.kt
@@ -1,0 +1,30 @@
+package uk.govuk.app.visited.navigation
+
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import uk.govuk.app.visited.ui.VisitedRoute
+
+const val VISITED_GRAPH_ROUTE = "visited_graph_route"
+private const val VISITED_ROUTE = "visited_route"
+
+fun NavGraphBuilder.visitedGraph(
+    navController: NavHostController,
+    modifier: Modifier = Modifier
+) {
+    navigation(
+        route = VISITED_GRAPH_ROUTE,
+        startDestination = VISITED_ROUTE
+    ) {
+        composable(
+            VISITED_ROUTE,
+        ) {
+            VisitedRoute(
+                onBack = { navController.popBackStack() },
+                modifier = modifier
+            )
+        }
+    }
+}

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -1,37 +1,24 @@
 package uk.govuk.app.visited.ui
 
 import android.annotation.SuppressLint
-import android.content.Intent
-import android.net.Uri
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.govuk.app.design.ui.component.BodyBoldLabel
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.ChildPageHeader
 import uk.govuk.app.design.ui.component.ExtraLargeVerticalSpacer
-import uk.govuk.app.design.ui.component.MediumVerticalSpacer
-import uk.govuk.app.design.ui.component.SubheadlineRegularLabel
 import uk.govuk.app.design.ui.theme.GovUkTheme
 import uk.govuk.app.visited.R
-import uk.govuk.app.visited.VisitedUi
 import uk.govuk.app.visited.VisitedViewModel
 
 @Composable
@@ -78,15 +65,12 @@ private fun VisitedScreen(
         ) {
             val visitedItems = viewModel.uiState.value?.visited
 
-            if (visitedItems == null) {
-                NoVisitedItems(modifier)
-            } else {
-                MediumVerticalSpacer()
-                VisitedItems("Today", visitedItems.slice(0..0), viewModel, modifier)
-                MediumVerticalSpacer()
-                VisitedItems("This month", visitedItems.slice(1..2), viewModel, modifier)
-                MediumVerticalSpacer()
-                VisitedItems("October 2023", visitedItems.slice(3..visitedItems.size - 1), viewModel, modifier)
+            if (visitedItems != null) {
+                if (visitedItems.isEmpty()) {
+                    NoVisitedItems(modifier)
+                } else {
+                    /* TODO: display the visited items */
+                }
             }
         }
     }
@@ -111,82 +95,5 @@ private fun NoVisitedItems(
             stringResource(R.string.visited_items_no_pages_description),
             textAlign = TextAlign.Center
         )
-    }
-}
-
-@Composable
-private fun VisitedItems(
-    sectionTitle: String,
-    items: List<VisitedUi>?,
-    viewModel: VisitedViewModel,
-    modifier: Modifier = Modifier
-) {
-    BodyBoldLabel(
-        sectionTitle,
-        modifier = Modifier.padding(start = GovUkTheme.spacing.large)
-    )
-
-    items?.forEach { item ->
-        val title = item.title
-        val lastVisited = item.lastVisited
-        val url = item.url
-        val context = LocalContext.current
-        val intent = Intent(Intent.ACTION_VIEW)
-        intent.data = Uri.parse(url)
-
-        OutlinedCard(
-            colors = CardDefaults.cardColors(
-                containerColor = GovUkTheme.colourScheme.surfaces.card
-            ),
-            modifier = Modifier.padding(
-                GovUkTheme.spacing.medium,
-                GovUkTheme.spacing.medium,
-                GovUkTheme.spacing.medium,
-                0.dp
-            )
-                .fillMaxWidth()
-                .clickable(
-                    onClick = {
-                        viewModel.onVisitedItemClicked(title, url)
-                        context.startActivity(intent)
-                    }
-                ),
-        ) {
-            Row(
-                Modifier.padding(
-                    GovUkTheme.spacing.medium,
-                    GovUkTheme.spacing.medium,
-                    GovUkTheme.spacing.medium,
-                    GovUkTheme.spacing.small
-                ),
-                verticalAlignment = Alignment.Top
-            ) {
-                BodyRegularLabel(
-                    text = title,
-                    modifier = Modifier.weight(1f),
-                    color = GovUkTheme.colourScheme.textAndIcons.link,
-                )
-
-                Icon(
-                    painter = painterResource(
-                        uk.govuk.app.design.R.drawable.baseline_open_in_new_24
-                    ),
-                    contentDescription = stringResource(
-                        uk.govuk.app.design.R.string.opens_in_web_browser
-                    ),
-                    tint = GovUkTheme.colourScheme.textAndIcons.link
-                )
-            }
-
-            SubheadlineRegularLabel(
-                text = "Last visited on $lastVisited",
-                modifier = Modifier.padding(
-                    GovUkTheme.spacing.medium,
-                    0.dp,
-                    GovUkTheme.spacing.medium,
-                    GovUkTheme.spacing.medium
-                )
-            )
-        }
     }
 }

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -1,0 +1,192 @@
+package uk.govuk.app.visited.ui
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import uk.govuk.app.design.ui.component.BodyBoldLabel
+import uk.govuk.app.design.ui.component.BodyRegularLabel
+import uk.govuk.app.design.ui.component.ChildPageHeader
+import uk.govuk.app.design.ui.component.ExtraLargeVerticalSpacer
+import uk.govuk.app.design.ui.component.MediumVerticalSpacer
+import uk.govuk.app.design.ui.component.SubheadlineRegularLabel
+import uk.govuk.app.design.ui.theme.GovUkTheme
+import uk.govuk.app.visited.R
+import uk.govuk.app.visited.VisitedUi
+import uk.govuk.app.visited.VisitedViewModel
+
+@Composable
+internal fun VisitedRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val viewModel: VisitedViewModel = hiltViewModel()
+
+    VisitedScreen(
+        viewModel = viewModel,
+        onPageView = { viewModel.onPageView() },
+        onBack = onBack,
+        modifier = modifier
+    )
+}
+
+@SuppressLint("StateFlowValueCalledInComposition")
+@Composable
+private fun VisitedScreen(
+    viewModel: VisitedViewModel,
+    onPageView: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LaunchedEffect(Unit) {
+        onPageView()
+    }
+
+    val title = stringResource(R.string.visited_items_title)
+
+    Column(modifier) {
+        ChildPageHeader(
+            text = title,
+            onBack = onBack
+        )
+        Column(
+            Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(
+                    top = GovUkTheme.spacing.small,
+                    bottom = GovUkTheme.spacing.extraLarge
+                )
+        ) {
+            val visitedItems = viewModel.uiState.value?.visited
+
+            if (visitedItems == null) {
+                NoVisitedItems(modifier)
+            } else {
+                MediumVerticalSpacer()
+                VisitedItems("Today", visitedItems.slice(0..0), viewModel, modifier)
+                MediumVerticalSpacer()
+                VisitedItems("This month", visitedItems.slice(1..2), viewModel, modifier)
+                MediumVerticalSpacer()
+                VisitedItems("October 2023", visitedItems.slice(3..visitedItems.size - 1), viewModel, modifier)
+            }
+        }
+    }
+}
+
+@Composable
+private fun NoVisitedItems(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier.padding(GovUkTheme.spacing.medium)
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        ExtraLargeVerticalSpacer()
+
+        BodyBoldLabel(
+            stringResource(R.string.visited_items_no_pages_title)
+        )
+
+        BodyRegularLabel(
+            stringResource(R.string.visited_items_no_pages_description),
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun VisitedItems(
+    sectionTitle: String,
+    items: List<VisitedUi>?,
+    viewModel: VisitedViewModel,
+    modifier: Modifier = Modifier
+) {
+    BodyBoldLabel(
+        sectionTitle,
+        modifier = Modifier.padding(start = GovUkTheme.spacing.large)
+    )
+
+    items?.forEach { item ->
+        val title = item.title
+        val lastVisited = item.lastVisited
+        val url = item.url
+        val context = LocalContext.current
+        val intent = Intent(Intent.ACTION_VIEW)
+        intent.data = Uri.parse(url)
+
+        OutlinedCard(
+            colors = CardDefaults.cardColors(
+                containerColor = GovUkTheme.colourScheme.surfaces.card
+            ),
+            modifier = Modifier.padding(
+                GovUkTheme.spacing.medium,
+                GovUkTheme.spacing.medium,
+                GovUkTheme.spacing.medium,
+                0.dp
+            )
+                .fillMaxWidth()
+                .clickable(
+                    onClick = {
+                        viewModel.onVisitedItemClicked(title, url)
+                        context.startActivity(intent)
+                    }
+                ),
+        ) {
+            Row(
+                Modifier.padding(
+                    GovUkTheme.spacing.medium,
+                    GovUkTheme.spacing.medium,
+                    GovUkTheme.spacing.medium,
+                    GovUkTheme.spacing.small
+                ),
+                verticalAlignment = Alignment.Top
+            ) {
+                BodyRegularLabel(
+                    text = title,
+                    modifier = Modifier.weight(1f),
+                    color = GovUkTheme.colourScheme.textAndIcons.link,
+                )
+
+                Icon(
+                    painter = painterResource(
+                        uk.govuk.app.design.R.drawable.baseline_open_in_new_24
+                    ),
+                    contentDescription = stringResource(
+                        uk.govuk.app.design.R.string.opens_in_web_browser
+                    ),
+                    tint = GovUkTheme.colourScheme.textAndIcons.link
+                )
+            }
+
+            SubheadlineRegularLabel(
+                text = "Last visited on $lastVisited",
+                modifier = Modifier.padding(
+                    GovUkTheme.spacing.medium,
+                    0.dp,
+                    GovUkTheme.spacing.medium,
+                    GovUkTheme.spacing.medium
+                )
+            )
+        }
+    }
+}

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/widget/VisitedWidget.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/widget/VisitedWidget.kt
@@ -24,10 +24,12 @@ import uk.govuk.app.design.ui.theme.GovUkTheme
 
 @Composable
 fun VisitedWidget(
+    onClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
         OutlinedCard(
+            onClick = { onClick("Visited") },
             colors = CardDefaults.cardColors(
                 containerColor = GovUkTheme.colourScheme.surfaces.card
             ),
@@ -37,7 +39,7 @@ fun VisitedWidget(
             )
         ) {
             Row(
-                Modifier
+                modifier = Modifier
                     .padding(GovUkTheme.spacing.large)
                     .fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
@@ -67,6 +69,7 @@ fun VisitedWidget(
 private fun VisitedWidgetPreview() {
     GovUkTheme {
         VisitedWidget(
+            onClick = { },
             Modifier
                 .fillMaxWidth()
                 .background(GovUkTheme.colourScheme.surfaces.background)

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/widget/VisitedWidget.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/widget/VisitedWidget.kt
@@ -28,8 +28,10 @@ fun VisitedWidget(
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
+        val widgetTitle = stringResource(uk.govuk.app.visited.R.string.visited_items_title)
+
         OutlinedCard(
-            onClick = { onClick("Visited") },
+            onClick = { onClick(widgetTitle) },
             colors = CardDefaults.cardColors(
                 containerColor = GovUkTheme.colourScheme.surfaces.card
             ),
@@ -51,7 +53,7 @@ fun VisitedWidget(
                         .padding(end = GovUkTheme.spacing.small)
                 )
                 BodyBoldLabel(
-                    stringResource(uk.govuk.app.visited.R.string.visited_items_title),
+                    widgetTitle,
                     modifier = Modifier.weight(1f)
                 )
                 Icon(

--- a/feature/visited/src/main/res/values/strings.xml
+++ b/feature/visited/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
   <string name="visited_items_title">Pages you\'ve visited</string>
+
+  <string name="visited_items_no_pages_title">No pages</string>
+  <string name="visited_items_no_pages_description">You haven\'t used the app to visit any GOV.UK pages yet</string>
 </resources>

--- a/feature/visited/src/test/kotlin/uk/govuk/app/visited/ExampleUnitTest.kt
+++ b/feature/visited/src/test/kotlin/uk/govuk/app/visited/ExampleUnitTest.kt
@@ -1,4 +1,0 @@
-package uk.govuk.app.visited
-
-class ExampleUnitTest {
-}

--- a/feature/visited/src/test/kotlin/uk/govuk/app/visited/VisitedViewModelTest.kt
+++ b/feature/visited/src/test/kotlin/uk/govuk/app/visited/VisitedViewModelTest.kt
@@ -1,0 +1,91 @@
+package uk.govuk.app.visited
+
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+import uk.govuk.app.analytics.Analytics
+
+@RunWith(Enclosed::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class VisitedViewModelTest {
+    class AnalyticsTest {
+        private val analytics = mockk<Analytics>(relaxed = true)
+        private val viewModel = VisitedViewModel(analytics)
+        private val dispatcher = UnconfinedTestDispatcher()
+
+        @Test
+        fun `Given a page view, then log analytics`() {
+            viewModel.onPageView()
+
+            verify {
+                analytics.screenView(
+                    screenClass = "VisitedScreen",
+                    screenName = "Pages you've visited",
+                    title = "Pages you've visited"
+                )
+            }
+        }
+
+        @Test
+        fun `Given the user views the visited items screen, and a visited item is clicked, then log analytics`() {
+            Dispatchers.setMain(dispatcher)
+
+            viewModel.onVisitedItemClicked("visited item title", "visited item title")
+
+            runTest {
+                coVerify {
+                    analytics.visitedItemClick("visited item title", "visited item title")
+                }
+            }
+        }
+    }
+
+    class UiStateTest {
+        private val analytics = mockk<Analytics>(relaxed = true)
+        private val viewModel = VisitedViewModel(analytics)
+
+        @Test
+        fun `Given there is a visited item, then the status in the view model is correct`() {
+            val visitedItems = VisitedUiState(
+                visited = listOf(
+                    VisitedUi("GOV.UK", "https://www.gov.uk", "24 July 2024")
+                )
+            )
+
+            /* TODO...
+            coEvery { /* mock where the visited items are retrieved from */ } returns visitedItems
+            */
+
+            viewModel.onPageView()
+
+            runTest {
+                val result = viewModel.uiState.first()
+
+                /* TODO: assertEquals(visitedItems, result) */
+            }
+        }
+
+        @Test
+        fun `Given there are no visited items, then the status in the view model are correct`() {
+            val visitedItems = VisitedUiState(visited = emptyList())
+
+            viewModel.onPageView()
+
+            runTest {
+                val result = viewModel.uiState.first()
+
+                assertEquals(visitedItems, result)
+            }
+        }
+    }
+}


### PR DESCRIPTION
# GOVUKAPP-648 : visited items - create list view

## Notes 🎶  

  - The visited item display is currently undergoing a re-design for Android, so will be picked up as part of this follow up ticket: https://govukverify.atlassian.net/browse/GOVUKAPP-650.
  - Currently, there is no visited item data. To be picked up as part of this follow up ticket: https://govukverify.atlassian.net/browse/GOVUKAPP-649.

## JIRA ticket(s)
  - [GOVAPP-648](https://govukverify.atlassian.net/browse/GOVUKAPP-648)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-84052&node-type=frame&t=iPF2iHrJU5wud318-0)

## Analytics events

```bash
# User visits Pages you've visited screen...
Firebase event sent with: Bundle[{language=en, screen_class=VisitedScreen, screen_title=Pages you've visited, screen_name=Pages you've visited}]

# User clicks on item in visited items list...
Firebase event sent with: Bundle[{external=true, language=en, url=https://www.gov.uk/, text=GOV.UK, type=VisitedItem}]
```

## Screenshots

| Light | Dark |
|---|---|
| ![light-portrait-no-pages](https://github.com/user-attachments/assets/d3a93107-0607-409e-8b60-ecea8716a993) | ![dark-portrait-no-pages](https://github.com/user-attachments/assets/162fac13-606d-45fa-bc73-cce7d17e8bf5) |

| Landscape |
|---|
| ![light-landscape-no-pages](https://github.com/user-attachments/assets/765fdf50-fd06-47b7-a4ef-77497659df29) |
| ![dark-landscape-no-pages](https://github.com/user-attachments/assets/9c33c0a0-33b5-4dca-a8b0-e6ff6bc98968) |



