### PR TITLE
GOVUKAPP-1011: PYV Edit Selection Bug

### DIFF
--- a/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/govuk/app/visited/ui/EditVisitedScreen.kt
@@ -1,5 +1,7 @@
 package uk.govuk.app.visited.ui
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -21,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -179,11 +182,18 @@ private fun CheckableExternalLinkListItem(
 ) {
     CardListItem(
         modifier = modifier,
-        onClick = { onSelect(item.title, item.url) },
         isFirst = isFirst,
         isLast = isLast
     ) {
+        val interactionSource = remember { MutableInteractionSource() }
         Row(
+            modifier = Modifier
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null
+                ){
+                    onSelect(item.title, item.url)
+                },
             verticalAlignment = Alignment.CenterVertically
         ) {
             Column(


### PR DESCRIPTION
# Title

Disable cell selection indicator in edit mode

## JIRA ticket(s)
  - [GOVUKAPP-1011](https://govukverify.atlassian.net/browse/GOVUKAPP-1011)

## Screen shots & video (if UI changes)

### Before
[Screen_recording_20241212_111231.webm](https://github.com/user-attachments/assets/f1ae5370-867b-4123-a97f-0aaec2dcf6c1)

### After
[Screen_recording_20241212_111128.webm](https://github.com/user-attachments/assets/05e0049c-ced5-4d42-b404-78760c6c10b6)


[GOVUKAPP-1011]: https://govukverify.atlassian.net/browse/GOVUKAPP-1011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