### PR TITLE
GOVUKAPP-590 Global ON/OFF switch - Post Amigos fix

### DIFF
--- a/design/src/main/kotlin/uk/govuk/app/design/ui/component/Button.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/component/Button.kt
@@ -210,7 +210,7 @@ private fun BaseButton(
             style = textStyle,
             modifier = Modifier.semantics {
                 contentDescription = altText
-            }
+            }.weight(1f, fill = false)
         )
         if (externalLink) ExternalLinkIcon()
     }


### PR DESCRIPTION
# Description
It was observed in Post Amigos that when large text size is set that a button text with external link icon causes the link icon to resize very small.
Added a weight modifier to button text to resolve this.

### Before

| Light Mode | Dark Mode |
|---|---|
| ![image](https://github.com/user-attachments/assets/49cb333e-9530-499b-aa42-208eaf79eeb0) | ![image](https://github.com/user-attachments/assets/a89a001d-4e23-4d80-a1b4-40ceffe2c4a7) |

### After

| Light Mode | Dark Mode |
|---|---|
| ![image](https://github.com/user-attachments/assets/1f1e3729-8a75-4e21-98fc-7c1296482253) | ![image](https://github.com/user-attachments/assets/4f2b7bbc-614a-4475-954b-f61eb0d76470) |
