### PR TITLE
Set Gradle configuration-cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
# Set Gradle configuration-cache

The [docs](https://docs.gradle.org/current/userguide/configuration_cache.html) state that...

> configuration cache is a feature that significantly improves build performance by caching the result of the [configuration phase](https://docs.gradle.org/current/userguide/build_lifecycle.html#build_lifecycle) and reusing this for subsequent builds

I've found this to improve build performance locally, so adding it to the project seems like a nice development improvement.

Adding as a separate PR so that it's easy to revert - should we need to.
