### PR TITLE
GOVUKAPP-1001: pages you've visited should ChildPageHeader

### DIFF
--- a/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
@@ -42,20 +42,16 @@ fun TabHeader(
     }
 }
 
-data class ActionButton(
-    val text: String? = null,
-    val onClick: () -> Unit
-)
-
 @Composable
 fun ChildPageHeader(
     modifier: Modifier = Modifier,
     text: String? = null,
-    backButton: ActionButton? = null,
-    actionButton: ActionButton? = null
+    onBack: (() -> Unit)?,
+    onAction: (() -> Unit)?,
+    actionText: String? = null
 ) {
     Column(modifier) {
-        if (backButton != null || actionButton != null) {
+        if (onBack != null || onAction != null) {
             Row(
                 modifier = Modifier
                     .height(64.dp)
@@ -64,72 +60,51 @@ fun ChildPageHeader(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                ChildPageHeaderBackButton(backButton)
-                ChildPageHeaderActionButton(actionButton)
+                if (onBack != null) {
+                    TextButton(
+                        onClick = onBack
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.content_desc_back),
+                            tint = GovUkTheme.colourScheme.textAndIcons.link
+                        )
+                        Spacer(Modifier)
+                    }
+                }
+
+                if (onAction != null && actionText != null) {
+                    Spacer(Modifier)
+
+                    TextButton(
+                        onClick = onAction
+                    ) {
+                        BodyRegularLabel(
+                            text = actionText,
+                            color = GovUkTheme.colourScheme.textAndIcons.link,
+                            textAlign = TextAlign.End
+                        )
+                    }
+                }
             }
         }
 
         if (text != null) {
-            ChildPageHeaderText(text = text, modifier = modifier)
+            Row(
+                modifier = modifier
+                    .defaultMinSize(64.dp)
+                    .fillMaxWidth()
+                    .padding(GovUkTheme.spacing.small),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                LargeTitleBoldLabel(
+                    text = text,
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = GovUkTheme.spacing.medium)
+                )
+            }
         }
-    }
-}
-
-@Composable
-private fun ChildPageHeaderBackButton(
-    actionButton: ActionButton? = null
-) {
-    if (actionButton == null) return
-
-    TextButton(
-        onClick = actionButton.onClick
-    ) {
-        Icon(
-            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-            contentDescription = stringResource(R.string.content_desc_back),
-            tint = GovUkTheme.colourScheme.textAndIcons.link
-        )
-        Spacer(Modifier)
-    }
-}
-
-@Composable
-private fun ChildPageHeaderActionButton(
-    actionButton: ActionButton? = null
-) {
-    if (actionButton == null) return
-
-    Spacer(Modifier)
-
-    TextButton(
-        onClick = actionButton.onClick
-    ) {
-        BodyRegularLabel(
-            text = actionButton.text!!,
-            color = GovUkTheme.colourScheme.textAndIcons.link,
-            textAlign = TextAlign.End
-        )
-    }
-}
-
-@Composable
-private fun ChildPageHeaderText(
-    text: String,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier
-            .defaultMinSize(64.dp)
-            .fillMaxWidth()
-            .padding(GovUkTheme.spacing.small),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        LargeTitleBoldLabel(
-            text = text,
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(horizontal = GovUkTheme.spacing.medium)
-        )
     }
 }
 
@@ -146,8 +121,9 @@ private fun TabHeaderPreview() {
 private fun ChildPageHeaderNoTextWithBackAndActionPreview() {
     GovUkTheme {
         ChildPageHeader(
-            backButton = ActionButton(onClick = { }),
-            actionButton = ActionButton(text = "Done", onClick = { })
+            onBack = {},
+            onAction = {},
+            actionText = "Done"
         )
     }
 }
@@ -158,8 +134,9 @@ private fun ChildPageHeaderBackAndActionPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
-            backButton = ActionButton(onClick = { }),
-            actionButton = ActionButton(text = "Done", onClick = { })
+            onBack = { },
+            onAction = {},
+            actionText = "Done"
         )
     }
 }
@@ -170,7 +147,9 @@ private fun ChildPageHeaderActionNoBackPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
-            actionButton = ActionButton(text = "Done", onClick = { })
+            onBack = null,
+            onAction = {},
+            actionText = "Done"
         )
     }
 }
