### PR TITLE
Post amigo edit visited item changes

### DIFF
--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -34,7 +33,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -44,7 +42,6 @@ import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.CardListItem
 import uk.govuk.app.design.ui.component.LargeVerticalSpacer
 import uk.govuk.app.design.ui.component.ListHeadingLabel
-import uk.govuk.app.design.ui.component.MediumHorizontalSpacer
 import uk.govuk.app.design.ui.component.SmallVerticalSpacer
 import uk.govuk.app.design.ui.component.SubheadlineRegularLabel
 import uk.govuk.app.design.ui.component.Title2BoldLabel
@@ -221,14 +218,6 @@ private fun CheckableExternalLinkListItem(
                         text = item.title,
                         modifier = Modifier.weight(1f),
                         color = GovUkTheme.colourScheme.textAndIcons.link
-                    )
-
-                    MediumHorizontalSpacer()
-
-                    Icon(
-                        painter = painterResource(uk.govuk.app.design.R.drawable.ic_external_link),
-                        contentDescription = "",
-                        tint = GovUkTheme.colourScheme.textAndIcons.link
                     )
                 }
 

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -1,6 +1,5 @@
 package uk.govuk.app.visited.ui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -19,7 +17,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,11 +37,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.CardListItem
+import uk.govuk.app.design.ui.component.LargeTitleBoldLabel
 import uk.govuk.app.design.ui.component.LargeVerticalSpacer
 import uk.govuk.app.design.ui.component.ListHeadingLabel
 import uk.govuk.app.design.ui.component.SmallVerticalSpacer
 import uk.govuk.app.design.ui.component.SubheadlineRegularLabel
-import uk.govuk.app.design.ui.component.Title2BoldLabel
 import uk.govuk.app.design.ui.theme.GovUkTheme
 import uk.govuk.app.visited.R
 import uk.govuk.app.visited.VisitedUiState
