### PR TITLE
GOVUKAPP-590 Global ON/OFF switch - Fix ALPHA build issue

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,6 +104,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.material3)
     implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.ui.tooling)
     implementation(libs.hilt.android)
     implementation(libs.androidx.datastore.preferences)
 
@@ -124,6 +125,5 @@ dependencies {
     androidTestImplementation(libs.androidx.hilt.navigation.compose)
     androidTestImplementation(libs.hilt.android)
 
-    debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 }


### PR DESCRIPTION
# Description
The original Global ON/OFF switch PR added a Compose Preview to a new UI file in the main app module.
The dependancy for Compose Preview was only available in the app to debug build variants.
This caused ALPHA build variants to fail building with an unknown resource error as the dependancy wasn't available to them.
To resolve we have made dependancy for Compose Preview available to ALL build variants.

## JIRA ticket(s)
  - [GOVAPP-590](https://govukverify.atlassian.net/browse/GOVUKAPP-590)
