### PR TITLE
Bug fix - last visited item being hidden or obscured by the bottom nav bar

### DIFF
--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -32,7 +32,6 @@ import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.ExternalLinkListItem
 import uk.govuk.app.design.ui.component.ExtraLargeVerticalSpacer
 import uk.govuk.app.design.ui.component.LargeTitleBoldLabel
-import uk.govuk.app.design.ui.component.LargeVerticalSpacer
 import uk.govuk.app.design.ui.component.ListHeadingLabel
 import uk.govuk.app.design.ui.component.SmallVerticalSpacer
 import uk.govuk.app.design.ui.theme.GovUkTheme
@@ -142,6 +141,10 @@ private fun VisitedScreen(
                     ShowVisitedItems(visitedItems, onClick)
                 }
             }
+
+            item {
+                Spacer(modifier = Modifier.height(100.dp))
+            }
         }
     }
 }
@@ -200,8 +203,6 @@ private fun ShowVisitedItems(
                     subText = "$lastVisitedText $lastVisited"
                 )
             }
-
-            LargeVerticalSpacer()
         }
     }
 }


### PR DESCRIPTION
# Bug fix - last visited item being hidden or obscured by the bottom nav bar

The last visited item in the list is being hidden or obscured by the bottom nav bar. Increase spacing below last visited list item.

## Screen shots

| Before | After |
|---|---|
| ![pyv-list-before](https://github.com/user-attachments/assets/7da7f71c-3cec-4d24-ac2f-fd814511869c) | ![pyv-list-after](https://github.com/user-attachments/assets/fcd16ec4-befc-4b91-9055-465616e45c9a) |

