### PR TITLE
Search URL bug fix

### DIFF
--- a/feature/search/src/main/kotlin/uk/govuk/app/search/di/SearchModule.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/di/SearchModule.kt
@@ -18,7 +18,7 @@ class SearchModule {
     @Singleton
     fun providesSearchApi(): SearchApi {
         return Retrofit.Builder()
-            .baseUrl(SearchConfig.BASE_URL)
+            .baseUrl(SearchConfig.API_BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
             .create(SearchApi::class.java)

--- a/feature/search/src/main/kotlin/uk/govuk/app/search/domain/SearchConfig.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/domain/SearchConfig.kt
@@ -1,13 +1,15 @@
 package uk.govuk.app.search.domain
 
 object SearchConfig {
+    val BASE_URL = "https://www.gov.uk"
+
 //    Search API V1 ===>
-//    val BASE_URL = "https://www.gov.uk"
+//    val API_BASE_URL = "https://www.gov.uk"
 //    const val SEARCH_PATH = "/api/search.json"
 //    const val DESCRIPTION_RESPONSE_FIELD = "description"
 
     //    Search API V2 ===>
-    val BASE_URL = "https://search.publishing.service.gov.uk"
+    val API_BASE_URL = "https://search.publishing.service.gov.uk"
     const val SEARCH_PATH = "/v0_1/search.json"
     //    field has both changed name and is now optional!
     const val DESCRIPTION_RESPONSE_FIELD = "description_with_highlighting"

--- a/feature/search/src/test/kotlin/uk/govuk/app/search/domain/StringUtilsTest.kt
+++ b/feature/search/src/test/kotlin/uk/govuk/app/search/domain/StringUtilsTest.kt
@@ -2,14 +2,13 @@ package uk.govuk.app.search.domain
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import uk.govuk.app.search.domain.SearchConfig.BASE_URL
 
 class StringUtilsTest {
     @Test
     fun `buildFullUrl returns a full url when given a path`() {
         val url = StringUtils.buildFullUrl("/hello-world")
 
-        assertEquals("${BASE_URL}/hello-world", url)
+        assertEquals("https://www.gov.uk/hello-world", url)
     }
 
     @Test


### PR DESCRIPTION
# Search URL bug fix

We need to keep the BASE_URL as it is only the Search API URL that changes between v1 and v2. I had forgotten that we also use this when generating the full URL from the path in the content item that is returned in the search results. So, when I updated the test - it still passed, but should not have. Lesson - listen to your tests.

This change fixes that issue by introducing an API_BASE_URL and updating the API call. The test is reverted to a hard-coded string as this is a good check that the user will go to the correct URL. 