@@ -181,7 +160,8 @@ private fun ChildPageHeaderBackNoActionPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
-            backButton = ActionButton(onClick = { }),
+            onBack = {},
+            onAction = null
         )
     }
 }
@@ -192,6 +172,8 @@ private fun ChildPageHeaderNoActionOrBackPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
+            onBack = null,
+            onAction = null
         )
     }
 }
@@ -202,6 +184,8 @@ private fun ChildPageHeaderLongTextNoActionOrBackPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "This is a very long child page title that goes on and on",
+            onBack = null,
+            onAction = null
         )
     }
 }

--- a/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
@@ -49,10 +49,10 @@ data class ActionButton(
 
 @Composable
 fun ChildPageHeader(
+    modifier: Modifier = Modifier,
     text: String? = null,
     backButton: ActionButton? = null,
-    actionButton: ActionButton? = null,
-    modifier: Modifier = Modifier,
+    actionButton: ActionButton? = null
 ) {
     Column(modifier) {
         if (backButton != null || actionButton != null) {
@@ -64,11 +64,8 @@ fun ChildPageHeader(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                ChildPageHeaderBackButton(backButton, modifier = modifier.weight(1f))
-                ChildPageHeaderActionButton(
-                    actionButton,
-                    modifier = modifier.weight(1f)
-                )
+                ChildPageHeaderBackButton(backButton)
+                ChildPageHeaderActionButton(actionButton)
             }
         }
 
@@ -80,35 +77,32 @@ fun ChildPageHeader(
 
 @Composable
 private fun ChildPageHeaderBackButton(
-    actionButton: ActionButton? = null,
-    modifier: Modifier = Modifier
+    actionButton: ActionButton? = null
 ) {
     if (actionButton == null) return
 
     TextButton(
-        onClick = actionButton.onClick,
-        modifier = modifier,
+        onClick = actionButton.onClick
     ) {
         Icon(
             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
             contentDescription = stringResource(R.string.content_desc_back),
             tint = GovUkTheme.colourScheme.textAndIcons.link
         )
-        Spacer(Modifier.weight(1f))
+        Spacer(Modifier)
     }
 }
 
 @Composable
 private fun ChildPageHeaderActionButton(
-    actionButton: ActionButton? = null,
-    modifier: Modifier = Modifier
+    actionButton: ActionButton? = null
 ) {
     if (actionButton == null) return
 
-    Spacer(modifier)
+    Spacer(Modifier)
 
     TextButton(
-        onClick = actionButton.onClick,
+        onClick = actionButton.onClick
     ) {
         BodyRegularLabel(
             text = actionButton.text!!,
@@ -183,7 +177,7 @@ private fun ChildPageHeaderActionNoBackPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun Default_ChildPageHeaderBackNoActionPreview() {
+private fun ChildPageHeaderBackNoActionPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
@@ -207,7 +201,7 @@ private fun ChildPageHeaderNoActionOrBackPreview() {
 private fun ChildPageHeaderLongTextNoActionOrBackPreview() {
     GovUkTheme {
         ChildPageHeader(
-            text = "Child page title Child page title Child page title",
+            text = "This is a very long child page title that goes on and on",
         )
     }
 }

--- a/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
@@ -42,18 +42,20 @@ fun TabHeader(
     }
 }
 
+data class ActionButton(
+    val text: String? = null,
+    val onClick: () -> Unit
+)
+
 @Composable
 fun ChildPageHeader(
     text: String? = null,
-    includeActionButton: Boolean = false,
-    actionText: String = "",
-    onAction: () -> Unit = {},
-    includeBackButton: Boolean = true,
-    onBack: () -> Unit = {},
+    backButton: ActionButton? = null,
+    actionButton: ActionButton? = null,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
-        if (includeBackButton || includeActionButton) {
+        if (backButton != null || actionButton != null) {
             Row(
                 modifier = Modifier
                     .height(64.dp)
@@ -62,52 +64,78 @@ fun ChildPageHeader(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (includeBackButton) {
-                    TextButton(
-                        onClick = onBack,
-                        modifier = Modifier.weight(1f),
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.content_desc_back),
-                            tint = GovUkTheme.colourScheme.textAndIcons.link
-                        )
-                        Spacer(Modifier.weight(1f))
-                    }
-                }
-
-                if (includeActionButton) {
-                    Spacer(Modifier.weight(1f))
-
-                    TextButton(
-                        onClick = onAction,
-                    ) {
-                        BodyRegularLabel(
-                            text = actionText,
-                            color = GovUkTheme.colourScheme.textAndIcons.link,
-                            textAlign = TextAlign.End
-                        )
-                    }
-                }
+                ChildPageHeaderBackButton(backButton, modifier = modifier.weight(1f))
+                ChildPageHeaderActionButton(
+                    actionButton,
+                    modifier = modifier.weight(1f)
+                )
             }
         }
 
         if (text != null) {
-            Row(
-                modifier = Modifier
-                    .defaultMinSize(64.dp)
-                    .fillMaxWidth()
-                    .padding(GovUkTheme.spacing.small),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                LargeTitleBoldLabel(
-                    text = text,
-                    modifier = modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = GovUkTheme.spacing.medium)
-                )
-            }
+            ChildPageHeaderText(text = text, modifier = modifier)
         }
+    }
+}
+
+@Composable
+private fun ChildPageHeaderBackButton(
+    actionButton: ActionButton? = null,
+    modifier: Modifier = Modifier
+) {
+    if (actionButton == null) return
+
+    TextButton(
+        onClick = actionButton.onClick,
+        modifier = modifier,
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = stringResource(R.string.content_desc_back),
+            tint = GovUkTheme.colourScheme.textAndIcons.link
+        )
+        Spacer(Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun ChildPageHeaderActionButton(
+    actionButton: ActionButton? = null,
+    modifier: Modifier = Modifier
+) {
+    if (actionButton == null) return
+
+    Spacer(modifier)
+
+    TextButton(
+        onClick = actionButton.onClick,
+    ) {
+        BodyRegularLabel(
+            text = actionButton.text!!,
+            color = GovUkTheme.colourScheme.textAndIcons.link,
+            textAlign = TextAlign.End
+        )
+    }
+}
+
+@Composable
+private fun ChildPageHeaderText(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .defaultMinSize(64.dp)
+            .fillMaxWidth()
+            .padding(GovUkTheme.spacing.small),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        LargeTitleBoldLabel(
+            text = text,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = GovUkTheme.spacing.medium)
+        )
     }
 }
 
@@ -124,9 +152,8 @@ private fun TabHeaderPreview() {
 private fun ChildPageHeaderNoTextWithBackAndActionPreview() {
     GovUkTheme {
         ChildPageHeader(
-            includeActionButton = true,
-            actionText = "Done",
-            onBack = { }
+            backButton = ActionButton(onClick = { }),
+            actionButton = ActionButton(text = "Done", onClick = { })
         )
     }
 }
@@ -137,9 +164,8 @@ private fun ChildPageHeaderBackAndActionPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
-            includeActionButton = true,
-            actionText = "Done",
-            onBack = { }
+            backButton = ActionButton(onClick = { }),
+            actionButton = ActionButton(text = "Done", onClick = { })
         )
     }
 }
@@ -150,9 +176,7 @@ private fun ChildPageHeaderActionNoBackPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
-            includeActionButton = true,
-            actionText = "Done",
-            includeBackButton = false
+            actionButton = ActionButton(text = "Done", onClick = { })
         )
     }
 }
@@ -163,7 +187,7 @@ private fun Default_ChildPageHeaderBackNoActionPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
-            onBack = { }
+            backButton = ActionButton(onClick = { }),
         )
     }
 }
