### PR TITLE
GOVUKAPP-999: Search result padding no description

### DIFF
--- a/feature/search/src/main/kotlin/uk/govuk/app/search/ui/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/ui/SearchScreen.kt
@@ -132,9 +132,6 @@ fun ShowResults(searchResults: List<Result>, onClick: (String, String) -> Unit) 
         LazyColumn {
             items(searchResults) { searchResult ->
                 val title = StringUtils.collapseWhitespace(searchResult.title)
-                val description = searchResult.description?.let {
-                    StringUtils.collapseWhitespace(it)
-                } ?: ""
                 val url = StringUtils.buildFullUrl(searchResult.link)
 
                 val context = LocalContext.current
@@ -173,9 +170,11 @@ fun ShowResults(searchResults: List<Result>, onClick: (String, String) -> Unit) 
                         )
                     }
 
-                    SmallVerticalSpacer()
-
-                    BodyRegularLabel(description)
+                    val description = searchResult.description
+                    if (!description.isNullOrBlank()) {
+                        SmallVerticalSpacer()
+                        BodyRegularLabel(StringUtils.collapseWhitespace(description))
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Title

Remove padding if search result has no description

## JIRA ticket(s)
  - [GOVUKAPP-999](https://govukverify.atlassian.net/browse/GOVUKAPP-999)

## Screen shots & video (if UI changes)
![Screenshot_20241209_115609](https://github.com/user-attachments/assets/8f79ca11-63f3-4f88-b1d4-f1a7aef21cde)


[GOVUKAPP-999]: https://govukverify.atlassian.net/browse/GOVUKAPP-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