### PR TITLE
Android | Visited items: Create edit mode

### DIFF
--- a/design/src/main/kotlin/uk/govuk/app/design/ui/theme/Color.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/theme/Color.kt
@@ -64,7 +64,8 @@ data class GovUkColourScheme(
         val buttonCompactFocused: Color,
         val buttonSuccess: Color,
         val trailingIcon: Color,
-        val buttonRemove: Color
+        val buttonRemove: Color,
+        val selectedTick: Color
     )
 
     data class Surfaces(
@@ -121,7 +122,8 @@ internal val LightColorScheme = GovUkColourScheme(
         buttonCompactFocused = Black,
         buttonSuccess = Green1,
         trailingIcon = Grey300,
-        buttonRemove = Red1
+        buttonRemove = Red1,
+        selectedTick = White
     ),
     surfaces = Surfaces(
         background = Grey50,
@@ -176,7 +178,8 @@ internal val DarkColorScheme = GovUkColourScheme(
         buttonCompactFocused = Black,
         buttonSuccess = Green2,
         trailingIcon = Grey500,
-        buttonRemove = Red1
+        buttonRemove = Red1,
+        selectedTick = White
     ),
     surfaces = Surfaces(
         background = Black,
@@ -232,7 +235,8 @@ internal val LocalColourScheme = staticCompositionLocalOf {
             buttonCompactFocused = Color.Unspecified,
             buttonSuccess = Color.Unspecified,
             trailingIcon = Color.Unspecified,
-            buttonRemove = Color.Unspecified
+            buttonRemove = Color.Unspecified,
+            selectedTick = Color.Unspecified
         ),
         surfaces = Surfaces(
             background = Color.Unspecified,

--- a/design/src/main/kotlin/uk/govuk/app/design/ui/theme/Color.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/theme/Color.kt
@@ -15,6 +15,7 @@ private val Blue6 = Color(0xFF7AC2FF)
 private val Blue7 = Color(0xFFE8F1F8)
 
 private val Yellow = Color(0xFFFFDD00)
+
 private val Red1 = Color(0xFFD4351C)
 
 private val Green1 = Color(0xFF11875A)

--- a/design/src/main/kotlin/uk/govuk/app/design/ui/theme/Color.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/theme/Color.kt
@@ -15,6 +15,7 @@ private val Blue6 = Color(0xFF7AC2FF)
 private val Blue7 = Color(0xFFE8F1F8)
 
 private val Yellow = Color(0xFFFFDD00)
+private val Red1 = Color(0xFFD4351C)
 
 private val Green1 = Color(0xFF11875A)
 private val Green2 = Color(0xFF66F39E)
@@ -62,7 +63,8 @@ data class GovUkColourScheme(
         val buttonCompactDisabled: Color,
         val buttonCompactFocused: Color,
         val buttonSuccess: Color,
-        val trailingIcon: Color
+        val trailingIcon: Color,
+        val buttonRemove: Color
     )
 
     data class Surfaces(
@@ -118,7 +120,8 @@ internal val LightColorScheme = GovUkColourScheme(
         buttonCompactDisabled = Grey600,
         buttonCompactFocused = Black,
         buttonSuccess = Green1,
-        trailingIcon = Grey300
+        trailingIcon = Grey300,
+        buttonRemove = Red1
     ),
     surfaces = Surfaces(
         background = Grey50,
@@ -172,7 +175,8 @@ internal val DarkColorScheme = GovUkColourScheme(
         buttonCompactDisabled = Black,
         buttonCompactFocused = Black,
         buttonSuccess = Green2,
-        trailingIcon = Grey500
+        trailingIcon = Grey500,
+        buttonRemove = Red1
     ),
     surfaces = Surfaces(
         background = Black,
@@ -227,7 +231,8 @@ internal val LocalColourScheme = staticCompositionLocalOf {
             buttonCompactDisabled = Color.Unspecified,
             buttonCompactFocused = Color.Unspecified,
             buttonSuccess = Color.Unspecified,
-            trailingIcon = Color.Unspecified
+            trailingIcon = Color.Unspecified,
+            buttonRemove = Color.Unspecified
         ),
         surfaces = Surfaces(
             background = Color.Unspecified,

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/VisitedViewModel.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/VisitedViewModel.kt
@@ -26,7 +26,8 @@ internal class VisitedViewModel @Inject constructor(
 ): ViewModel() {
 
     companion object {
-        private const val SCREEN_CLASS = "VisitedScreen"
+        private const val EDIT_SCREEN_CLASS = "EditVisitedScreen"
+        private const val VIEW_SCREEN_CLASS = "VisitedScreen"
         private const val SCREEN_NAME = "Pages you've visited"
         private const val SCREEN_TITLE = "Pages you've visited"
     }
@@ -45,7 +46,15 @@ internal class VisitedViewModel @Inject constructor(
 
     fun onPageView() {
         analytics.screenView(
-            screenClass = SCREEN_CLASS,
+            screenClass = VIEW_SCREEN_CLASS,
+            screenName = SCREEN_NAME,
+            title = SCREEN_TITLE
+        )
+    }
+
+    fun onEditPageView() {
+        analytics.screenView(
+            screenClass = EDIT_SCREEN_CLASS,
             screenName = SCREEN_NAME,
             title = SCREEN_TITLE
         )

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/navigation/VisitedNavigation.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/navigation/VisitedNavigation.kt
@@ -1,14 +1,17 @@
 package uk.govuk.app.visited.navigation
 
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import uk.govuk.app.visited.ui.EditVisitedRoute
 import uk.govuk.app.visited.ui.VisitedRoute
 
 const val VISITED_GRAPH_ROUTE = "visited_graph_route"
 const val VISITED_ROUTE = "visited_route"
+const val EDIT_VISITED_ROUTE = "edit_visited_route"
 
 fun NavGraphBuilder.visitedGraph(
     navController: NavHostController,
@@ -18,13 +21,22 @@ fun NavGraphBuilder.visitedGraph(
         route = VISITED_GRAPH_ROUTE,
         startDestination = VISITED_ROUTE
     ) {
-        composable(
-            VISITED_ROUTE,
-        ) {
+        composable(VISITED_ROUTE) {
             VisitedRoute(
+                navController = navController,
+                onBack = { navController.popBackStack() },
+                modifier = modifier
+            )
+        }
+        composable(EDIT_VISITED_ROUTE) {
+            EditVisitedRoute(
                 onBack = { navController.popBackStack() },
                 modifier = modifier
             )
         }
     }
+}
+
+fun NavController.navigateToEditVisited() {
+    navigate(EDIT_VISITED_ROUTE)
 }

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -1,0 +1,149 @@
+package uk.govuk.app.visited.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import uk.govuk.app.design.ui.component.BodyRegularLabel
+import uk.govuk.app.design.ui.component.Title2BoldLabel
+import uk.govuk.app.design.ui.theme.GovUkTheme
+import uk.govuk.app.visited.R
+
+@Composable
+internal fun EditVisitedRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    EditVisitedScreen(
+        onBack = onBack,
+        modifier = modifier
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EditVisitedScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+
+    val title = stringResource(R.string.visited_items_title)
+    val doneText = stringResource(R.string.visited_items_done_button)
+    val selectText = stringResource(R.string.visited_items_select_all_button)
+    val removeText = stringResource(R.string.visited_items_remove_button)
+
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+
+        topBar = {
+            CenterAlignedTopAppBar(
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = GovUkTheme.colourScheme.surfaces.background,
+                    titleContentColor = GovUkTheme.colourScheme.textAndIcons.primary,
+                ),
+                title = {
+                    Title2BoldLabel(
+                        title,
+                    )
+                },
+                actions = {
+                    TextButton(
+                        onClick = onBack,
+                        modifier = Modifier.wrapContentSize()
+                    ) {
+                        BodyRegularLabel(
+                            text = doneText,
+                            color = GovUkTheme.colourScheme.textAndIcons.link,
+                            textAlign = TextAlign.End
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        },
+        bottomBar = {
+            NavigationBar(
+                containerColor = GovUkTheme.colourScheme.surfaces.background,
+                contentColor = GovUkTheme.colourScheme.textAndIcons.primary,
+                modifier = modifier.fillMaxWidth()
+                    .height(81.dp)
+                    .border(width = 1.dp, color = GovUkTheme.colourScheme.strokes.listDivider)
+            ) {
+                Row(
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .height(64.dp)
+                        .padding(horizontal = GovUkTheme.spacing.large),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    TextButton(
+                        onClick = { /* TODO */ }
+                    ) {
+                        BodyRegularLabel(
+                            text = selectText,
+                            color = GovUkTheme.colourScheme.textAndIcons.link,
+                            textAlign = TextAlign.Start
+                        )
+                    }
+                    TextButton(
+                        onClick =  { /* TODO */ },
+                    ) {
+                        BodyRegularLabel(
+                            text = removeText,
+                            color = GovUkTheme.colourScheme.textAndIcons.buttonRemove,
+                            textAlign = TextAlign.End
+                        )
+                    }
+                }
+            }
+        }
+    ) { innerPadding ->
+        Column (
+            modifier = modifier.padding(innerPadding)
+                .fillMaxWidth()
+                .height(64.dp)
+                .background(GovUkTheme.colourScheme.surfaces.background),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // TODO: Add real content
+            BodyRegularLabel(
+                text = "Coming soon!",
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EditVisitedScreenPreview() {
+    GovUkTheme {
+        EditVisitedScreen(
+            onBack = {},
+            modifier = Modifier
+        )
+    }
+}

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -1,40 +1,57 @@
 package uk.govuk.app.visited.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import uk.govuk.app.design.ui.component.BodyRegularLabel
+import uk.govuk.app.design.ui.component.ExternalLinkListItem
+import uk.govuk.app.design.ui.component.LargeVerticalSpacer
+import uk.govuk.app.design.ui.component.ListHeadingLabel
+import uk.govuk.app.design.ui.component.SmallVerticalSpacer
 import uk.govuk.app.design.ui.component.Title2BoldLabel
 import uk.govuk.app.design.ui.theme.GovUkTheme
 import uk.govuk.app.visited.R
+import uk.govuk.app.visited.VisitedUiState
+import uk.govuk.app.visited.VisitedViewModel
 
 @Composable
 internal fun EditVisitedRoute(
     onBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val viewModel: VisitedViewModel = hiltViewModel()
+    val uiState by viewModel.uiState.collectAsState()
+
     EditVisitedScreen(
+        uiState = uiState,
+        onEditPageView = { viewModel.onEditPageView() },
         onBack = onBack,
         modifier = modifier
     )
@@ -43,96 +60,156 @@ internal fun EditVisitedRoute(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun EditVisitedScreen(
+    uiState: VisitedUiState?,
+    onEditPageView: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    LaunchedEffect(Unit) {
+        onEditPageView()
+    }
+
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
 
-    val title = stringResource(R.string.visited_items_title)
+    val visitedItems = uiState?.visited
+    val titleText = stringResource(R.string.visited_items_title)
     val doneText = stringResource(R.string.visited_items_done_button)
     val selectText = stringResource(R.string.visited_items_select_all_button)
     val removeText = stringResource(R.string.visited_items_remove_button)
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        containerColor = GovUkTheme.colourScheme.surfaces.background,
+        modifier = modifier
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+            .fillMaxWidth(),
 
         topBar = {
-            CenterAlignedTopAppBar(
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = GovUkTheme.colourScheme.surfaces.background,
-                    titleContentColor = GovUkTheme.colourScheme.textAndIcons.primary,
-                ),
-                title = {
-                    Title2BoldLabel(
-                        title,
-                    )
-                },
-                actions = {
-                    TextButton(
-                        onClick = onBack,
-                        modifier = Modifier.wrapContentSize()
-                    ) {
-                        BodyRegularLabel(
-                            text = doneText,
-                            color = GovUkTheme.colourScheme.textAndIcons.link,
-                            textAlign = TextAlign.End
-                        )
-                    }
-                },
-                scrollBehavior = scrollBehavior,
-            )
+            TopNavBar(title = titleText, onBack = onBack, modifier = modifier, scrollBehavior = scrollBehavior, doneText = doneText)
         },
         bottomBar = {
-            NavigationBar(
-                containerColor = GovUkTheme.colourScheme.surfaces.background,
-                contentColor = GovUkTheme.colourScheme.textAndIcons.primary,
-                modifier = modifier.fillMaxWidth()
-                    .height(81.dp)
-                    .border(width = 1.dp, color = GovUkTheme.colourScheme.strokes.listDivider)
-            ) {
-                Row(
-                    modifier = modifier
-                        .fillMaxWidth()
-                        .height(64.dp)
-                        .padding(horizontal = GovUkTheme.spacing.large),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    TextButton(
-                        onClick = { /* TODO */ }
-                    ) {
-                        BodyRegularLabel(
-                            text = selectText,
-                            color = GovUkTheme.colourScheme.textAndIcons.link,
-                            textAlign = TextAlign.Start
-                        )
-                    }
-                    TextButton(
-                        onClick =  { /* TODO */ },
-                    ) {
-                        BodyRegularLabel(
-                            text = removeText,
-                            color = GovUkTheme.colourScheme.textAndIcons.buttonRemove,
-                            textAlign = TextAlign.End
-                        )
+            BottomNavBar(modifier = modifier, selectText = selectText, removeText = removeText)
+        }
+    ) { innerPadding ->
+        LazyColumn (
+            modifier = modifier
+                .padding(innerPadding)
+                .padding(horizontal = GovUkTheme.spacing.medium)
+                .fillMaxWidth()
+                .background(GovUkTheme.colourScheme.surfaces.background)
+        ) {
+            item {
+                if (visitedItems != null) {
+                    val lastVisitedText = stringResource(R.string.visited_items_last_visited)
+
+                    visitedItems.forEach { (sectionTitle, visitedItems) ->
+                        if (visitedItems.isNotEmpty()) {
+                            ListHeadingLabel(sectionTitle)
+                            SmallVerticalSpacer()
+
+                            visitedItems.forEachIndexed { index, item ->
+                                val title = item.title
+                                val lastVisited = item.lastVisited
+                                val url = item.url
+
+                                // TODO:
+                                //     - Add Checkbox to select items
+                                //     - Add Select all and Remove handlers
+                                //     - Remove alt text from title and 'Open in browser' icon
+                                ExternalLinkListItem(
+                                    title = title,
+                                    onClick = { /* Do nothing */ },
+                                    isFirst = index == 0,
+                                    isLast = index == visitedItems.size - 1,
+                                    subText = "$lastVisitedText $lastVisited"
+                                )
+                            }
+
+                            LargeVerticalSpacer()
+                        }
                     }
                 }
             }
         }
-    ) { innerPadding ->
-        Column (
-            modifier = modifier.padding(innerPadding)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TopNavBar(title: String, onBack: () -> Unit, modifier : Modifier = Modifier, scrollBehavior: TopAppBarScrollBehavior, doneText: String) {
+    CenterAlignedTopAppBar(
+        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+            containerColor = GovUkTheme.colourScheme.surfaces.background,
+            scrolledContainerColor = GovUkTheme.colourScheme.surfaces.background,
+            titleContentColor = GovUkTheme.colourScheme.textAndIcons.primary,
+        ),
+        title = {
+            Title2BoldLabel(
+                title,
+            )
+        },
+        actions = {
+            TextButton(
+                onClick = onBack,
+                modifier = Modifier.wrapContentSize()
+            ) {
+                BodyRegularLabel(
+                    text = doneText,
+                    color = GovUkTheme.colourScheme.textAndIcons.link,
+                    textAlign = TextAlign.End
+                )
+            }
+        },
+        scrollBehavior = scrollBehavior,
+    )
+}
+
+@Composable
+private fun BottomNavBar(modifier : Modifier = Modifier, selectText: String, removeText: String) {
+    val borderColor = GovUkTheme.colourScheme.strokes.listDivider
+
+    NavigationBar(
+        containerColor = GovUkTheme.colourScheme.surfaces.background,
+        contentColor = GovUkTheme.colourScheme.textAndIcons.primary,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(81.dp)
+            .drawBehind {
+                val borderSize = 1.dp
+                val topEdge = 0f
+                drawLine(
+                    color = borderColor,
+                    start = Offset(0f, topEdge),
+                    end = Offset(size.width, topEdge),
+                    strokeWidth = borderSize.toPx()
+                )
+            }
+    ) {
+        Row(
+            modifier = modifier
                 .fillMaxWidth()
                 .height(64.dp)
-                .background(GovUkTheme.colourScheme.surfaces.background),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+                .padding(horizontal = GovUkTheme.spacing.large),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            // TODO: Add real content
-            BodyRegularLabel(
-                text = "Coming soon!",
-                textAlign = TextAlign.Center
-            )
+            TextButton(
+                onClick = { /* TODO */ }
+            ) {
+                BodyRegularLabel(
+                    text = selectText,
+                    color = GovUkTheme.colourScheme.textAndIcons.link,
+                    textAlign = TextAlign.Start
+                )
+            }
+            TextButton(
+                onClick = { /* TODO */ },
+            ) {
+                BodyRegularLabel(
+                    text = removeText,
+                    color = GovUkTheme.colourScheme.textAndIcons.buttonRemove,
+                    textAlign = TextAlign.End
+                )
+            }
         }
     }
 }
@@ -142,6 +219,8 @@ private fun EditVisitedScreen(
 private fun EditVisitedScreenPreview() {
     GovUkTheme {
         EditVisitedScreen(
+            uiState = VisitedUiState(visited = emptyMap()),
+            onEditPageView = {},
             onBack = {},
             modifier = Modifier
         )

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -2,6 +2,7 @@ package uk.govuk.app.visited.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -9,7 +10,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TextButton
@@ -25,21 +29,25 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.govuk.app.design.ui.component.BodyRegularLabel
-import uk.govuk.app.design.ui.component.ExternalLinkListItem
+import uk.govuk.app.design.ui.component.CardListItem
 import uk.govuk.app.design.ui.component.LargeVerticalSpacer
 import uk.govuk.app.design.ui.component.ListHeadingLabel
+import uk.govuk.app.design.ui.component.MediumHorizontalSpacer
 import uk.govuk.app.design.ui.component.SmallVerticalSpacer
+import uk.govuk.app.design.ui.component.SubheadlineRegularLabel
 import uk.govuk.app.design.ui.component.Title2BoldLabel
 import uk.govuk.app.design.ui.theme.GovUkTheme
 import uk.govuk.app.visited.R
 import uk.govuk.app.visited.VisitedUiState
 import uk.govuk.app.visited.VisitedViewModel
+import kotlin.random.Random
 
 @Composable
 internal fun EditVisitedRoute(
@@ -84,10 +92,20 @@ private fun EditVisitedScreen(
             .fillMaxWidth(),
 
         topBar = {
-            TopNavBar(title = titleText, onBack = onBack, modifier = modifier, scrollBehavior = scrollBehavior, doneText = doneText)
+            TopNavBar(
+                title = titleText,
+                doneText = doneText,
+                onBack = onBack,
+                scrollBehavior = scrollBehavior,
+                modifier = modifier
+            )
         },
         bottomBar = {
-            BottomNavBar(modifier = modifier, selectText = selectText, removeText = removeText)
+            BottomNavBar(
+                selectText = selectText,
+                removeText = removeText,
+                modifier = modifier
+            )
         }
     ) { innerPadding ->
         LazyColumn (
@@ -112,15 +130,15 @@ private fun EditVisitedScreen(
                                 val url = item.url
 
                                 // TODO:
-                                //     - Add Checkbox to select items
                                 //     - Add Select all and Remove handlers
-                                //     - Remove alt text from title and 'Open in browser' icon
-                                ExternalLinkListItem(
+                                //     - Handle select/deselect
+                                //     - Add tests
+                                CheckableExternalLinkListItem(
                                     title = title,
-                                    onClick = { /* Do nothing */ },
+                                    subText = "$lastVisitedText $lastVisited",
                                     isFirst = index == 0,
                                     isLast = index == visitedItems.size - 1,
-                                    subText = "$lastVisitedText $lastVisited"
+                                    modifier = modifier
                                 )
                             }
 
@@ -133,9 +151,90 @@ private fun EditVisitedScreen(
     }
 }
 
+@Composable
+private fun CheckableExternalLinkListItem(
+    title: String,
+    subText: String,
+    isFirst: Boolean,
+    isLast: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    CardListItem(
+        modifier = modifier,
+        onClick = { /* Do nothing */ },
+        isFirst = isFirst,
+        isLast = isLast
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier.padding(0.dp),
+            ) {
+                Checkbox(
+                    checked = Random.nextBoolean(),
+                    onCheckedChange = { /* checked = it */ },
+                    colors = CheckboxDefaults.colors(
+                        checkedColor = GovUkTheme.colourScheme.surfaces.primary,
+                        uncheckedColor = GovUkTheme.colourScheme.strokes.buttonCompactBorder,
+                        checkmarkColor = GovUkTheme.colourScheme.textAndIcons.selectedTick,
+                    )
+                )
+            }
+
+            Column(
+                modifier = Modifier.padding(0.dp),
+            ) {
+                Row(
+                    modifier = Modifier.padding(
+                        top = GovUkTheme.spacing.medium,
+                        start = GovUkTheme.spacing.medium,
+                        end = GovUkTheme.spacing.medium,
+                        bottom = 0.dp
+                    )
+                ) {
+                    BodyRegularLabel(
+                        text = title,
+                        modifier = Modifier.weight(1f),
+                        color = GovUkTheme.colourScheme.textAndIcons.link
+                    )
+
+                    MediumHorizontalSpacer()
+
+                    Icon(
+                        painter = painterResource(uk.govuk.app.design.R.drawable.ic_external_link),
+                        contentDescription = "",
+                        tint = GovUkTheme.colourScheme.textAndIcons.link
+                    )
+                }
+
+                Row(
+                    modifier = Modifier.padding(
+                        start = GovUkTheme.spacing.medium,
+                        top = 0.dp,
+                        bottom = GovUkTheme.spacing.medium
+                    ),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    SubheadlineRegularLabel(
+                        text = subText,
+                        color = GovUkTheme.colourScheme.textAndIcons.primary
+                    )
+                }
+            }
+        }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun TopNavBar(title: String, onBack: () -> Unit, modifier : Modifier = Modifier, scrollBehavior: TopAppBarScrollBehavior, doneText: String) {
+private fun TopNavBar(
+    title: String,
+    doneText: String,
+    onBack: () -> Unit,
+    scrollBehavior: TopAppBarScrollBehavior,
+    modifier : Modifier = Modifier,
+) {
     CenterAlignedTopAppBar(
         colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
             containerColor = GovUkTheme.colourScheme.surfaces.background,
@@ -150,7 +249,7 @@ private fun TopNavBar(title: String, onBack: () -> Unit, modifier : Modifier = M
         actions = {
             TextButton(
                 onClick = onBack,
-                modifier = Modifier.wrapContentSize()
+                modifier = modifier.wrapContentSize()
             ) {
                 BodyRegularLabel(
                     text = doneText,
@@ -164,7 +263,11 @@ private fun TopNavBar(title: String, onBack: () -> Unit, modifier : Modifier = M
 }
 
 @Composable
-private fun BottomNavBar(modifier : Modifier = Modifier, selectText: String, removeText: String) {
+private fun BottomNavBar(
+    selectText: String,
+    removeText: String,
+    modifier : Modifier = Modifier
+) {
     val borderColor = GovUkTheme.colourScheme.strokes.listDivider
 
     NavigationBar(

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -24,6 +24,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -47,7 +50,6 @@ import uk.govuk.app.design.ui.theme.GovUkTheme
 import uk.govuk.app.visited.R
 import uk.govuk.app.visited.VisitedUiState
 import uk.govuk.app.visited.VisitedViewModel
-import kotlin.random.Random
 
 @Composable
 internal fun EditVisitedRoute(
@@ -129,12 +131,9 @@ private fun EditVisitedScreen(
                                 val lastVisited = item.lastVisited
                                 val url = item.url
 
-                                // TODO:
-                                //     - Add Select all and Remove handlers
-                                //     - Handle select/deselect
-                                //     - Add tests
                                 CheckableExternalLinkListItem(
                                     title = title,
+                                    url = url,
                                     subText = "$lastVisitedText $lastVisited",
                                     isFirst = index == 0,
                                     isLast = index == visitedItems.size - 1,
@@ -154,11 +153,14 @@ private fun EditVisitedScreen(
 @Composable
 private fun CheckableExternalLinkListItem(
     title: String,
+    url: String,
     subText: String,
     isFirst: Boolean,
     isLast: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    var checked by remember { mutableStateOf(false) }
+
     CardListItem(
         modifier = modifier,
         onClick = { /* Do nothing */ },
@@ -172,8 +174,16 @@ private fun CheckableExternalLinkListItem(
                 modifier = Modifier.padding(0.dp),
             ) {
                 Checkbox(
-                    checked = Random.nextBoolean(),
-                    onCheckedChange = { /* checked = it */ },
+                    checked = checked,
+                    onCheckedChange = {
+                        checked = it
+
+                        if (checked) {
+                            println("Adding : $title [$url]")
+                        } else {
+                            println("Removing : $title [$url]")
+                        }
+                    },
                     colors = CheckboxDefaults.colors(
                         checkedColor = GovUkTheme.colourScheme.surfaces.primary,
                         uncheckedColor = GovUkTheme.colourScheme.strokes.buttonCompactBorder,

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -175,15 +175,7 @@ private fun CheckableExternalLinkListItem(
             ) {
                 Checkbox(
                     checked = checked,
-                    onCheckedChange = {
-                        checked = it
-
-                        if (checked) {
-                            println("Adding : $title [$url]")
-                        } else {
-                            println("Removing : $title [$url]")
-                        }
-                    },
+                    onCheckedChange = { checked = it },
                     colors = CheckboxDefaults.colors(
                         checkedColor = GovUkTheme.colourScheme.surfaces.primary,
                         uncheckedColor = GovUkTheme.colourScheme.strokes.buttonCompactBorder,

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -118,25 +118,21 @@ private fun EditVisitedScreen(
                 .background(GovUkTheme.colourScheme.surfaces.background)
         ) {
             item {
-                if (visitedItems != null) {
+                visitedItems?.let { items ->
                     val lastVisitedText = stringResource(R.string.visited_items_last_visited)
 
-                    visitedItems.forEach { (sectionTitle, visitedItems) ->
-                        if (visitedItems.isNotEmpty()) {
+                    items.forEach { (sectionTitle, sectionItems) ->
+                        sectionItems.takeIf { it.isNotEmpty() }?.let { items ->
                             ListHeadingLabel(sectionTitle)
                             SmallVerticalSpacer()
 
-                            visitedItems.forEachIndexed { index, item ->
-                                val title = item.title
-                                val lastVisited = item.lastVisited
-                                val url = item.url
-
+                            items.forEachIndexed { index, (title, lastVisited, url) ->
                                 CheckableExternalLinkListItem(
                                     title = title,
                                     url = url,
                                     subText = "$lastVisitedText $lastVisited",
                                     isFirst = index == 0,
-                                    isLast = index == visitedItems.size - 1,
+                                    isLast = index == items.size - 1,
                                     modifier = modifier
                                 )
                             }

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -110,7 +110,7 @@ private fun EditVisitedScreen(
             )
         }
     ) { innerPadding ->
-        LazyColumn (
+        LazyColumn(
             modifier = modifier
                 .padding(innerPadding)
                 .padding(horizontal = GovUkTheme.spacing.medium)
@@ -231,7 +231,7 @@ private fun TopNavBar(
     doneText: String,
     onBack: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
-    modifier : Modifier = Modifier,
+    modifier: Modifier = Modifier,
 ) {
     CenterAlignedTopAppBar(
         colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
@@ -264,7 +264,7 @@ private fun TopNavBar(
 private fun BottomNavBar(
     selectText: String,
     removeText: String,
-    modifier : Modifier = Modifier
+    modifier: Modifier = Modifier
 ) {
     val borderColor = GovUkTheme.colourScheme.strokes.listDivider
 

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -80,6 +80,7 @@ private fun VisitedScreen(
 
     val title = stringResource(R.string.visited_items_title)
     val editText = stringResource(R.string.visited_items_edit_button)
+    val visitedItems = uiState?.visited
 
     Column(modifier) {
         val visitedItems = uiState?.visited

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -119,10 +119,15 @@ private fun VisitedScreen(
                 text = title,
                 modifier = modifier
                     .fillMaxWidth()
+                    .height(47.dp)
                     .padding(horizontal = GovUkTheme.spacing.medium)
+                    .padding(bottom = GovUkTheme.spacing.small)
             )
         }
-        LazyColumn(Modifier.padding(horizontal = GovUkTheme.spacing.medium)) {
+        LazyColumn(
+            Modifier.padding(horizontal = GovUkTheme.spacing.medium)
+                .padding(top = GovUkTheme.spacing.small)
+        ) {
             item {
                 if (visitedItems != null) {
                     if (visitedItems.isEmpty()) {

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -4,9 +4,16 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -16,12 +23,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
 import uk.govuk.app.design.ui.component.BodyBoldLabel
 import uk.govuk.app.design.ui.component.BodyRegularLabel
-import uk.govuk.app.design.ui.component.ChildPageHeader
 import uk.govuk.app.design.ui.component.ExternalLinkListItem
 import uk.govuk.app.design.ui.component.ExtraLargeVerticalSpacer
+import uk.govuk.app.design.ui.component.LargeTitleBoldLabel
 import uk.govuk.app.design.ui.component.LargeVerticalSpacer
 import uk.govuk.app.design.ui.component.ListHeadingLabel
 import uk.govuk.app.design.ui.component.SmallVerticalSpacer
@@ -29,10 +38,12 @@ import uk.govuk.app.design.ui.theme.GovUkTheme
 import uk.govuk.app.visited.R
 import uk.govuk.app.visited.VisitedUiState
 import uk.govuk.app.visited.VisitedViewModel
+import uk.govuk.app.visited.navigation.navigateToEditVisited
 import uk.govuk.app.visited.ui.model.VisitedUi
 
 @Composable
 internal fun VisitedRoute(
+    navController: NavController,
     onBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -46,6 +57,9 @@ internal fun VisitedRoute(
         onClick = { title, url ->
             viewModel.onVisitedItemClicked(title, url)
         },
+        onEditClick = {
+            navController.navigateToEditVisited()
+        },
         modifier = modifier
     )
 }
@@ -57,6 +71,7 @@ private fun VisitedScreen(
     onPageView: () -> Unit,
     onBack: () -> Unit,
     onClick: (title: String, url: String) -> Unit,
+    onEditClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     LaunchedEffect(Unit) {
@@ -64,15 +79,51 @@ private fun VisitedScreen(
     }
 
     val title = stringResource(R.string.visited_items_title)
+    val editText = stringResource(R.string.visited_items_edit_button)
 
     Column(modifier) {
-        ChildPageHeader(
-            text = title,
-            onBack = onBack
-        )
+        val visitedItems = uiState?.visited
+
+        Column(modifier) {
+            Row(
+                modifier = Modifier.height(64.dp)
+                    .fillMaxWidth()
+                    .padding(end = GovUkTheme.spacing.small),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(
+                    onClick = onBack,
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(uk.govuk.app.design.R.string.content_desc_back),
+                        tint = GovUkTheme.colourScheme.textAndIcons.link
+                    )
+                }
+
+                if (!visitedItems.isNullOrEmpty()) {
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    TextButton(
+                        onClick = onEditClick,
+                        modifier = Modifier.padding(end = GovUkTheme.spacing.small)
+                    ) {
+                        BodyRegularLabel(
+                            text = editText,
+                            color = GovUkTheme.colourScheme.textAndIcons.link,
+                        )
+                    }
+                }
+            }
+            LargeTitleBoldLabel(
+                text = title,
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = GovUkTheme.spacing.medium)
+            )
+        }
         LazyColumn(Modifier.padding(horizontal = GovUkTheme.spacing.medium)) {
             item {
-                val visitedItems = uiState?.visited
                 if (visitedItems != null) {
                     if (visitedItems.isEmpty()) {
                         NoVisitedItems(modifier)

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -83,11 +83,10 @@ private fun VisitedScreen(
     val visitedItems = uiState?.visited
 
     Column(modifier) {
-        val visitedItems = uiState?.visited
-
         Column(modifier) {
             Row(
-                modifier = Modifier.height(64.dp)
+                modifier = Modifier
+                    .height(64.dp)
                     .fillMaxWidth()
                     .padding(end = GovUkTheme.spacing.small),
                 verticalAlignment = Alignment.CenterVertically,
@@ -126,7 +125,8 @@ private fun VisitedScreen(
             )
         }
         LazyColumn(
-            Modifier.padding(horizontal = GovUkTheme.spacing.medium)
+            Modifier
+                .padding(horizontal = GovUkTheme.spacing.medium)
                 .padding(top = GovUkTheme.spacing.small)
         ) {
             item {
@@ -145,7 +145,8 @@ private fun NoVisitedItems(
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier.padding(GovUkTheme.spacing.medium)
+        modifier
+            .padding(GovUkTheme.spacing.medium)
             .fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -129,12 +129,10 @@ private fun VisitedScreen(
                 .padding(top = GovUkTheme.spacing.small)
         ) {
             item {
-                if (visitedItems != null) {
-                    if (visitedItems.isEmpty()) {
-                        NoVisitedItems(modifier)
-                    } else {
-                        ShowVisitedItems(visitedItems, onClick)
-                    }
+                if (visitedItems.isNullOrEmpty()) {
+                    NoVisitedItems(modifier)
+                } else {
+                    ShowVisitedItems(visitedItems, onClick)
                 }
             }
         }

--- a/feature/visited/src/main/res/values/strings.xml
+++ b/feature/visited/src/main/res/values/strings.xml
@@ -5,4 +5,9 @@
   <string name="visited_items_no_pages_description">You haven\'t used the app to visit any GOV.UK pages yet</string>
 
   <string name="visited_items_last_visited">Last visited on</string>
+
+  <string name="visited_items_edit_button">Edit</string>
+  <string name="visited_items_done_button">Done</string>
+  <string name="visited_items_select_all_button">Select all</string>
+  <string name="visited_items_remove_button">Remove</string>
 </resources>

--- a/feature/visited/src/test/kotlin/uk/govuk/app/visited/VisitedViewModelTest.kt
+++ b/feature/visited/src/test/kotlin/uk/govuk/app/visited/VisitedViewModelTest.kt
@@ -57,6 +57,21 @@ class VisitedViewModelTest {
     }
 
     @Test
+    fun `Given an edit page view, then log analytics`() {
+        val viewModel = VisitedViewModel(visitedRepo, visited, analytics)
+
+        viewModel.onEditPageView()
+
+        verify {
+            analytics.screenView(
+                screenClass = "EditVisitedScreen",
+                screenName = "Pages you've visited",
+                title = "Pages you've visited"
+            )
+        }
+    }
+
+    @Test
     fun `Given the user re-views a visited item, then run the insert or update function`() {
         val viewModel = VisitedViewModel(visitedRepo, visited, analytics)
 


### PR DESCRIPTION
# Android | Visited items: Create edit mode

This change adds the edit screen for visited items. 

It also fixes a padding issue [identified here](https://govukverify.atlassian.net/browse/GOVUKAPP-645) on the view screen.

## Note 🎵 

Visited items on the edit screen retain  the link colouration for the title and `open in...` icon from the view screen. However, the link is no longer clickable and the alt text for the icon has been removed. This is in-line with the iOS implementation.

This change does not address:

- Removing visited items from the Realm database
- Selecting and deselecting all visited items
- Removing all visited items
- The `Select all` and `Remove` button logic 

All of the above will be addressed in [this ticket](https://govukverify.atlassian.net/browse/GOVUKAPP-652).

## JIRA ticket(s)
  - [GOVAPP-651](https://govukverify.atlassian.net/browse/GOVUKAPP-651)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-83650&node-type=canvas&t=2TPX3uBvnxrgiSto-0)

## Screenshots

| Light | Dark |
| --- | --- |
| ![after-light-view](https://github.com/user-attachments/assets/cd710458-7aac-4d1e-acfd-353a577e014f) | ![after-dark-view](https://github.com/user-attachments/assets/f40ddcf1-6228-4361-8152-3271ec245ccb) |
| ![after-light-edit](https://github.com/user-attachments/assets/6e2a8938-c331-43aa-85c6-fad59fb8941d) | ![after-dark-edit](https://github.com/user-attachments/assets/e199e92f-7fbb-44b8-b325-7e08f905851d) |
