### PR TITLE
Fix padding issue with visited items widget icon

### DIFF
--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/widget/VisitedWidget.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/widget/VisitedWidget.kt
@@ -42,7 +42,12 @@ fun VisitedWidget(
         ) {
             Row(
                 modifier = Modifier
-                    .padding(GovUkTheme.spacing.large)
+                    .padding(
+                        start = GovUkTheme.spacing.medium,
+                        end = GovUkTheme.spacing.medium,
+                        top = GovUkTheme.spacing.large,
+                        bottom = GovUkTheme.spacing.large
+                    )
                     .fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
             ) {


### PR DESCRIPTION
# Fix padding issue with visited items widget icon

Padding should be 16.dp not 24.dp as it currently is.

## JIRA ticket(s)
  - [GOVAPP-895](https://govukverify.atlassian.net/browse/GOVUKAPP-895)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-83650&node-type=canvas&t=nLINUAGLOTU5fEtF-0)

## Screenshots

### Before

| Light Mode | Dark Mode |
|---|---|
| ![padding-before-day](https://github.com/user-attachments/assets/b316062d-0ae0-4b8f-bf21-6f96b02960b4) | ![padding-before-night](https://github.com/user-attachments/assets/a45a2e5f-3392-4217-9aca-c934ad6a912b) |

### After

| Light Mode | Dark Mode |
|---|---|
| ![padding-after-day](https://github.com/user-attachments/assets/6b12b89e-d798-438f-9a03-e844a9efa450) | ![padding-after-night](https://github.com/user-attachments/assets/5054b747-358a-462c-9c63-2a9797e50013) |
