### PR TITLE
GOVUKAPP-1010 : Padding around "open in browser" icon

### DIFF
--- a/feature/search/src/main/kotlin/uk/govuk/app/search/ui/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/ui/SearchScreen.kt
@@ -168,7 +168,8 @@ fun ShowResults(searchResults: List<Result>, onClick: (String, String) -> Unit) 
                             contentDescription = stringResource(
                                 uk.govuk.app.design.R.string.opens_in_web_browser
                             ),
-                            tint = GovUkTheme.colourScheme.textAndIcons.link
+                            tint = GovUkTheme.colourScheme.textAndIcons.link,
+                            modifier = Modifier.padding(start = GovUkTheme.spacing.medium)
                         )
                     }
 


### PR DESCRIPTION
# GOVUKAPP-1010 : Padding around "open in browser" icon

## JIRA ticket(s)
  - [GOVAPP-1010](https://govukverify.atlassian.net/browse/GOVUKAPP-1010)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-74994&node-type=canvas&t=fYBpuivAbDg9jGKS-0)

## Screen shots 

| Before | After |
|---|---|
| ![spacing-before](https://github.com/user-attachments/assets/846edded-7553-4acc-9806-f84673989d87) | ![spacing-after](https://github.com/user-attachments/assets/4360e875-777e-4ade-8785-c8064ed3b755) |

