### PR TITLE
GOVUKAPP-1012 Inconsistent padding

### DIFF
--- a/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
@@ -257,7 +257,9 @@ private fun GovUkNavHost(
             modifier = Modifier.padding(paddingValues)
         )
         searchGraph(navController)
-        visitedGraph(navController)
+        visitedGraph(
+            navController = navController,
+            modifier = Modifier.padding(paddingValues))
     }
 }
 

--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/VisitedScreen.kt
@@ -84,8 +84,8 @@ private fun VisitedScreen(
     val editText = stringResource(R.string.visited_items_edit_button)
     val visitedItems = uiState?.visited
 
-    Column(modifier) {
-        Column(modifier) {
+    Column(modifier.fillMaxWidth()) {
+        Column {
             Row(
                 modifier = Modifier
                     .height(64.dp)
@@ -127,7 +127,7 @@ private fun VisitedScreen(
             item {
                 LargeTitleBoldLabel(
                     text = title,
-                    modifier = modifier
+                    modifier = Modifier
                         .fillMaxWidth()
                         .wrapContentSize()
                         .padding(horizontal = GovUkTheme.spacing.medium)
@@ -141,10 +141,6 @@ private fun VisitedScreen(
                 } else {
                     ShowVisitedItems(visitedItems, onClick)
                 }
-            }
-
-            item {
-                Spacer(modifier = Modifier.height(76.dp))
             }
         }
     }


### PR DESCRIPTION
# Inconsistent padding

Padding at bottom of PYV list is different on edit and non edit mode

# Resolution
Pass padding values for tab bar etc into visited screen so visited screen padding can be set correctly

## JIRA ticket(s)
  - [GOVAPP-1012](https://govukverify.atlassian.net/browse/GOVUKAPP-1012)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=3245-19697&node-type=frame&t=SuOEuXkoh7K39MQp-0)

### Before

| Normal Mode | Edit Mode |
|---|---|
| ![image](https://github.com/user-attachments/assets/9bc310d7-84a4-4281-8603-d299b82ad6b2) | ![image](https://github.com/user-attachments/assets/2a11f6b9-07fb-4273-b4f5-9469b71b4cda) |

### After

| Normal Mode | Edit Mode |
|---|---|
| ![image](https://github.com/user-attachments/assets/eedecf71-dd3c-459f-a0a9-132c52f68c3f) | ![image](https://github.com/user-attachments/assets/4e4eac6b-7575-41ce-b8bb-9758ff0fcbeb) |
