### PR TITLE
Visited items minor content fixups

### DIFF
--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/SectionTitles.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/SectionTitles.kt
@@ -2,5 +2,5 @@ package uk.govuk.app.visited
 
 data class SectionTitles(
     val today: String = "Today",
-    val thisMonth: String = "This Month",
+    val thisMonth: String = "This month",
 )

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/data/DateFormatter.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/data/DateFormatter.kt
@@ -5,7 +5,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 fun localDateFormatter(millis: Long): String {
-    val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd LLLL yyyy")
+    val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d LLLL")
     return LocalDateTime.ofEpochSecond(millis, 0, ZoneOffset.UTC).format(formatter)
 }
 

--- a/feature/visited/src/test/kotlin/uk/govuk/app/visited/data/DateFormatterTest.kt
+++ b/feature/visited/src/test/kotlin/uk/govuk/app/visited/data/DateFormatterTest.kt
@@ -11,7 +11,17 @@ class DateFormatterTest {
         val dayInMillis = LocalDateTime.of(2023, 10, 15, 0, 0, 0).toEpochSecond(ZoneOffset.UTC)
 
         val actual = localDateFormatter(dayInMillis)
-        val expected = "15 October 2023"
+        val expected = "15 October"
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Given a date in epoch days, then you get back a formatted date string - with the day minus leading zero`() {
+        val dayInMillis = LocalDateTime.of(2023, 10, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC)
+
+        val actual = localDateFormatter(dayInMillis)
+        val expected = "1 October"
 
         assertEquals(expected, actual)
     }


### PR DESCRIPTION
Visited items: minor context fixes:

- Don't capitalise the word `month` in `This month`
- Remove `year` from dates
- Change day of month from 2 digits to 1 or 2, so `1 October` not `01 October`