### PR TITLE
GOVUKAPP-1075: Update search, previous search and autocomplete Google Analytics

### DIFF
--- a/analytics/src/main/kotlin/uk/govuk/app/analytics/AnalyticsClient.kt
+++ b/analytics/src/main/kotlin/uk/govuk/app/analytics/AnalyticsClient.kt
@@ -82,11 +82,15 @@ class AnalyticsClient @Inject constructor(
     }
 
     fun search(searchTerm: String) {
-        redactedEvent(name = "Search", inputString = searchTerm)
+        redactedEvent(name = "Search", type = "typed", inputString = searchTerm)
     }
 
     fun autocomplete(searchTerm: String) {
-        redactedEvent(name = "Autocomplete", inputString = searchTerm)
+        redactedEvent(name = "Search", type = "autocomplete", inputString = searchTerm)
+    }
+
+    fun history(searchTerm: String) {
+        redactedEvent(name = "Search", type = "history", inputString = searchTerm)
     }
 
     fun searchResultClick(text: String, url: String) {
@@ -130,10 +134,11 @@ class AnalyticsClient @Inject constructor(
         firebaseAnalyticsClient.setUserProperty("topics_customised", "true")
     }
 
-    private fun redactedEvent(name: String, inputString: String) {
+    private fun redactedEvent(name: String, type: String, inputString: String) {
         firebaseAnalyticsClient.logEvent(
             name,
             mapOf(
+                "type" to type,
                 "text" to inputString.redactPii()
             )
         )

--- a/analytics/src/test/kotlin/uk/govuk/app/analytics/AnalyticsClientTest.kt
+++ b/analytics/src/test/kotlin/uk/govuk/app/analytics/AnalyticsClientTest.kt
@@ -114,6 +114,7 @@ class AnalyticsClientTest {
             firebaseAnalyticClient.logEvent(
                 "Search",
                 mapOf(
+                    "type" to "typed",
                     "text" to "search term"
                 )
             )
@@ -128,6 +129,7 @@ class AnalyticsClientTest {
             firebaseAnalyticClient.logEvent(
                 "Search",
                 mapOf(
+                    "type" to "typed",
                     "text" to "search term [postcode]"
                 )
             )
@@ -142,6 +144,7 @@ class AnalyticsClientTest {
             firebaseAnalyticClient.logEvent(
                 "Search",
                 mapOf(
+                    "type" to "typed",
                     "text" to "search term [email]"
                 )
             )
@@ -156,6 +159,7 @@ class AnalyticsClientTest {
             firebaseAnalyticClient.logEvent(
                 "Search",
                 mapOf(
+                    "type" to "typed",
                     "text" to "search term [NI number]"
                 )
             )
@@ -168,8 +172,9 @@ class AnalyticsClientTest {
 
         verify {
             firebaseAnalyticClient.logEvent(
-                "Autocomplete",
+                "Search",
                 mapOf(
+                    "type" to "autocomplete",
                     "text" to "input"
                 )
             )
@@ -182,8 +187,9 @@ class AnalyticsClientTest {
 
         verify {
             firebaseAnalyticClient.logEvent(
-                "Autocomplete",
+                "Search",
                 mapOf(
+                    "type" to "autocomplete",
                     "text" to "input [postcode]"
                 )
             )
@@ -196,8 +202,9 @@ class AnalyticsClientTest {
 
         verify {
             firebaseAnalyticClient.logEvent(
-                "Autocomplete",
+                "Search",
                 mapOf(
+                    "type" to "autocomplete",
                     "text" to "input [email]"
                 )
             )
@@ -210,8 +217,69 @@ class AnalyticsClientTest {
 
         verify {
             firebaseAnalyticClient.logEvent(
-                "Autocomplete",
+                "Search",
                 mapOf(
+                    "type" to "autocomplete",
+                    "text" to "input [NI number]"
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Given a history search, then log event`() {
+        analyticsClient.history("input")
+
+        verify {
+            firebaseAnalyticClient.logEvent(
+                "Search",
+                mapOf(
+                    "type" to "history",
+                    "text" to "input"
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Given a history search with postcode, then redact and log event`() {
+        analyticsClient.history("input A1 1AA")
+
+        verify {
+            firebaseAnalyticClient.logEvent(
+                "Search",
+                mapOf(
+                    "type" to "history",
+                    "text" to "input [postcode]"
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Given a history search with email address, then redact and log event`() {
+        analyticsClient.history("input test@email.com")
+
+        verify {
+            firebaseAnalyticClient.logEvent(
+                "Search",
+                mapOf(
+                    "type" to "history",
+                    "text" to "input [email]"
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Given a history search with NI number, then redact and log event`() {
+        analyticsClient.history("input AA 00 00 00 A")
+
+        verify {
+            firebaseAnalyticClient.logEvent(
+                "Search",
+                mapOf(
+                    "type" to "history",
                     "text" to "input [NI number]"
                 )
             )

--- a/feature/search/src/main/kotlin/uk/govuk/app/search/SearchViewModel.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/SearchViewModel.kt
@@ -133,9 +133,18 @@ internal class SearchViewModel @Inject constructor(
     fun onAutocomplete(searchTerm: String) {
         if (searchTerm.length >= SearchConfig.AUTOCOMPLETE_MIN_LENGTH) {
             fetchAutocompleteSuggestions(searchTerm)
-            analyticsClient.autocomplete(searchTerm)
         } else {
             onClear()
         }
+    }
+
+    fun onAutocompleteResultClick(searchTerm: String) {
+        fetchSearchResults(searchTerm)
+        analyticsClient.autocomplete(searchTerm)
+    }
+
+    fun onPreviousSearchClick(searchTerm: String) {
+        fetchSearchResults(searchTerm)
+        analyticsClient.history(searchTerm)
     }
 }

--- a/feature/search/src/main/kotlin/uk/govuk/app/search/ui/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/ui/SearchScreen.kt
@@ -60,8 +60,16 @@ internal fun SearchRoute(
             onRemovePreviousSearch = { searchTerm ->
                 viewModel.onRemovePreviousSearch(searchTerm)
             },
+            onPreviousSearchClick = { searchTerm ->
+                keyboardController?.hide()
+                viewModel.onPreviousSearchClick(searchTerm)
+            },
             onAutocomplete = { searchTerm ->
                 viewModel.onAutocomplete(searchTerm)
+            },
+            onAutocompleteResultClick = { searchTerm ->
+                keyboardController?.hide()
+                viewModel.onAutocompleteResultClick(searchTerm)
             }
         ),
         modifier = modifier
@@ -78,6 +86,8 @@ private class SearchScreenActions(
     val onRemoveAllPreviousSearches: () -> Unit,
     val onRemovePreviousSearch: (String) -> Unit,
     val onAutocomplete: (String) -> Unit,
+    val onPreviousSearchClick: (String) -> Unit,
+    val onAutocompleteResultClick: (String) -> Unit,
 )
 
 @Composable
@@ -129,7 +139,7 @@ private fun SearchScreen(
                         previousSearches = it.previousSearches,
                         onClick = {
                             searchTerm = it
-                            actions.onSearch(it)
+                            actions.onPreviousSearchClick(it)
                         },
                         onRemoveAll = actions.onRemoveAllPreviousSearches,
                         onRemove = actions.onRemovePreviousSearch
@@ -141,7 +151,7 @@ private fun SearchScreen(
                         suggestions = it.suggestions,
                         onSearch = {
                             searchTerm = it
-                            actions.onSearch(it)
+                            actions.onAutocompleteResultClick(it)
                         }
                     )
 

--- a/feature/search/src/test/kotlin/uk/govuk/app/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/kotlin/uk/govuk/app/search/SearchViewModelTest.kt
@@ -81,12 +81,34 @@ class SearchViewModelTest {
         }
 
         @Test
-        fun `Given an autocomplete, then log analytics`() {
+        fun `Given an autocomplete API lookup, then we do not log analytics`() {
             viewModel.onAutocomplete(searchTerm)
+
+            runTest {
+                coVerify(exactly = 0) {
+                    analyticsClient.autocomplete(searchTerm)
+                }
+            }
+        }
+
+        @Test
+        fun `Given an autocomplete suggestion click, then log analytics`() {
+            viewModel.onAutocompleteResultClick(searchTerm)
 
             runTest {
                 coVerify {
                     analyticsClient.autocomplete(searchTerm)
+                }
+            }
+        }
+
+        @Test
+        fun `Given a previous search click, then log analytics`() {
+            viewModel.onPreviousSearchClick(searchTerm)
+
+            runTest {
+                coVerify {
+                    analyticsClient.history(searchTerm)
                 }
             }
         }


### PR DESCRIPTION
# GOVUKAPP-1075: Update search, previous search and autocomplete Google Analytics

Acceptance criteria

- When user inputs a search term into the search bar and clicks search, then a search event with type `typed` is fired. 
- When user clicks a search term from the autocomplete suggestions, then a search event with type `autocomplete` is fired. 
- When user clicks a search term from the previous searches list, then a search event with type `history` is fired

⚠️  Autocomplete API calls (all keystrokes equal to, or greater than AUTOCOMPLETE_MIN_LENGTH) do not fire an event.

## JIRA ticket(s)
  - [GOVAPP-1075](https://govukverify.atlassian.net/browse/GOVUKAPP-1075)

## Figma
  - N/A

## Video

https://github.com/user-attachments/assets/dde8faf8-c770-4ea2-b4b6-f5fdd3eb6162
