### PR TITLE
Revert "Set Gradle configuration-cache"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-org.gradle.configuration-cache=true


### PR DESCRIPTION
A little unsure, but it looks like this change is [causing issues with CI](https://github.com/alphagov/govuk-mobile-android-app/actions/runs/11793131865/job/32848503296)

Reverts alphagov/govuk-mobile-android-app#102