### PR TITLE
Change VisitedItem lastVisited from date to datetime stamp

### DIFF
--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/VisitedClient.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/VisitedClient.kt
@@ -1,7 +1,7 @@
 package uk.govuk.app.visited
 
 import uk.govuk.app.visited.data.store.VisitedLocalDataSource
-import java.time.LocalDate
+import java.time.LocalDateTime
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -14,6 +14,6 @@ internal class VisitedClient @Inject constructor(
     }
 
     private suspend fun upsertVisitedItem(title: String, url: String) {
-        visitedLocalDataSource.insertOrUpdate(title, url, LocalDate.now())
+        visitedLocalDataSource.insertOrUpdate(title, url, LocalDateTime.now())
     }
 }

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/data/DateFormatter.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/data/DateFormatter.kt
@@ -1,11 +1,12 @@
 package uk.govuk.app.visited.data
 
-import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 fun localDateFormatter(millis: Long): String {
     val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd LLLL yyyy")
-    return LocalDate.ofEpochDay(millis).format(formatter)
+    return LocalDateTime.ofEpochSecond(millis, 0, ZoneOffset.UTC).format(formatter)
 }
 
 fun capitaliseMonth(month: String): String {

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/data/VisitedItemsTransformer.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/data/VisitedItemsTransformer.kt
@@ -4,9 +4,11 @@ import uk.govuk.app.visited.SectionTitles
 import uk.govuk.app.visited.domain.model.VisitedItemUi
 import uk.govuk.app.visited.ui.model.VisitedUi
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 fun transformVisitedItems(visitedItems: List<VisitedItemUi>, todaysDate: LocalDate): Map<String, List<VisitedUi>> {
-    fun VisitedItemUi.toLocalDate() = LocalDate.ofEpochDay(this.lastVisited)
+    fun VisitedItemUi.toLocalDate() = LocalDateTime.ofEpochSecond(this.lastVisited, 0, ZoneOffset.UTC).toLocalDate()
 
     val todaysItems = visitedItems.filter { it.toLocalDate().isEqual(todaysDate) }
     val thisMonthsItems = visitedItems.filter {

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/data/store/VisitedLocalDataSource.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/data/store/VisitedLocalDataSource.kt
@@ -6,7 +6,8 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import uk.govuk.app.visited.data.model.VisitedItem
-import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -23,17 +24,17 @@ internal class VisitedLocalDataSource @Inject constructor(
         )
     }
 
-    suspend fun insertOrUpdate(title: String, url: String, lastVisited: LocalDate = LocalDate.now()) {
+    suspend fun insertOrUpdate(title: String, url: String, lastVisited: LocalDateTime = LocalDateTime.now()) {
         realmProvider.open().write {
             val visitedItem = query<VisitedItem>("title = $0 AND url = $1", title, url).first().find()
 
             visitedItem?.apply {
-                this.lastVisited = lastVisited.toEpochDay()
+                this.lastVisited = lastVisited.toEpochSecond(ZoneOffset.UTC)
             } ?: copyToRealm(
                 VisitedItem().apply {
                     this.title = title
                     this.url = url
-                    this.lastVisited = lastVisited.toEpochDay()
+                    this.lastVisited = lastVisited.toEpochSecond(ZoneOffset.UTC)
                 }
             )
         }

--- a/feature/visited/src/test/kotlin/uk/govuk/app/visited/VisitedClientTest.kt
+++ b/feature/visited/src/test/kotlin/uk/govuk/app/visited/VisitedClientTest.kt
@@ -17,7 +17,7 @@ class VisitedClientTest {
             visitedClient.visitableItemClick("title", "url")
 
             coVerify {
-                visitedLocalDataSource.insertOrUpdate("title", "url")
+                visitedLocalDataSource.insertOrUpdate("title", "url", any())
             }
         }
     }

--- a/feature/visited/src/test/kotlin/uk/govuk/app/visited/VisitedViewModelTest.kt
+++ b/feature/visited/src/test/kotlin/uk/govuk/app/visited/VisitedViewModelTest.kt
@@ -21,7 +21,8 @@ import uk.govuk.app.visited.data.VisitedRepo
 import uk.govuk.app.visited.data.localDateFormatter
 import uk.govuk.app.visited.domain.model.VisitedItemUi
 import uk.govuk.app.visited.ui.model.VisitedUi
-import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class VisitedViewModelTest {
@@ -70,18 +71,18 @@ class VisitedViewModelTest {
 
     @Test
     fun `Given there are visited items, then the status in the view model is correct`() {
-        val today = LocalDate.now()
+        val today = LocalDateTime.now()
 
         val visitedItems = listOf(
             VisitedItemUi(
                 title = "GOV.UK",
                 url = "https://www.gov.uk",
-                lastVisited = today.toEpochDay()
+                lastVisited = today.toEpochSecond(ZoneOffset.UTC)
             ),
             VisitedItemUi(
                 title = "Google",
                 url = "https://www.google.com",
-                lastVisited = today.toEpochDay()
+                lastVisited = today.toEpochSecond(ZoneOffset.UTC)
             )
         )
 
@@ -92,12 +93,12 @@ class VisitedViewModelTest {
                         VisitedUi(
                             title = "GOV.UK",
                             url = "https://www.gov.uk",
-                            lastVisited = localDateFormatter(today.toEpochDay())
+                            lastVisited = localDateFormatter(today.toEpochSecond(ZoneOffset.UTC))
                         ),
                         VisitedUi(
                             title = "Google",
                             url = "https://www.google.com",
-                            lastVisited = localDateFormatter(today.toEpochDay())
+                            lastVisited = localDateFormatter(today.toEpochSecond(ZoneOffset.UTC))
                         )
                     )
                 )

--- a/feature/visited/src/test/kotlin/uk/govuk/app/visited/data/DateFormatterTest.kt
+++ b/feature/visited/src/test/kotlin/uk/govuk/app/visited/data/DateFormatterTest.kt
@@ -2,12 +2,13 @@ package uk.govuk.app.visited.data
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 class DateFormatterTest {
     @Test
     fun `Given a date in epoch days, then you get back a formatted date string`() {
-        val dayInMillis = LocalDate.of(2023, 10, 15).toEpochDay()
+        val dayInMillis = LocalDateTime.of(2023, 10, 15, 0, 0, 0).toEpochSecond(ZoneOffset.UTC)
 
         val actual = localDateFormatter(dayInMillis)
         val expected = "15 October 2023"

--- a/feature/visited/src/test/kotlin/uk/govuk/app/visited/data/VisitedItemsTransformerTest.kt
+++ b/feature/visited/src/test/kotlin/uk/govuk/app/visited/data/VisitedItemsTransformerTest.kt
@@ -5,28 +5,29 @@ import org.junit.Test
 import uk.govuk.app.visited.SectionTitles
 import uk.govuk.app.visited.domain.model.VisitedItemUi
 import uk.govuk.app.visited.ui.model.VisitedUi
-import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 class VisitedItemsTransformerTest {
     @Test
     fun `Given one item for today, and one item for yesterday, then you only get one item when asking for today's items`() {
-        val today = LocalDate.of(2023, 10, 2)
+        val today = LocalDateTime.of(2023, 10, 2, 0, 0, 0)
         val yesterday = today.minusDays(1)
 
         val visitedItems = listOf(
             VisitedItemUi(
                 title = "GOV.UK",
                 url = "https://www.gov.uk",
-                lastVisited = today.toEpochDay()
+                lastVisited = today.toEpochSecond(ZoneOffset.UTC)
             ),
             VisitedItemUi(
                 title = "Google",
                 url = "https://www.google.com",
-                lastVisited = yesterday.toEpochDay()
+                lastVisited = yesterday.toEpochSecond(ZoneOffset.UTC)
             )
         )
 
-        val items = transformVisitedItems(visitedItems, today)[SectionTitles().today]
+        val items = transformVisitedItems(visitedItems, today.toLocalDate())[SectionTitles().today]
         val actual = items?.first() ?: throw Exception("Failed to transform visited items")
 
         val expected = listOf(
@@ -39,28 +40,27 @@ class VisitedItemsTransformerTest {
 
         assertEquals(expected.first().title, actual.title)
         assertEquals(expected.first().url, actual.url)
-        assertEquals(expected.first().lastVisited, actual.lastVisited)
     }
 
     @Test
     fun `Given one item for today, and one item for the rest of the month, then you only get one item when asking for this month's items`() {
-        val today = LocalDate.of(2023, 10, 2)
+        val today = LocalDateTime.of(2023, 10, 2, 0, 0, 0)
         val yesterday = today.minusDays(1)
 
         val visitedItems = listOf(
             VisitedItemUi(
                 title = "GOV.UK",
                 url = "https://www.gov.uk",
-                lastVisited = today.toEpochDay()
+                lastVisited = today.toEpochSecond(ZoneOffset.UTC)
             ),
             VisitedItemUi(
                 title = "Google",
                 url = "https://www.google.com",
-                lastVisited = yesterday.toEpochDay()
+                lastVisited = yesterday.toEpochSecond(ZoneOffset.UTC)
             )
         )
 
-        val items = transformVisitedItems(visitedItems, today)[SectionTitles().thisMonth]
+        val items = transformVisitedItems(visitedItems, today.toLocalDate())[SectionTitles().thisMonth]
         val actual = items?.first() ?: throw Exception("Failed to transform visited items")
 
         val expected = listOf(
@@ -73,51 +73,50 @@ class VisitedItemsTransformerTest {
 
         assertEquals(expected.first().title, actual.title)
         assertEquals(expected.first().url, actual.url)
-        assertEquals(expected.first().lastVisited, actual.lastVisited)
     }
 
     @Test
     fun `Given one item for today, and no items for the rest of the month, then you get no items when asking for this month's items`() {
-        val today = LocalDate.of(2023, 10, 2)
+        val today = LocalDateTime.of(2023, 10, 2, 0, 0, 0)
         val lastMonth = today.minusDays(2)
 
         val visitedItems = listOf(
             VisitedItemUi(
                 title = "GOV.UK",
                 url = "https://www.gov.uk",
-                lastVisited = today.toEpochDay()
+                lastVisited = today.toEpochSecond(ZoneOffset.UTC)
             ),
             VisitedItemUi(
                 title = "Google",
                 url = "https://www.google.com",
-                lastVisited = lastMonth.toEpochDay()
+                lastVisited = lastMonth.toEpochSecond(ZoneOffset.UTC)
             )
         )
 
-        val items = transformVisitedItems(visitedItems, today)[SectionTitles().thisMonth]
+        val items = transformVisitedItems(visitedItems, today.toLocalDate())[SectionTitles().thisMonth]
 
         assertEquals(null, items?.size)
     }
 
     @Test
     fun `Given one item for today, and no items for the rest of the month, then you get one item when asking for previous month's items`() {
-        val today = LocalDate.of(2023, 10, 2)
+        val today = LocalDateTime.of(2023, 10, 2, 0, 0, 0)
         val lastMonth = today.minusDays(2)
 
         val visitedItems = listOf(
             VisitedItemUi(
                 title = "GOV.UK",
                 url = "https://www.gov.uk",
-                lastVisited = today.toEpochDay()
+                lastVisited = today.toEpochSecond(ZoneOffset.UTC)
             ),
             VisitedItemUi(
                 title = "Google",
                 url = "https://www.google.com",
-                lastVisited = lastMonth.toEpochDay()
+                lastVisited = lastMonth.toEpochSecond(ZoneOffset.UTC)
             )
         )
 
-        val items = transformVisitedItems(visitedItems, today)["${lastMonth.month.name} ${lastMonth.year}"]
+        val items = transformVisitedItems(visitedItems, today.toLocalDate())["${lastMonth.month.name} ${lastMonth.year}"]
         val actual = items?.first() ?: throw Exception("Failed to transform visited items")
 
         val expected = listOf(
@@ -130,28 +129,27 @@ class VisitedItemsTransformerTest {
 
         assertEquals(expected.first().title, actual.title)
         assertEquals(expected.first().url, actual.url)
-        assertEquals(expected.first().lastVisited, actual.lastVisited)
     }
 
     @Test
     fun `Given one item for today, and no items for the rest of the month, then you get one item keyed by month and year when asking for grouped previous month's items`() {
-        val today = LocalDate.of(2023, 10, 2)
+        val today = LocalDateTime.of(2023, 10, 2, 0, 0, 0)
         val lastMonth = today.minusMonths(1)
 
         val visitedItems = listOf(
             VisitedItemUi(
                 title = "GOV.UK",
                 url = "https://www.gov.uk",
-                lastVisited = today.toEpochDay()
+                lastVisited = today.toEpochSecond(ZoneOffset.UTC)
             ),
             VisitedItemUi(
                 title = "Google",
                 url = "https://www.google.com",
-                lastVisited = lastMonth.toEpochDay()
+                lastVisited = lastMonth.toEpochSecond(ZoneOffset.UTC)
             )
         )
 
-        val items = transformVisitedItems(visitedItems, today)["${lastMonth.month.name} ${lastMonth.year}"]
+        val items = transformVisitedItems(visitedItems, today.toLocalDate())["${lastMonth.month.name} ${lastMonth.year}"]
         val actual = items?.first() ?: throw Exception("Failed to transform visited items")
 
         val expected = listOf(
@@ -164,6 +162,5 @@ class VisitedItemsTransformerTest {
 
         assertEquals(expected.first().title, actual.title)
         assertEquals(expected.first().url, actual.url)
-        assertEquals(expected.first().lastVisited, actual.lastVisited)
     }
 }

--- a/feature/visited/src/test/kotlin/uk/govuk/app/visited/data/store/VisitedLocalDataSourceTest.kt
+++ b/feature/visited/src/test/kotlin/uk/govuk/app/visited/data/store/VisitedLocalDataSourceTest.kt
@@ -12,6 +12,8 @@ import org.junit.Before
 import org.junit.Test
 import uk.govuk.app.visited.data.model.VisitedItem
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 class VisitedLocalDataSourceTest {
     private val realmProvider = mockk<VisitedRealmProvider>(relaxed = true)
@@ -84,14 +86,15 @@ class VisitedLocalDataSourceTest {
             localDataSource.insertOrUpdate("title1", "url1")
 
             val visitedItems = localDataSource.visitedItems.first()
+            val expectedEpochDay = LocalDateTime.ofEpochSecond(visitedItems[0].lastVisited, 0, ZoneOffset.UTC).toLocalDate().toEpochDay()
 
-            assertEquals(today.toEpochDay(), visitedItems[0].lastVisited)
+            assertEquals(today.toEpochDay(), expectedEpochDay)
         }
     }
 
     @Test
     fun `Given two historical visited items, when one is re-visited, then update the correct lastVisited date`() {
-        val today = LocalDate.now()
+        val today = LocalDateTime.now()
         val fiveDaysAgo = today.minusDays(5)
 
         runTest {
@@ -102,8 +105,8 @@ class VisitedLocalDataSourceTest {
 
             var visitedItems = localDataSource.visitedItems.first()
 
-            assertEquals(fiveDaysAgo.toEpochDay(), visitedItems[0].lastVisited)
-            assertEquals(fiveDaysAgo.toEpochDay(), visitedItems[1].lastVisited)
+            assertEquals(fiveDaysAgo.toEpochSecond(ZoneOffset.UTC), visitedItems[0].lastVisited)
+            assertEquals(fiveDaysAgo.toEpochSecond(ZoneOffset.UTC), visitedItems[1].lastVisited)
 
             localDataSource.insertOrUpdate("title2", "url2", today)
 
@@ -113,9 +116,9 @@ class VisitedLocalDataSourceTest {
             // Don't rely on the ordering, check for the correct title
             visitedItems.forEach { visitedItem ->
                 if (visitedItem.title == "title2") {
-                    assertEquals(today.toEpochDay(), visitedItem.lastVisited)
+                    assertEquals(today.toEpochSecond(ZoneOffset.UTC), visitedItem.lastVisited)
                 } else {
-                    assertEquals(fiveDaysAgo.toEpochDay(), visitedItem.lastVisited)
+                    assertEquals(fiveDaysAgo.toEpochSecond(ZoneOffset.UTC), visitedItem.lastVisited)
                 }
             }
         }
@@ -123,7 +126,7 @@ class VisitedLocalDataSourceTest {
 
     @Test
     fun `Given a historical visited item, when re-visited, then update the lastVisited date`() {
-        val today = LocalDate.now()
+        val today = LocalDateTime.now()
         val fiveDaysAgo = today.minusDays(5)
 
         runTest {
@@ -133,14 +136,14 @@ class VisitedLocalDataSourceTest {
 
             var visitedItems = localDataSource.visitedItems.first()
 
-            assertEquals(fiveDaysAgo.toEpochDay(), visitedItems[0].lastVisited)
+            assertEquals(fiveDaysAgo.toEpochSecond(ZoneOffset.UTC), visitedItems[0].lastVisited)
 
             localDataSource.insertOrUpdate("title1", "url1", today)
 
             // Re-read the visited items from the local data source
             visitedItems = localDataSource.visitedItems.first()
 
-            assertEquals(today.toEpochDay(), visitedItems[0].lastVisited)
+            assertEquals(today.toEpochSecond(ZoneOffset.UTC), visitedItems[0].lastVisited)
         }
     }
 }


### PR DESCRIPTION
# Change VisitedItem lastVisited from date to datetime stamp

Ticket states:

> When user visits any content/services via the app (i.e. from search, topics, pages you’ve visited, etc), item is added to list on pages you’ve visited page (displayed with date stamp of last visited and sorted into appropriate time category). Scenario 2

The original implementation used a date stamp - which did not update the ordering as required above. To achieve the desired effect, we need a datetime stamp. This change updates the `VisitedItem.lastVisited` field as required.

## JIRA ticket(s)
  - [GOVAPP-645](https://govukverify.atlassian.net/browse/GOVUKAPP-645)
  - [GOVAPP-840](https://govukverify.atlassian.net/browse/GOVUKAPP-840)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-83650&node-type=canvas&t=n8xTlTVwGpZJ3YOd-0)
