### PR TITLE
Update settings links

### DIFF
--- a/analytics/src/main/kotlin/uk/govuk/app/analytics/Analytics.kt
+++ b/analytics/src/main/kotlin/uk/govuk/app/analytics/Analytics.kt
@@ -19,5 +19,6 @@ interface Analytics {
     fun search(searchTerm: String)
     fun searchResultClick(text: String, url: String)
     fun visitedItemClick(text: String, url: String)
+    fun settingsItemClick(text: String, url: String)
     fun toggleFunction(text: String, section: String, action: String)
 }

--- a/analytics/src/main/kotlin/uk/govuk/app/analytics/AnalyticsClient.kt
+++ b/analytics/src/main/kotlin/uk/govuk/app/analytics/AnalyticsClient.kt
@@ -97,6 +97,11 @@ class AnalyticsClient @Inject constructor(
         navigation(text = text, type = "VisitedItem", url = url, external = true)
     }
 
+    override fun settingsItemClick(text: String, url: String) {
+        // external as these links will be opened in the device browser
+        navigation(text = text, type = "SettingsItem", url = url, external = true)
+    }
+
     override fun toggleFunction(text: String, section: String, action: String) {
         val parameters = mutableMapOf(
             "text" to text,

--- a/analytics/src/test/kotlin/uk/govuk/app/analytics/AnalyticsClientTest.kt
+++ b/analytics/src/test/kotlin/uk/govuk/app/analytics/AnalyticsClientTest.kt
@@ -233,6 +233,28 @@ class AnalyticsClientTest {
     }
 
     @Test
+    fun `Given a settings item click, then log event`() {
+        val analyticsClient = AnalyticsClient(analyticsLogger, analyticsRepo)
+        analyticsClient.settingsItemClick("settings item title", "settings item link")
+
+        verify {
+            analyticsLogger.logEvent(
+                true,
+                AnalyticsEvent(
+                    eventType = "Navigation",
+                    parameters = mapOf(
+                        "type" to "SettingsItem",
+                        "external" to true,
+                        "language" to Locale.getDefault().language,
+                        "text" to "settings item title",
+                        "url" to "settings item link"
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
     fun `Given a tab click, then log event`() {
         val analyticsClient = AnalyticsClient(analyticsLogger, analyticsRepo)
         analyticsClient.tabClick("text")

--- a/app/src/main/kotlin/uk/govuk/app/Constants.kt
+++ b/app/src/main/kotlin/uk/govuk/app/Constants.kt
@@ -1,3 +1,0 @@
-package uk.govuk.app
-
-const val PRIVACY_POLICY_URL = "https://www.gov.uk/government/publications/govuk-app-privacy-notice-how-we-use-your-data"

--- a/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
@@ -34,7 +34,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import uk.govuk.app.AppViewModel
 import uk.govuk.app.BuildConfig
-import uk.govuk.app.PRIVACY_POLICY_URL
 import uk.govuk.app.analytics.navigation.ANALYTICS_GRAPH_ROUTE
 import uk.govuk.app.analytics.navigation.analyticsGraph
 import uk.govuk.app.design.ui.theme.GovUkTheme
@@ -47,6 +46,7 @@ import uk.govuk.app.onboarding.navigation.onboardingGraph
 import uk.govuk.app.search.navigation.SEARCH_GRAPH_ROUTE
 import uk.govuk.app.search.navigation.searchGraph
 import uk.govuk.app.search.ui.widget.SearchWidget
+import uk.govuk.app.settings.BuildConfig.PRIVACY_POLICY_URL
 import uk.govuk.app.settings.navigation.settingsGraph
 import uk.govuk.app.topics.navigation.navigateToTopic
 import uk.govuk.app.topics.navigation.navigateToTopicsAll
@@ -226,7 +226,6 @@ private fun BottomNavScaffold(
                 )
                 settingsGraph(
                     appVersion = BuildConfig.VERSION_NAME,
-                    privacyPolicyUrl = PRIVACY_POLICY_URL,
                     navController = navController,
                     modifier = Modifier.padding(paddingValues)
                 )

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -13,6 +13,20 @@ android {
 
     defaultConfig {
         minSdk = Version.MIN_SDK
+
+        buildConfigField("String", "ACCESSIBILITY_STATEMENT_EVENT", "\"AccessibilityStatement\"")
+        buildConfigField("String", "ACCESSIBILITY_STATEMENT_URL", "\"https://www.gov.uk/government/publications/accessibility-statement-for-the-govuk-app\"")
+
+        buildConfigField("String", "HELP_AND_FEEDBACK_EVENT", "\"HelpAndFeedback\"")
+        buildConfigField("String", "HELP_AND_FEEDBACK_URL", "\"https://www.gov.uk\"")
+
+        buildConfigField("String", "OPEN_SOURCE_LICENCE_EVENT", "\"OpenSourceLicenses\"")
+
+        buildConfigField("String", "PRIVACY_POLICY_EVENT", "\"PrivacyPolicy\"")
+        buildConfigField("String", "PRIVACY_POLICY_URL", "\"https://www.gov.uk/government/publications/govuk-app-privacy-notice-how-we-use-your-data\"")
+
+        buildConfigField("String", "TERMS_AND_CONDITIONS_EVENT", "\"TermsAndConditions\"")
+        buildConfigField("String", "TERMS_AND_CONDITIONS_URL", "\"http://www.gov.uk/government/publications/govuk-app-terms-and-conditions\"")
     }
 
     compileOptions {
@@ -26,6 +40,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/SettingsViewModel.kt
@@ -7,6 +7,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import uk.govuk.app.analytics.Analytics
+import uk.govuk.app.settings.BuildConfig.ACCESSIBILITY_STATEMENT_EVENT
+import uk.govuk.app.settings.BuildConfig.ACCESSIBILITY_STATEMENT_URL
+import uk.govuk.app.settings.BuildConfig.HELP_AND_FEEDBACK_EVENT
+import uk.govuk.app.settings.BuildConfig.HELP_AND_FEEDBACK_URL
+import uk.govuk.app.settings.BuildConfig.OPEN_SOURCE_LICENCE_EVENT
+import uk.govuk.app.settings.BuildConfig.PRIVACY_POLICY_EVENT
+import uk.govuk.app.settings.BuildConfig.PRIVACY_POLICY_URL
+import uk.govuk.app.settings.BuildConfig.TERMS_AND_CONDITIONS_EVENT
+import uk.govuk.app.settings.BuildConfig.TERMS_AND_CONDITIONS_URL
 import javax.inject.Inject
 
 internal data class SettingsUiState(
@@ -44,12 +53,38 @@ internal class SettingsViewModel @Inject constructor(
     }
 
     fun onLicenseView() {
-        val eventText = "OpenSourceLicenses"
-
         analytics.screenView(
-            screenClass = eventText,
-            screenName = eventText,
-            title = eventText
+            screenClass = OPEN_SOURCE_LICENCE_EVENT,
+            screenName = OPEN_SOURCE_LICENCE_EVENT,
+            title = OPEN_SOURCE_LICENCE_EVENT
+        )
+    }
+
+    fun onHelpAndFeedbackView() {
+        analytics.settingsItemClick(
+            text = HELP_AND_FEEDBACK_EVENT,
+            url = HELP_AND_FEEDBACK_URL
+        )
+    }
+
+    fun onPrivacyPolicyView() {
+        analytics.settingsItemClick(
+            text = PRIVACY_POLICY_EVENT,
+            url = PRIVACY_POLICY_URL
+        )
+    }
+
+    fun onAccessibilityStatementView() {
+        analytics.settingsItemClick(
+            text = ACCESSIBILITY_STATEMENT_EVENT,
+            url = ACCESSIBILITY_STATEMENT_URL
+        )
+    }
+
+    fun onTermsAndConditionsView() {
+        analytics.settingsItemClick(
+            text = TERMS_AND_CONDITIONS_EVENT,
+            url = TERMS_AND_CONDITIONS_URL
         )
     }
 

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/navigation/SettingsNavigation.kt
@@ -1,5 +1,6 @@
 package uk.govuk.app.settings.navigation
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.ui.Modifier
@@ -10,6 +11,10 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navDeepLink
 import androidx.navigation.navigation
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
+import uk.govuk.app.settings.BuildConfig.ACCESSIBILITY_STATEMENT_URL
+import uk.govuk.app.settings.BuildConfig.HELP_AND_FEEDBACK_URL
+import uk.govuk.app.settings.BuildConfig.PRIVACY_POLICY_URL
+import uk.govuk.app.settings.BuildConfig.TERMS_AND_CONDITIONS_URL
 import uk.govuk.app.settings.ui.SettingsRoute
 import uk.govuk.app.settings.ui.SettingsSubRoute
 
@@ -19,7 +24,6 @@ private const val SETTINGS_SUB_ROUTE = "settings_sub_route"
 
 fun NavGraphBuilder.settingsGraph(
     appVersion: String,
-    privacyPolicyUrl: String,
     navController: NavController,
     modifier: Modifier = Modifier
 ) {
@@ -40,11 +44,17 @@ fun NavGraphBuilder.settingsGraph(
 
             SettingsRoute(
                 appVersion = appVersion,
-                onHelpClick = { navController.navigateToSettingsSubScreen() },
+                onHelpClick = {
+                    openInBrowser(context, HELP_AND_FEEDBACK_URL)
+                },
                 onPrivacyPolicyClick = {
-                    val intent = Intent(Intent.ACTION_VIEW)
-                    intent.data = Uri.parse(privacyPolicyUrl)
-                    context.startActivity(intent)
+                    openInBrowser(context, PRIVACY_POLICY_URL)
+                },
+                onAccessibilityStatementClick = {
+                    openInBrowser(context, ACCESSIBILITY_STATEMENT_URL)
+                },
+                onTermsAndConditionsClick = {
+                    openInBrowser(context, TERMS_AND_CONDITIONS_URL)
                 },
                 onOpenSourceLicenseClick = {
                     val intent = Intent(context, OssLicensesMenuActivity::class.java)
@@ -65,4 +75,11 @@ fun NavGraphBuilder.settingsGraph(
     }
 }
 
+// TODO: do we still need this sub screen or can it be removed?
 private fun NavController.navigateToSettingsSubScreen() = navigate(SETTINGS_SUB_ROUTE)
+
+private fun openInBrowser(context: Context, url: String) {
+    val intent = Intent(Intent.ACTION_VIEW)
+    intent.data = Uri.parse(url)
+    context.startActivity(intent)
+}

--- a/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/govuk/app/settings/ui/SettingsScreen.kt
@@ -37,6 +37,8 @@ internal fun SettingsRoute(
     appVersion: String,
     onHelpClick: () -> Unit,
     onPrivacyPolicyClick: () -> Unit,
+    onAccessibilityStatementClick: () -> Unit,
+    onTermsAndConditionsClick: () -> Unit,
     onOpenSourceLicenseClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -52,9 +54,23 @@ internal fun SettingsRoute(
                 viewModel.onLicenseView()
                 onOpenSourceLicenseClick()
             },
-            onHelpClick = onHelpClick,
+            onHelpClick = {
+                viewModel.onHelpAndFeedbackView()
+                onHelpClick()
+            },
             onAnalyticsConsentChange = { enabled -> viewModel.onAnalyticsConsentChanged(enabled) },
-            onPrivacyPolicyClick = onPrivacyPolicyClick,
+            onPrivacyPolicyClick = {
+                viewModel.onPrivacyPolicyView()
+                onPrivacyPolicyClick()
+            },
+            onAccessibilityStatementClick = {
+                viewModel.onAccessibilityStatementView()
+                onAccessibilityStatementClick()
+            },
+            onTermsAndConditionsClick = {
+                viewModel.onTermsAndConditionsView()
+                onTermsAndConditionsClick()
+            },
             modifier = modifier
         )
     }
@@ -69,6 +85,8 @@ private fun SettingsScreen(
     onHelpClick: () -> Unit,
     onAnalyticsConsentChange: (Boolean) -> Unit,
     onPrivacyPolicyClick: () -> Unit,
+    onAccessibilityStatementClick: () -> Unit,
+    onTermsAndConditionsClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     LaunchedEffect(Unit) {
@@ -96,8 +114,13 @@ private fun SettingsScreen(
                 onAnalyticsConsentChange = onAnalyticsConsentChange,
                 onPrivacyPolicyClick = onPrivacyPolicyClick
             )
+
             MediumVerticalSpacer()
+
+            PrivacyPolicy(onPrivacyPolicyClick)
+            AccessibilityStatement(onAccessibilityStatementClick)
             OpenSourceLicenses(onLicenseClick)
+            TermsAndConditions(onTermsAndConditionsClick)
         }
     }
 }
@@ -116,7 +139,7 @@ private fun AboutTheApp(
         SmallVerticalSpacer()
 
         ExternalLinkListItem(
-            title = stringResource(R.string.help_setting),
+            title = stringResource(R.string.help_and_feedback_title),
             onClick = onHelpClick,
             isFirst = true,
             isLast = false
@@ -188,6 +211,34 @@ private fun PrivacyAndLegal(
 }
 
 @Composable
+private fun PrivacyPolicy(
+    onPrivacyPolicyClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ExternalLinkListItem(
+        title = stringResource(R.string.privacy_policy_title),
+        onClick = onPrivacyPolicyClick,
+        modifier = modifier,
+        isFirst = true,
+        isLast = false,
+    )
+}
+
+@Composable
+private fun AccessibilityStatement(
+    onAccessibilityStatementClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ExternalLinkListItem(
+        title = stringResource(R.string.accessibility_title),
+        onClick = onAccessibilityStatementClick,
+        modifier = modifier,
+        isFirst = false,
+        isLast = false,
+    )
+}
+
+@Composable
 private fun OpenSourceLicenses(
     onLicenseClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -195,6 +246,23 @@ private fun OpenSourceLicenses(
     InternalLinkListItem(
         title = stringResource(R.string.oss_licenses_title),
         onClick = onLicenseClick,
-        modifier = modifier
+        modifier = modifier,
+        isFirst = false,
+        isLast = false,
     )
 }
+
+@Composable
+private fun TermsAndConditions(
+    onLicenseClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ExternalLinkListItem(
+        title = stringResource(R.string.terms_and_conditions_title),
+        onClick = onLicenseClick,
+        modifier = modifier,
+        isFirst = false,
+        isLast = true,
+    )
+}
+

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
   <string name="screen_title">Settings</string>
   <string name="about_title">About the app</string>
-  <string name="help_setting">Help and feedback</string>
+  <string name="help_and_feedback_title">Help and feedback</string>
   <string name="version_setting">App version number</string>
   <string name="privacy_title">Privacy and legal</string>
   <string name="privacy_description">
@@ -15,4 +15,7 @@
   <string name="share_setting">Share app usage statistics</string>
   <string name="link_opens_in">Opens in web browser</string>
   <string name="oss_licenses_title">Open source licenses</string>
+  <string name="accessibility_title">Accessibility statement</string>
+  <string name="terms_and_conditions_title">Terms and conditions</string>
+  <string name="privacy_policy_title">Privacy policy</string>
 </resources>

--- a/feature/settings/src/test/kotlin/uk/govuk/app/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/uk/govuk/app/settings/SettingsViewModelTest.kt
@@ -17,6 +17,15 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import uk.govuk.app.analytics.Analytics
+import uk.govuk.app.settings.BuildConfig.ACCESSIBILITY_STATEMENT_EVENT
+import uk.govuk.app.settings.BuildConfig.ACCESSIBILITY_STATEMENT_URL
+import uk.govuk.app.settings.BuildConfig.HELP_AND_FEEDBACK_EVENT
+import uk.govuk.app.settings.BuildConfig.HELP_AND_FEEDBACK_URL
+import uk.govuk.app.settings.BuildConfig.OPEN_SOURCE_LICENCE_EVENT
+import uk.govuk.app.settings.BuildConfig.PRIVACY_POLICY_EVENT
+import uk.govuk.app.settings.BuildConfig.PRIVACY_POLICY_URL
+import uk.govuk.app.settings.BuildConfig.TERMS_AND_CONDITIONS_EVENT
+import uk.govuk.app.settings.BuildConfig.TERMS_AND_CONDITIONS_URL
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SettingsViewModelTest {
@@ -108,16 +117,67 @@ class SettingsViewModelTest {
     @Test
     fun `Given a license page view, then log analytics`() {
         val viewModel = SettingsViewModel(analytics)
-        val eventText = "OpenSourceLicenses"
 
         viewModel.onLicenseView()
 
         verify {
             analytics.screenView(
-                screenClass = eventText,
-                screenName = eventText,
-                title = eventText
+                screenClass = OPEN_SOURCE_LICENCE_EVENT,
+                screenName = OPEN_SOURCE_LICENCE_EVENT,
+                title = OPEN_SOURCE_LICENCE_EVENT
             )
         }
+    }
+
+    @Test
+    fun `Given a help and feedback page view, then log analytics`() {
+        val viewModel = SettingsViewModel(analytics)
+
+        viewModel.onHelpAndFeedbackView()
+
+        verify {
+            analytics.settingsItemClick(
+                text = HELP_AND_FEEDBACK_EVENT,
+                url = HELP_AND_FEEDBACK_URL
+            )
+        }
+    }
+
+    @Test
+    fun `Given a privacy policy page view, then log analytics`() {
+        val viewModel = SettingsViewModel(analytics)
+
+        viewModel.onPrivacyPolicyView()
+
+        verify {
+            analytics.settingsItemClick(
+                text = PRIVACY_POLICY_EVENT,
+                url = PRIVACY_POLICY_URL
+            )
+        }
+    }
+
+    @Test
+    fun `Given a accessibility statement page view, then log analytics`() {
+        val viewModel = SettingsViewModel(analytics)
+
+        viewModel.onAccessibilityStatementView()
+
+        analytics.settingsItemClick(
+            text = ACCESSIBILITY_STATEMENT_EVENT,
+            url = ACCESSIBILITY_STATEMENT_URL
+        )
+    }
+
+    @Test
+    fun `Given a terms and conditions page view, then log analytics`() {
+        val viewModel = SettingsViewModel(analytics)
+
+        viewModel.onTermsAndConditionsView()
+
+        analytics.settingsItemClick(
+            text = TERMS_AND_CONDITIONS_EVENT,
+            url = TERMS_AND_CONDITIONS_URL
+        )
     }
 }


### PR DESCRIPTION
# Update settings links

This change:

- Redirects Help and feedback link from sub page to an external URL
- Adds external links and analytics handlers for:
    - Help and feedback
    - Privacy policy
    - Accessibility statement
    - Terms and conditions

## JIRA ticket(s)
  - [GOVAPP-844](https://govukverify.atlassian.net/browse/GOVUKAPP-844)
  - [GOVAPP-845](https://govukverify.atlassian.net/browse/GOVUKAPP-845)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-82977&node-type=canvas&t=4yA7SYm6CsHOqieL-0)

## Screenshots

| Light Mode | Dark Mode |
|---|---|
| ![settings-day](https://github.com/user-attachments/assets/c14dbd03-889a-4497-804a-b957a0966e12) | ![settings-night](https://github.com/user-attachments/assets/aa177299-e46c-411e-a725-f9a0b83bf60b) |

## Analytics events

```bash
Firebase event sent with: Bundle[{external=true, language=en, url=https://www.gov.uk, text=HelpAndFeedback, type=SettingsItem}]
Firebase event sent with: Bundle[{external=true, language=en, url=https://www.gov.uk/government/publications/govuk-app-privacy-notice-how-we-use-your-data, text=PrivacyPolicy, type=SettingsItem}]
Firebase event sent with: Bundle[{external=true, language=en, url=https://www.gov.uk/government/publications/accessibility-statement-for-the-govuk-app, text=AccessibilityStatement, type=SettingsItem}]
Firebase event sent with: Bundle[{external=true, language=en, url=http://www.gov.uk/government/publications/govuk-app-terms-and-conditions, text=TermsAndConditions, type=SettingsItem}]
```

## Notes 🎶 

- The URL for Help and feedback is currently set to the GOV.UK home page. The actual URL is pending completion of [User Feedback Form](https://govukverify.atlassian.net/browse/GOVUKAPP-796)
- All other URLs are supposedly correct, but pending those pages being published on GOV.UK.
- All URLs and analytic event names are now stored - once - in the Settings `BuildConfig`.