### PR TITLE
GOVUKAPP-1015 : Analytics consent link icon position

### DIFF
--- a/analytics/src/main/kotlin/uk/govuk/app/analytics/ui/AnalyticsConsentScreen.kt
+++ b/analytics/src/main/kotlin/uk/govuk/app/analytics/ui/AnalyticsConsentScreen.kt
@@ -159,7 +159,6 @@ private fun PrivacyPolicyLink(
     ) {
         BodyRegularLabel(
             text = stringResource(R.string.analytics_consent_privacy_policy),
-            modifier = Modifier.weight(1f),
             color = GovUkTheme.colourScheme.textAndIcons.link,
         )
         SmallHorizontalSpacer()


### PR DESCRIPTION
# GOVUKAPP-1015 : Analytics consent link icon position

Description

## JIRA ticket(s)
  - [GOVAPP-1015](https://govukverify.atlassian.net/browse/GOVUKAPP-1015)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-65919&node-type=frame&t=fYBpuivAbDg9jGKS-0)

## Screen shots

### Portrait

| Before | After |
|---|---|
| ![consent-before](https://github.com/user-attachments/assets/9f17f0d4-b0cc-4a88-be3a-471c89d11afe) | ![consent-after](https://github.com/user-attachments/assets/9b2ddec3-1baa-4313-9eb5-9753eec1c60e) |

### Landscape

| Before | After |
|---|---|
| ![consent-before-ls](https://github.com/user-attachments/assets/060e5977-f1f1-4af1-827f-3fc7761585de) | ![consent-after-ls](https://github.com/user-attachments/assets/2dc7e89d-9549-4a28-8218-b2c18b760998) |




