### PR TITLE
GOVUKAPP-993 - Capitalisation of months

### DIFF
--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/data/VisitedItemsTransformer.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/data/VisitedItemsTransformer.kt
@@ -21,7 +21,7 @@ fun transformVisitedItems(visitedItems: List<VisitedItemUi>, todaysDate: LocalDa
             it.toLocalDate().year != todaysDate.year
     }
 
-    fun VisitedItemUi.previousMonthKey() = "${toLocalDate().month.name} ${toLocalDate().year}"
+    fun VisitedItemUi.previousMonthKey() = "${capitaliseMonth(toLocalDate().month.name)} ${toLocalDate().year}"
     val groupedPreviousMonthsItems = previousMonthsItems.groupBy { it.previousMonthKey() }
 
     fun toVisitedUi(items: List<VisitedItemUi>): List<VisitedUi> = items.map {

--- a/feature/visited/src/test/kotlin/uk/govuk/app/visited/data/VisitedItemsTransformerTest.kt
+++ b/feature/visited/src/test/kotlin/uk/govuk/app/visited/data/VisitedItemsTransformerTest.kt
@@ -116,7 +116,7 @@ class VisitedItemsTransformerTest {
             )
         )
 
-        val items = transformVisitedItems(visitedItems, today.toLocalDate())["${lastMonth.month.name} ${lastMonth.year}"]
+        val items = transformVisitedItems(visitedItems, today.toLocalDate())["${capitaliseMonth(lastMonth.month.name)} ${lastMonth.year}"]
         val actual = items?.first() ?: throw Exception("Failed to transform visited items")
 
         val expected = listOf(
@@ -149,7 +149,7 @@ class VisitedItemsTransformerTest {
             )
         )
 
-        val items = transformVisitedItems(visitedItems, today.toLocalDate())["${lastMonth.month.name} ${lastMonth.year}"]
+        val items = transformVisitedItems(visitedItems, today.toLocalDate())["${capitaliseMonth(lastMonth.month.name)} ${lastMonth.year}"]
         val actual = items?.first() ?: throw Exception("Failed to transform visited items")
 
         val expected = listOf(


### PR DESCRIPTION
# GOVUKAPP-993 - Capitalisation of months

The call to the `capitaliseMonth` function in the VisitedItemsTransformer somehow got removed at some point - add it back in.

## JIRA ticket(s)
  - [GOVAPP-993](https://govukverify.atlassian.net/browse/GOVUKAPP-993)

## Screen shots 

🎶  Note the use of fake data here!

| Before | After |
|---|---|
| ![month-before](https://github.com/user-attachments/assets/75de6973-4868-4ed0-9256-a875c54e144b) | ![month-after](https://github.com/user-attachments/assets/8b2feef6-554a-4c4c-ad6b-45ee439fec89) |