@@ -116,10 +113,8 @@ private fun EditVisitedScreen(
 
         topBar = {
             TopNavBar(
-                title = titleText,
                 doneText = doneText,
                 onBack = onBack,
-                scrollBehavior = scrollBehavior,
                 modifier = modifier
             )
         },
@@ -137,9 +132,21 @@ private fun EditVisitedScreen(
             modifier = modifier
                 .padding(innerPadding)
                 .padding(horizontal = GovUkTheme.spacing.medium)
+                .padding(top = GovUkTheme.spacing.small)
                 .fillMaxWidth()
-                .background(GovUkTheme.colourScheme.surfaces.background)
         ) {
+            item {
+                LargeTitleBoldLabel(
+                    text = titleText,
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .wrapContentSize()
+                        .padding(horizontal = GovUkTheme.spacing.medium)
+                        .padding(bottom = GovUkTheme.spacing.small),
+                    textAlign = TextAlign.Start
+                )
+            }
+
             item {
                 visitedItems?.let { items ->
                     val lastVisitedText = stringResource(R.string.visited_items_last_visited)
@@ -239,29 +246,23 @@ private fun CheckableExternalLinkListItem(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun TopNavBar(
-    title: String,
     doneText: String,
     onBack: () -> Unit,
-    scrollBehavior: TopAppBarScrollBehavior,
     modifier: Modifier = Modifier,
 ) {
     var isDoneButtonEnabled by remember { mutableStateOf(true) }
 
-    CenterAlignedTopAppBar(
-        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-            containerColor = GovUkTheme.colourScheme.surfaces.background,
-            scrolledContainerColor = GovUkTheme.colourScheme.surfaces.background,
-            titleContentColor = GovUkTheme.colourScheme.textAndIcons.primary,
-        ),
-        title = {
-            Title2BoldLabel(
-                title,
-            )
-        },
-        actions = {
+    Column(modifier) {
+        Row(
+            modifier = Modifier
+                .height(64.dp)
+                .fillMaxWidth()
+                .padding(end = GovUkTheme.spacing.small),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.End
+        ) {
             TextButton(
                 onClick = {
                     isDoneButtonEnabled = false
@@ -276,9 +277,8 @@ private fun TopNavBar(
                     textAlign = TextAlign.End
                 )
             }
-        },
-        scrollBehavior = scrollBehavior,
-    )
+        }
+    }
 }
 
 @Composable

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -120,7 +121,7 @@ private fun VisitedScreen(
                 text = title,
                 modifier = modifier
                     .fillMaxWidth()
-                    .height(47.dp)
+                    .wrapContentSize()
                     .padding(horizontal = GovUkTheme.spacing.medium)
                     .padding(bottom = GovUkTheme.spacing.small)
             )

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -117,20 +117,24 @@ private fun VisitedScreen(
                     }
                 }
             }
-            LargeTitleBoldLabel(
-                text = title,
-                modifier = modifier
-                    .fillMaxWidth()
-                    .wrapContentSize()
-                    .padding(horizontal = GovUkTheme.spacing.medium)
-                    .padding(bottom = GovUkTheme.spacing.small)
-            )
         }
         LazyColumn(
             Modifier
                 .padding(horizontal = GovUkTheme.spacing.medium)
                 .padding(top = GovUkTheme.spacing.small)
         ) {
+
+            item {
+                LargeTitleBoldLabel(
+                    text = title,
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .wrapContentSize()
+                        .padding(horizontal = GovUkTheme.spacing.medium)
+                        .padding(bottom = GovUkTheme.spacing.small)
+                )
+            }
+
             item {
                 if (visitedItems.isNullOrEmpty()) {
                     NoVisitedItems(modifier)


### PR DESCRIPTION
# Post amigo edit visited item changes

Following discussions with Design (ER) where various options were presented, the chosen solution is to move the header into the scrolling part of the content - so that goes behind the header, and the header is centered. Both the list and edit `Pages you've visited` pages have been updated. The title text now performs as desired.

It was suggested that maintaining the `Opens in browser...` icons for each visited item be remove in the Edit view as clicking on a visited item in this view selects or deselects. It does not `Open in browser...`. 

## JIRA ticket(s)
  - [GOVAPP-646](https://govukverify.atlassian.net/browse/GOVUKAPP-646)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-84094&node-type=frame&t=yHDV5lKHdGAe4yF1-0)

## Screen shots - Header issue

### Before

🎶  In these screen shots the font size is at the max size (above 200%) and the display size is also at the max size.

| List | List - scrolled | Edit | Edit - scrolled |
|---|---|---|---|
| ![before-list-full-font-and-display](https://github.com/user-attachments/assets/ac7e04e8-4001-4e82-8801-77f3d0d283e2) | ![before-list-full-font-and-display-scrolled](https://github.com/user-attachments/assets/185cc0bc-ea4c-49e7-92ce-7d3ebbdd0310) | ![before-edit-full-font-and-display](https://github.com/user-attachments/assets/c09dcc85-c269-4d5d-851a-1dc5901e9ff8) | ![before-edit-full-font-and-display-scrolled](https://github.com/user-attachments/assets/79d6e0ae-94c5-4438-b7a7-98f53e2a036f) |


### After

| List | List - scrolled | Edit | Edit - scrolled |
|---|---|---|---|
| ![list-full-font-and-display](https://github.com/user-attachments/assets/01650895-1104-4dc2-bedc-c76d2b6cde69) | ![list-full-font-and-display-scrolled](https://github.com/user-attachments/assets/b3bf9cad-0778-4f51-8e80-1842a4cdcb6b) | ![edit-full-font-and-display](https://github.com/user-attachments/assets/567c4879-30b0-4b35-bf96-a3a401d221be) | ![edit-full-font-and-display-scrolled](https://github.com/user-attachments/assets/8180e940-6c1f-4bca-94e8-036ad0c71b86) |

## Screen shots - Remove `Opens in browser...` icons

| Before | After |
|---|---|
| ![icons-before](https://github.com/user-attachments/assets/28bdb3fa-8aeb-47ed-9932-43673ed01a6d) | ![icons-after](https://github.com/user-attachments/assets/febc717b-a99c-4e1c-a318-5a783d44fd81) |


