### PR TITLE
GOVUKAPP-1009 Onboarding screens missed when using swipe to navigate

### DIFF
--- a/feature/onboarding/src/main/kotlin/uk/govuk/app/onboarding/ui/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/uk/govuk/app/onboarding/ui/OnboardingScreen.kt
@@ -151,8 +151,8 @@ private fun OnboardingScreen(
 @Composable
 private fun Page(
     page: OnboardingPage,
-    modifier: Modifier = Modifier,
-    isCurrentPage: Boolean
+    isCurrentPage: Boolean,
+    modifier: Modifier = Modifier
 ) {
     val focusRequester = remember { FocusRequester() }
     val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass

--- a/feature/onboarding/src/main/kotlin/uk/govuk/app/onboarding/ui/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/uk/govuk/app/onboarding/ui/OnboardingScreen.kt
@@ -1,6 +1,5 @@
 package uk.govuk.app.onboarding.ui
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -84,7 +83,6 @@ internal fun OnboardingRoute(
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun OnboardingScreen(
     pages: List<OnboardingPage>,
@@ -111,7 +109,10 @@ private fun OnboardingScreen(
                 .weight(1f),
             verticalAlignment = Alignment.Top
         ) { pageIndex ->
-            Page(pages[pageIndex])
+            Page(
+                page = pages[pageIndex],
+                isCurrentPage = pagerState.currentPage == pageIndex
+            )
         }
 
         ListDivider()
@@ -150,7 +151,8 @@ private fun OnboardingScreen(
 @Composable
 private fun Page(
     page: OnboardingPage,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isCurrentPage: Boolean
 ) {
     val focusRequester = remember { FocusRequester() }
     val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
@@ -189,8 +191,10 @@ private fun Page(
                 .padding(horizontal = GovUkTheme.spacing.extraLarge),
             textAlign = TextAlign.Center
         )
+    }
 
-        LaunchedEffect(page.title) {
+    LaunchedEffect(page.title) {
+        if (isCurrentPage) {
             delay(200)
             focusRequester.requestFocus()
         }


### PR DESCRIPTION
# Onboarding screens missed when using swipe to navigate

# Cause
Focus of page title labels was being requested on instances of further pages than the current one causing the pager to skip to the further pages 

# Resolution
Only request focus of page title on current page

## JIRA ticket(s)
  - [GOVAPP-1009](https://govukverify.atlassian.net/browse/GOVUKAPP-1009)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-53780&node-type=canvas&t=VGAdGIeB8VjkoH3y-0)

### Before

https://github.com/user-attachments/assets/faae8c68-7979-46b0-aea6-c3d46996210e

### After

https://github.com/user-attachments/assets/220387ed-8464-463f-883b-6d0ac7bebfa4