@@ -174,7 +198,6 @@ private fun ChildPageHeaderNoActionOrBackPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
-            includeBackButton = false
         )
     }
 }
@@ -185,7 +208,6 @@ private fun ChildPageHeaderLongTextNoActionOrBackPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title Child page title Child page title",
-            includeBackButton = false
         )
     }
 }

--- a/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
@@ -1,8 +1,10 @@
 package uk.govuk.app.design.ui.component
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -42,31 +44,70 @@ fun TabHeader(
 
 @Composable
 fun ChildPageHeader(
-    text: String,
-    onBack: () -> Unit,
+    text: String? = null,
+    includeActionButton: Boolean = false,
+    actionText: String = "",
+    onAction: () -> Unit = {},
+    includeBackButton: Boolean = true,
+    onBack: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
-        Box(
-            modifier = Modifier.height(64.dp),
-            contentAlignment = Alignment.CenterStart
-        ) {
-            TextButton(
-                onClick = onBack,
+        if (includeBackButton || includeActionButton) {
+            Row(
+                modifier = Modifier
+                    .height(64.dp)
+                    .fillMaxWidth()
+                    .padding(GovUkTheme.spacing.small),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = stringResource(R.string.content_desc_back),
-                    tint = GovUkTheme.colourScheme.textAndIcons.link
+                if (includeBackButton) {
+                    TextButton(
+                        onClick = onBack,
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.content_desc_back),
+                            tint = GovUkTheme.colourScheme.textAndIcons.link
+                        )
+                        Spacer(Modifier.weight(1f))
+                    }
+                }
+
+                if (includeActionButton) {
+                    Spacer(Modifier.weight(1f))
+
+                    TextButton(
+                        onClick = onAction,
+                    ) {
+                        BodyRegularLabel(
+                            text = actionText,
+                            color = GovUkTheme.colourScheme.textAndIcons.link,
+                            textAlign = TextAlign.End
+                        )
+                    }
+                }
+            }
+        }
+
+        if (text != null) {
+            Row(
+                modifier = Modifier
+                    .defaultMinSize(64.dp)
+                    .fillMaxWidth()
+                    .padding(GovUkTheme.spacing.small),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                LargeTitleBoldLabel(
+                    text = text,
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = GovUkTheme.spacing.medium)
                 )
             }
         }
-        LargeTitleBoldLabel(
-            text = text,
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(horizontal = GovUkTheme.spacing.medium)
-        )
     }
 }
 
