### PR TITLE
Autocomplete select bug fix

### DIFF
--- a/feature/search/src/main/kotlin/uk/govuk/app/search/ui/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/ui/SearchScreen.kt
@@ -136,7 +136,14 @@ private fun SearchScreen(
                     )
 
                 is SearchUiState.Autocomplete ->
-                    SearchAutocomplete(it.searchTerm, it.suggestions, actions.onSearch)
+                    SearchAutocomplete(
+                        searchTerm = it.searchTerm,
+                        suggestions = it.suggestions,
+                        onSearch = {
+                            searchTerm = it
+                            actions.onSearch(it)
+                        }
+                    )
 
                 is SearchUiState.Results ->
                     SearchResults(it.searchTerm, it.searchResults, actions.onResultClick)


### PR DESCRIPTION
# Autocomplete select bug fix

When you click on an autocomplete suggestion it doesn't populate the search bar with the suggestion. Instead, it leaves what you've typed. For example: type `dog` and select the `dog breeding` suggestion - the search bar stays as `dog`.