### PR TITLE
GOVUKAPP-1019 Update privacy policy wording

### DIFF
--- a/analytics/src/main/kotlin/uk/govuk/app/analytics/ui/AnalyticsConsentScreen.kt
+++ b/analytics/src/main/kotlin/uk/govuk/app/analytics/ui/AnalyticsConsentScreen.kt
@@ -160,6 +160,7 @@ private fun PrivacyPolicyLink(
         BodyRegularLabel(
             text = stringResource(R.string.analytics_consent_privacy_policy),
             color = GovUkTheme.colourScheme.textAndIcons.link,
+            modifier = Modifier.weight(1f, fill = false)
         )
         SmallHorizontalSpacer()
         Icon(
@@ -167,7 +168,8 @@ private fun PrivacyPolicyLink(
                 uk.govuk.app.design.R.drawable.ic_external_link
             ),
             contentDescription = stringResource(R.string.analytics_consent_link_opens_in),
-            tint = GovUkTheme.colourScheme.textAndIcons.link
+            tint = GovUkTheme.colourScheme.textAndIcons.link,
+            modifier = Modifier.align(Alignment.CenterVertically)
         )
     }
 }

--- a/analytics/src/main/res/values/strings.xml
+++ b/analytics/src/main/res/values/strings.xml
@@ -10,6 +10,6 @@
     <string name="analytics_consent_stop">You can stop sharing these statistics at any time by changing your app settings.</string>
     <string name="analytics_consent_button_enable">Allow statistics sharing</string>
     <string name="analytics_consent_button_disable">Don\'t allow statistics sharing</string>
-    <string name="analytics_consent_privacy_policy">Read more about this in the privacy policy</string>
+    <string name="analytics_consent_privacy_policy">Read more about this in the privacy notice</string>
     <string name="analytics_consent_link_opens_in">Opens in web browser</string>
 </resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -11,11 +11,11 @@
     These statistics are anonymous and don’t contain any of
     your personal information.
   </string>
-  <string name="privacy_read_more">Read more about this in the privacy policy.</string>
+  <string name="privacy_read_more">Read more about this in the privacy notice.</string>
   <string name="share_setting">Share app usage statistics</string>
   <string name="link_opens_in">Opens in web browser</string>
   <string name="oss_licenses_title">Open source licenses</string>
   <string name="accessibility_title">Accessibility statement</string>
   <string name="terms_and_conditions_title">Terms and conditions</string>
-  <string name="privacy_policy_title">Privacy policy</string>
+  <string name="privacy_policy_title">Privacy notice</string>
 </resources>


### PR DESCRIPTION
# Update privacy policy wording

- Update all string occurrences of "privacy policy" to "privacy notice"
- Fix issue where Analytics Consent screen external link icon is pushed out of view by it's accompanying text

## JIRA ticket(s)
  - [GOVAPP-1019](https://govukverify.atlassian.net/browse/GOVUKAPP-1019)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=1-53780&node-type=canvas&t=ImDxEfyo7oT994ze-0)

### Before

| Analytics Consent | Settings |
|---|---|
| ![image](https://github.com/user-attachments/assets/5d2d8e1a-cbb6-42ff-a681-785c1e5e4830) | ![image](https://github.com/user-attachments/assets/33a707d0-6d23-4c23-85d1-7a198ce66abe) |

### After

| Analytics Consent | Settings |
|---|---|
| ![image](https://github.com/user-attachments/assets/f7105e8b-0c27-4940-9113-1ff648019b9a) | ![image](https://github.com/user-attachments/assets/0b6b2983-7250-4b5d-a3b3-cd7de1951a40) |