@@ -80,11 +121,71 @@ private fun TabHeaderPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun ChildPageHeaderPreview() {
+private fun ChildPageHeaderNoTextWithBackAndActionPreview() {
+    GovUkTheme {
+        ChildPageHeader(
+            includeActionButton = true,
+            actionText = "Done",
+            onBack = { }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ChildPageHeaderBackAndActionPreview() {
+    GovUkTheme {
+        ChildPageHeader(
+            text = "Child page title",
+            includeActionButton = true,
+            actionText = "Done",
+            onBack = { }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ChildPageHeaderActionNoBackPreview() {
+    GovUkTheme {
+        ChildPageHeader(
+            text = "Child page title",
+            includeActionButton = true,
+            actionText = "Done",
+            includeBackButton = false
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun Default_ChildPageHeaderBackNoActionPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
             onBack = { }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ChildPageHeaderNoActionOrBackPreview() {
+    GovUkTheme {
+        ChildPageHeader(
+            text = "Child page title",
+            includeBackButton = false
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ChildPageHeaderLongTextNoActionOrBackPreview() {
+    GovUkTheme {
+        ChildPageHeader(
+            text = "Child page title Child page title Child page title",
+            includeBackButton = false
         )
     }
 }

--- a/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
+++ b/design/src/main/kotlin/uk/govuk/app/design/ui/component/Header.kt
@@ -46,8 +46,8 @@ fun TabHeader(
 fun ChildPageHeader(
     modifier: Modifier = Modifier,
     text: String? = null,
-    onBack: (() -> Unit)?,
-    onAction: (() -> Unit)?,
+    onBack: (() -> Unit)? = null,
+    onAction: (() -> Unit)? = null,
     actionText: String? = null
 ) {
     Column(modifier) {
@@ -134,7 +134,7 @@ private fun ChildPageHeaderBackAndActionPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
-            onBack = { },
+            onBack = {},
             onAction = {},
             actionText = "Done"
         )
@@ -147,7 +147,6 @@ private fun ChildPageHeaderActionNoBackPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
-            onBack = null,
             onAction = {},
             actionText = "Done"
         )
@@ -160,8 +159,7 @@ private fun ChildPageHeaderBackNoActionPreview() {
     GovUkTheme {
         ChildPageHeader(
             text = "Child page title",
-            onBack = {},
-            onAction = null
+            onBack = {}
         )
     }
 }
@@ -171,9 +169,7 @@ private fun ChildPageHeaderBackNoActionPreview() {
 private fun ChildPageHeaderNoActionOrBackPreview() {
     GovUkTheme {
         ChildPageHeader(
-            text = "Child page title",
-            onBack = null,
-            onAction = null
+            text = "Child page title"
         )
     }
 }
@@ -183,9 +179,7 @@ private fun ChildPageHeaderNoActionOrBackPreview() {
 private fun ChildPageHeaderLongTextNoActionOrBackPreview() {
     GovUkTheme {
         ChildPageHeader(
-            text = "This is a very long child page title that goes on and on",
-            onBack = null,
-            onAction = null
+            text = "This is a very long child page title that goes on and on"
         )
     }
 }

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllStepByStepsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllStepByStepsScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
-import uk.govuk.app.design.ui.component.ActionButton
 import uk.govuk.app.design.ui.component.ChildPageHeader
 import uk.govuk.app.design.ui.component.ExternalLinkListItem
 import uk.govuk.app.design.ui.component.LargeVerticalSpacer
@@ -65,7 +64,8 @@ private fun AllStepByStepsScreen(
 
         ChildPageHeader(
             text = title,
-            backButton = ActionButton(onClick = onBack)
+            onBack = onBack,
+            onAction = null
         )
 
         if (stepBySteps != null) {

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllStepByStepsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllStepByStepsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
+import uk.govuk.app.design.ui.component.ActionButton
 import uk.govuk.app.design.ui.component.ChildPageHeader
 import uk.govuk.app.design.ui.component.ExternalLinkListItem
 import uk.govuk.app.design.ui.component.LargeVerticalSpacer
@@ -64,7 +65,7 @@ private fun AllStepByStepsScreen(
 
         ChildPageHeader(
             text = title,
-            onBack = onBack
+            backButton = ActionButton(onClick = onBack)
         )
 
         if (stepBySteps != null) {

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllStepByStepsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllStepByStepsScreen.kt
@@ -64,8 +64,7 @@ private fun AllStepByStepsScreen(
 
         ChildPageHeader(
             text = title,
-            onBack = onBack,
-            onAction = null
+            onBack = onBack
         )
 
         if (stepBySteps != null) {

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllTopicsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllTopicsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
-import uk.govuk.app.design.ui.component.ActionButton
 import uk.govuk.app.design.ui.component.ChildPageHeader
 import uk.govuk.app.design.ui.component.MediumVerticalSpacer
 import uk.govuk.app.design.ui.theme.GovUkTheme
@@ -58,7 +57,8 @@ private fun AllTopicsScreen(
     Column(modifier) {
         ChildPageHeader(
             text = title,
-            backButton = ActionButton(onClick = onBack)
+            onBack = onBack,
+            onAction = null
         )
 
         if (!topics.isNullOrEmpty()) {

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllTopicsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllTopicsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
+import uk.govuk.app.design.ui.component.ActionButton
 import uk.govuk.app.design.ui.component.ChildPageHeader
 import uk.govuk.app.design.ui.component.MediumVerticalSpacer
 import uk.govuk.app.design.ui.theme.GovUkTheme
@@ -57,7 +58,7 @@ private fun AllTopicsScreen(
     Column(modifier) {
         ChildPageHeader(
             text = title,
-            onBack = onBack
+            backButton = ActionButton(onClick = onBack)
         )
 
         if (!topics.isNullOrEmpty()) {

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllTopicsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllTopicsScreen.kt
@@ -57,8 +57,7 @@ private fun AllTopicsScreen(
     Column(modifier) {
         ChildPageHeader(
             text = title,
-            onBack = onBack,
-            onAction = null
+            onBack = onBack
         )
 
         if (!topics.isNullOrEmpty()) {

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/EditTopicsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/EditTopicsScreen.kt
@@ -61,8 +61,7 @@ private fun EditTopicsScreen(
     Column(modifier) {
         ChildPageHeader(
             text = title,
-            onBack = onBack,
-            onAction = null
+            onBack = onBack
         )
         LazyColumn(
             Modifier

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/EditTopicsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/EditTopicsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
-import uk.govuk.app.design.ui.component.ActionButton
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.ChildPageHeader
 import uk.govuk.app.design.ui.component.ExtraLargeVerticalSpacer
@@ -62,7 +61,8 @@ private fun EditTopicsScreen(
     Column(modifier) {
         ChildPageHeader(
             text = title,
-            backButton = ActionButton(onClick = onBack)
+            onBack = onBack,
+            onAction = null
         )
         LazyColumn(
             Modifier

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/EditTopicsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/EditTopicsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
+import uk.govuk.app.design.ui.component.ActionButton
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.ChildPageHeader
 import uk.govuk.app.design.ui.component.ExtraLargeVerticalSpacer
@@ -61,7 +62,7 @@ private fun EditTopicsScreen(
     Column(modifier) {
         ChildPageHeader(
             text = title,
-            onBack = onBack
+            backButton = ActionButton(onClick = onBack)
         )
         LazyColumn(
             Modifier

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/TopicScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/TopicScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import uk.govuk.app.design.ui.component.ActionButton
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.ChildPageHeader
 import uk.govuk.app.design.ui.component.ExternalLinkListItem
@@ -111,7 +112,7 @@ private fun TopicScreen(
 
         ChildPageHeader(
             text = topic.title,
-            onBack = onBack
+            backButton = ActionButton(onClick = onBack)
         )
 
         val popularPagesSection = TopicUi.Section(
@@ -258,7 +259,7 @@ private fun ErrorScreen(
 
         ChildPageHeader(
             text = topicName,
-            onBack = onBack
+            backButton = ActionButton(onClick = onBack)
         )
 
         content()

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/TopicScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/TopicScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
-import uk.govuk.app.design.ui.component.ActionButton
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.ChildPageHeader
 import uk.govuk.app.design.ui.component.ExternalLinkListItem
@@ -112,7 +111,8 @@ private fun TopicScreen(
 
         ChildPageHeader(
             text = topic.title,
-            backButton = ActionButton(onClick = onBack)
+            onBack = onBack,
+            onAction = null
         )
 
         val popularPagesSection = TopicUi.Section(
@@ -259,7 +259,8 @@ private fun ErrorScreen(
 
         ChildPageHeader(
             text = topicName,
-            backButton = ActionButton(onClick = onBack)
+            onBack = onBack,
+            onAction = null
         )
 
         content()

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/TopicScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/TopicScreen.kt
@@ -111,8 +111,7 @@ private fun TopicScreen(
 
         ChildPageHeader(
             text = topic.title,
-            onBack = onBack,
-            onAction = null
+            onBack = onBack
         )
 
         val popularPagesSection = TopicUi.Section(
@@ -259,8 +258,7 @@ private fun ErrorScreen(
 
         ChildPageHeader(
             text = topicName,
-            onBack = onBack,
-            onAction = null
+            onBack = onBack
         )
 
         content()

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
@@ -22,9 +21,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -37,7 +33,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.CardListItem
-import uk.govuk.app.design.ui.component.LargeTitleBoldLabel
+import uk.govuk.app.design.ui.component.ChildPageHeader
 import uk.govuk.app.design.ui.component.LargeVerticalSpacer
 import uk.govuk.app.design.ui.component.ListHeadingLabel
 import uk.govuk.app.design.ui.component.SmallVerticalSpacer
@@ -112,9 +108,12 @@ private fun EditVisitedScreen(
             .fillMaxWidth(),
 
         topBar = {
-            TopNavBar(
-                doneText = doneText,
-                onBack = onBack,
+            ChildPageHeader(
+                text = titleText,
+                includeActionButton = true,
+                actionText = doneText,
+                onAction = onBack,
+                includeBackButton = false,
                 modifier = modifier
             )
         },
@@ -135,18 +134,6 @@ private fun EditVisitedScreen(
                 .padding(top = GovUkTheme.spacing.small)
                 .fillMaxWidth()
         ) {
-            item {
-                LargeTitleBoldLabel(
-                    text = titleText,
-                    modifier = modifier
-                        .fillMaxWidth()
-                        .wrapContentSize()
-                        .padding(horizontal = GovUkTheme.spacing.medium)
-                        .padding(bottom = GovUkTheme.spacing.small),
-                    textAlign = TextAlign.Start
-                )
-            }
-
             item {
                 visitedItems?.let { items ->
                     val lastVisitedText = stringResource(R.string.visited_items_last_visited)
@@ -241,41 +228,6 @@ private fun CheckableExternalLinkListItem(
                         color = GovUkTheme.colourScheme.textAndIcons.primary
                     )
                 }
-            }
-        }
-    }
-}
-
-@Composable
-private fun TopNavBar(
-    doneText: String,
-    onBack: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var isDoneButtonEnabled by remember { mutableStateOf(true) }
-
-    Column(modifier) {
-        Row(
-            modifier = Modifier
-                .height(64.dp)
-                .fillMaxWidth()
-                .padding(end = GovUkTheme.spacing.small),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.End
-        ) {
-            TextButton(
-                onClick = {
-                    isDoneButtonEnabled = false
-                    onBack()
-                },
-                modifier = modifier.wrapContentSize(),
-                enabled = isDoneButtonEnabled
-            ) {
-                BodyRegularLabel(
-                    text = doneText,
-                    color = GovUkTheme.colourScheme.textAndIcons.link,
-                    textAlign = TextAlign.End
-                )
             }
         }
     }

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import uk.govuk.app.design.ui.component.ActionButton
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.CardListItem
 import uk.govuk.app.design.ui.component.ChildPageHeader
@@ -111,8 +110,9 @@ private fun EditVisitedScreen(
         topBar = {
             ChildPageHeader(
                 text = titleText,
-                actionButton = ActionButton(text = doneText, onClick = onBack),
-                modifier = modifier
+                onBack = null,
+                onAction = onBack,
+                actionText = doneText
             )
         },
         bottomBar = {

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -110,7 +110,6 @@ private fun EditVisitedScreen(
         topBar = {
             ChildPageHeader(
                 text = titleText,
-                onBack = null,
                 onAction = onBack,
                 actionText = doneText
             )

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import uk.govuk.app.design.ui.component.ActionButton
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.CardListItem
 import uk.govuk.app.design.ui.component.ChildPageHeader
@@ -110,10 +111,7 @@ private fun EditVisitedScreen(
         topBar = {
             ChildPageHeader(
                 text = titleText,
-                includeActionButton = true,
-                actionText = doneText,
-                onAction = onBack,
-                includeBackButton = false,
+                actionButton = ActionButton(text = doneText, onClick = onBack),
                 modifier = modifier
             )
         },

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import uk.govuk.app.design.ui.component.ActionButton
 import uk.govuk.app.design.ui.component.BodyBoldLabel
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.ChildPageHeader
@@ -83,19 +84,14 @@ private fun VisitedScreen(
             if (visitedItems.isNullOrEmpty()) {
                 ChildPageHeader(
                     text = title,
-                    includeActionButton = false,
-                    includeBackButton = true,
-                    onBack = onBack,
+                    backButton = ActionButton(onClick = onBack),
                     modifier = modifier
                 )
             } else {
                 ChildPageHeader(
                     text = title,
-                    includeActionButton = true,
-                    actionText = editText,
-                    onAction = onEditClick,
-                    includeBackButton = true,
-                    onBack = onBack,
+                    backButton = ActionButton(onClick = onBack),
+                    actionButton = ActionButton(text = editText, onClick = onEditClick),
                     modifier = modifier
                 )
             }

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import uk.govuk.app.design.ui.component.ActionButton
 import uk.govuk.app.design.ui.component.BodyBoldLabel
 import uk.govuk.app.design.ui.component.BodyRegularLabel
 import uk.govuk.app.design.ui.component.ChildPageHeader
@@ -81,20 +80,18 @@ private fun VisitedScreen(
 
     Column(modifier) {
         Column(modifier) {
-            if (visitedItems.isNullOrEmpty()) {
-                ChildPageHeader(
-                    text = title,
-                    backButton = ActionButton(onClick = onBack),
-                    modifier = modifier
-                )
-            } else {
-                ChildPageHeader(
-                    text = title,
-                    backButton = ActionButton(onClick = onBack),
-                    actionButton = ActionButton(text = editText, onClick = onEditClick),
-                    modifier = modifier
-                )
+            var onAction: (() -> Unit)? = null
+
+            if (!visitedItems.isNullOrEmpty()) {
+                onAction = onEditClick
             }
+
+            ChildPageHeader(
+                text = title,
+                onBack = onBack,
+                onAction = onAction,
+                actionText = editText
+            )
         }
         LazyColumn(
             Modifier

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -76,16 +76,14 @@ private fun VisitedScreen(
     val visitedItems = uiState?.visited
 
     Column(modifier) {
-        Column(modifier) {
-            val onAction = if (!visitedItems.isNullOrEmpty()) onEditClick else null
+        val onAction = if (!visitedItems.isNullOrEmpty()) onEditClick else null
 
-            ChildPageHeader(
-                text = title,
-                onBack = onBack,
-                onAction = onAction,
-                actionText = editText
-            )
-        }
+        ChildPageHeader(
+            text = title,
+            onBack = onBack,
+            onAction = onAction,
+            actionText = editText
+        )
         LazyColumn(
             Modifier
                 .padding(horizontal = GovUkTheme.spacing.medium)

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -4,9 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
@@ -18,7 +16,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import uk.govuk.app.design.ui.component.BodyBoldLabel

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -80,11 +80,7 @@ private fun VisitedScreen(
 
     Column(modifier) {
         Column(modifier) {
-            var onAction: (() -> Unit)? = null
-
-            if (!visitedItems.isNullOrEmpty()) {
-                onAction = onEditClick
-            }
+            val onAction = if (!visitedItems.isNullOrEmpty()) onEditClick else null
 
             ChildPageHeader(
                 text = title,

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -4,17 +4,11 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Icon
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -29,9 +23,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import uk.govuk.app.design.ui.component.BodyBoldLabel
 import uk.govuk.app.design.ui.component.BodyRegularLabel
+import uk.govuk.app.design.ui.component.ChildPageHeader
 import uk.govuk.app.design.ui.component.ExternalLinkListItem
 import uk.govuk.app.design.ui.component.ExtraLargeVerticalSpacer
-import uk.govuk.app.design.ui.component.LargeTitleBoldLabel
 import uk.govuk.app.design.ui.component.LargeVerticalSpacer
 import uk.govuk.app.design.ui.component.ListHeadingLabel
 import uk.govuk.app.design.ui.component.SmallVerticalSpacer
@@ -84,38 +78,26 @@ private fun VisitedScreen(
     val editText = stringResource(R.string.visited_items_edit_button)
     val visitedItems = uiState?.visited
 
-    Column(modifier.fillMaxWidth()) {
-        Column {
-            Row(
-                modifier = Modifier
-                    .height(64.dp)
-                    .fillMaxWidth()
-                    .padding(end = GovUkTheme.spacing.small),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                TextButton(
-                    onClick = onBack,
-                ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = stringResource(uk.govuk.app.design.R.string.content_desc_back),
-                        tint = GovUkTheme.colourScheme.textAndIcons.link
-                    )
-                }
-
-                if (!visitedItems.isNullOrEmpty()) {
-                    Spacer(modifier = Modifier.weight(1f))
-
-                    TextButton(
-                        onClick = onEditClick,
-                        modifier = Modifier.padding(end = GovUkTheme.spacing.small)
-                    ) {
-                        BodyRegularLabel(
-                            text = editText,
-                            color = GovUkTheme.colourScheme.textAndIcons.link,
-                        )
-                    }
-                }
+    Column(modifier) {
+        Column(modifier) {
+            if (visitedItems.isNullOrEmpty()) {
+                ChildPageHeader(
+                    text = title,
+                    includeActionButton = false,
+                    includeBackButton = true,
+                    onBack = onBack,
+                    modifier = modifier
+                )
+            } else {
+                ChildPageHeader(
+                    text = title,
+                    includeActionButton = true,
+                    actionText = editText,
+                    onAction = onEditClick,
+                    includeBackButton = true,
+                    onBack = onBack,
+                    modifier = modifier
+                )
             }
         }
         LazyColumn(
@@ -123,18 +105,6 @@ private fun VisitedScreen(
                 .padding(horizontal = GovUkTheme.spacing.medium)
                 .padding(top = GovUkTheme.spacing.small)
         ) {
-
-            item {
-                LargeTitleBoldLabel(
-                    text = title,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .wrapContentSize()
-                        .padding(horizontal = GovUkTheme.spacing.medium)
-                        .padding(bottom = GovUkTheme.spacing.small)
-                )
-            }
-
             item {
                 if (visitedItems.isNullOrEmpty()) {
                     NoVisitedItems(modifier)


### PR DESCRIPTION
# GOVUKAPP-1001: pages you've visited should ChildPageHeader

ChildPageHeader component updated to handle optional Back (left hand side) button, 'action' (right hand side) button, and header text.

## JIRA ticket(s)
  - [GOVAPP-1001](https://govukverify.atlassian.net/browse/GOVUKAPP-1001)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-83650&node-type=canvas&t=wNQf4guNUFZXVKUN-0)

## Screen shots 

| ChildPageHeader Previews |
|---|
| ![Screenshot 2024-12-09 at 11 53 21](https://github.com/user-attachments/assets/57b4a746-91b7-4a20-aec5-cc3de98688e7) |

| List Screen | Edit Screen |
|---|---|
| ![list-screen](https://github.com/user-attachments/assets/df490c34-1b1e-4708-a378-3ac732ef0d30) | ![edit-screen](https://github.com/user-attachments/assets/2a3d6222-842b-4eed-bd5e-85c42136fb9e) |






