### PR TITLE
GOVUKAPP-1008 :  Keyboard obscures search results

### DIFF
--- a/feature/search/src/main/kotlin/uk/govuk/app/search/ui/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/ui/SearchScreen.kt
@@ -46,12 +46,14 @@ internal fun SearchRoute(
     modifier: Modifier = Modifier
 ) {
     val viewModel: SearchViewModel = hiltViewModel()
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     SearchScreen(
         viewModel = viewModel,
         onPageView = { viewModel.onPageView() },
         onBack = onBack,
         onSearch = { searchTerm ->
+            keyboardController?.hide()
             viewModel.onSearch(searchTerm)
         },
         onClear = {


### PR DESCRIPTION
# GOVUKAPP-1008 :  Keyboard obscures search results

Hide the keyboard when the user searches for search term

## JIRA ticket(s)
  - [GOVAPP-1008](https://govukverify.atlassian.net/browse/GOVUKAPP-1008)

## Screen recordings

| Before | After |
|---|---|
| [search-keyboard-before.webm](https://github.com/user-attachments/assets/37d4bce6-8d8e-4bb7-b7d8-1a3e540ea999) | [search-keyboard-after.webm](https://github.com/user-attachments/assets/cc811639-6cb0-432a-98f9-60747e89ffa6) |

