### PR TITLE
GOVUKAPP-961 Onboarding slides off-centre

### DIFF
--- a/feature/onboarding/src/main/kotlin/uk/govuk/app/onboarding/ui/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/uk/govuk/app/onboarding/ui/OnboardingScreen.kt
@@ -154,22 +154,35 @@ private fun Page(
         modifier = modifier
             .verticalScroll(rememberScrollState())
             .fillMaxWidth()
-            .padding(top = GovUkTheme.spacing.extraLarge)
-            .padding(horizontal = GovUkTheme.spacing.extraLarge),
-        horizontalAlignment = Alignment.CenterHorizontally,
+            .padding(top = GovUkTheme.spacing.extraLarge),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         if (windowSizeClass.windowHeightSizeClass != WindowHeightSizeClass.COMPACT) {
             Image(
                 painter = painterResource(id = page.image),
-                contentDescription = null
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(horizontal = GovUkTheme.spacing.extraLarge)
             )
 
             ExtraLargeVerticalSpacer()
         }
 
-        LargeTitleBoldLabel(stringResource(page.title), modifier = Modifier.focusable(), textAlign = TextAlign.Center)
+        LargeTitleBoldLabel(
+            stringResource(page.title),
+            modifier = Modifier
+                .focusable()
+                .padding(horizontal = GovUkTheme.spacing.extraLarge),
+            textAlign = TextAlign.Center
+        )
         MediumVerticalSpacer()
-        BodyRegularLabel(stringResource(page.body), modifier = Modifier.focusable(), textAlign = TextAlign.Center)
+        BodyRegularLabel(
+            stringResource(page.body),
+            modifier = Modifier
+                .focusable()
+                .padding(horizontal = GovUkTheme.spacing.extraLarge),
+            textAlign = TextAlign.Center
+        )
     }
 }
 


### PR DESCRIPTION
# Title
Bug: Onboarding slides off-centre.

# Description
When navigating Onboarding slides using a keyboard the text and image becomes off-centre.

# Resolution
Set horizontal padding on the columns children rather than the column.

## JIRA ticket(s)
  - [GOVAPP-961](https://govukverify.atlassian.net/browse/GOVUKAPP-961)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-53780&node-type=canvas&t=OsppmOx5g6akleui-0)

### Before

| Light Mode | Dark Mode |
|---|---|
| ![Screenshot_1732283706](https://github.com/user-attachments/assets/dd9be54b-6830-4692-8b4f-303779e533a5) | ![image](https://github.com/user-attachments/assets/eb6221f2-1452-4a2e-a707-7548d93f3388) |

### After

| Light Mode | Dark Mode |
|---|---|
| ![image](https://github.com/user-attachments/assets/9b7ca7eb-82e2-4dca-a29c-c01d0de5208a) | ![image](https://github.com/user-attachments/assets/cd882213-c9f8-4ce3-8e43-02113fa83754) |
