### PR TITLE
Switch Search API to V2

### DIFF
--- a/feature/search/src/main/kotlin/uk/govuk/app/search/data/remote/SearchApi.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/data/remote/SearchApi.kt
@@ -3,9 +3,10 @@ package uk.govuk.app.search.data.remote
 import retrofit2.http.GET
 import retrofit2.http.Query
 import uk.govuk.app.search.data.remote.model.SearchResponse
+import uk.govuk.app.search.domain.SearchConfig
 
 interface SearchApi {
-    @GET("/api/search.json")
+    @GET(SearchConfig.SEARCH_PATH)
     suspend fun getSearchResults(
         @Query("q") searchTerm: String,
         @Query("count") count: Int

--- a/feature/search/src/main/kotlin/uk/govuk/app/search/data/remote/model/Result.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/data/remote/model/Result.kt
@@ -1,9 +1,10 @@
 package uk.govuk.app.search.data.remote.model
 
 import com.google.gson.annotations.SerializedName
+import uk.govuk.app.search.domain.SearchConfig.DESCRIPTION_RESPONSE_FIELD
 
 data class Result(
     @SerializedName("title") val title: String,
-    @SerializedName("description_with_highlighting") val description: String?,
+    @SerializedName(DESCRIPTION_RESPONSE_FIELD) val description: String?,
     @SerializedName("link") val link: String
 )

--- a/feature/search/src/main/kotlin/uk/govuk/app/search/data/remote/model/Result.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/data/remote/model/Result.kt
@@ -4,6 +4,6 @@ import com.google.gson.annotations.SerializedName
 
 data class Result(
     @SerializedName("title") val title: String,
-    @SerializedName("description") val description: String,
+    @SerializedName("description_with_highlighting") val description: String?,
     @SerializedName("link") val link: String
 )

--- a/feature/search/src/main/kotlin/uk/govuk/app/search/domain/SearchConfig.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/domain/SearchConfig.kt
@@ -1,7 +1,16 @@
 package uk.govuk.app.search.domain
 
 object SearchConfig {
+//    Search API V1 ===>
+//    val BASE_URL = "https://www.gov.uk"
+//    const val SEARCH_PATH = "/api/search.json"
+//    const val DESCRIPTION_RESPONSE_FIELD = "description"
+
+    //    Search API V2 ===>
     val BASE_URL = "https://search.publishing.service.gov.uk"
     const val SEARCH_PATH = "/v0_1/search.json"
+    //    field has both changed name and is now optional!
+    const val DESCRIPTION_RESPONSE_FIELD = "description_with_highlighting"
+
     val DEFAULT_RESULTS_PER_PAGE = 10
 }

--- a/feature/search/src/main/kotlin/uk/govuk/app/search/domain/SearchConfig.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/domain/SearchConfig.kt
@@ -1,6 +1,7 @@
 package uk.govuk.app.search.domain
 
 object SearchConfig {
-    val BASE_URL = "https://www.gov.uk"
+    val BASE_URL = "https://search.publishing.service.gov.uk"
+    const val SEARCH_PATH = "/v0_1/search.json"
     val DEFAULT_RESULTS_PER_PAGE = 10
 }

--- a/feature/search/src/main/kotlin/uk/govuk/app/search/ui/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/ui/SearchScreen.kt
@@ -135,7 +135,9 @@ fun ShowResults(searchResults: List<Result>, onClick: (String, String) -> Unit) 
         LazyColumn {
             items(searchResults) { searchResult ->
                 val title = StringUtils.collapseWhitespace(searchResult.title)
-                val description = StringUtils.collapseWhitespace(searchResult.description)
+                val description = searchResult.description?.let {
+                    StringUtils.collapseWhitespace(it)
+                } ?: ""
                 val url = StringUtils.buildFullUrl(searchResult.link)
 
                 val context = LocalContext.current

--- a/feature/search/src/test/kotlin/uk/govuk/app/search/domain/StringUtilsTest.kt
+++ b/feature/search/src/test/kotlin/uk/govuk/app/search/domain/StringUtilsTest.kt
@@ -2,13 +2,14 @@ package uk.govuk.app.search.domain
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import uk.govuk.app.search.domain.SearchConfig.BASE_URL
 
 class StringUtilsTest {
     @Test
     fun `buildFullUrl returns a full url when given a path`() {
         val url = StringUtils.buildFullUrl("/hello-world")
 
-        assertEquals("https://search.publishing.service.gov.uk/hello-world", url)
+        assertEquals("${BASE_URL}/hello-world", url)
     }
 
     @Test

--- a/feature/search/src/test/kotlin/uk/govuk/app/search/domain/StringUtilsTest.kt
+++ b/feature/search/src/test/kotlin/uk/govuk/app/search/domain/StringUtilsTest.kt
@@ -8,7 +8,7 @@ class StringUtilsTest {
     fun `buildFullUrl returns a full url when given a path`() {
         val url = StringUtils.buildFullUrl("/hello-world")
 
-        assertEquals("https://www.gov.uk/hello-world", url)
+        assertEquals("https://search.publishing.service.gov.uk/hello-world", url)
     }
 
     @Test


### PR DESCRIPTION
# Switch Search API to V2

- [Search v1](https://www.gov.uk/api/search.json?q=micropig)
- [Search v2](https://search.publishing.service.gov.uk/v0_1/search.json?q=micropig)

## Notes 🎶 

- `description` in v1 has been renamed/moved to `description_with_highlighting`
- `description_with_highlighting` is an optional field

## JIRA ticket(s)
  - [GOVAPP-833](https://govukverify.atlassian.net/browse/GOVUKAPP-833)
