### PR TITLE
Bottom navigation selected icon colour bug fix

### DIFF
--- a/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/govuk/app/ui/GovUkApp.kt
@@ -220,7 +220,7 @@ private fun BottomNav(
                             .colors(
                                 selectedIconColor = GovUkTheme.colourScheme.textAndIcons.buttonPrimary,
                                 selectedTextColor = GovUkTheme.colourScheme.textAndIcons.link,
-                                indicatorColor = GovUkTheme.colourScheme.surfaces.buttonPrimary,
+                                indicatorColor = GovUkTheme.colourScheme.surfaces.primary,
                                 unselectedIconColor = GovUkTheme.colourScheme.textAndIcons.secondary,
                                 unselectedTextColor = GovUkTheme.colourScheme.textAndIcons.secondary,
                             )


### PR DESCRIPTION
# Bottom navigation selected icon colour bug fix

The bottom navigation selected icon colour should remained `Blue1` not `Green1`

## Screen shots 

| Before| After |
|---|---|
| ![light-after-page-6](https://github.com/user-attachments/assets/1b4167ce-a69f-42af-a6ab-5332be9841e8) | ![light-after-home](https://github.com/user-attachments/assets/fed3b774-88ba-40e8-aa64-654943de8399) |
| ![light-after-page-7](https://github.com/user-attachments/assets/4af474e4-a9d9-4bec-a6e7-3477f00fa30d) | ![light-after-settings](https://github.com/user-attachments/assets/f11b2e40-30a2-4b03-8f39-fbca3fa357a3) |
| ![dark-after-page-6](https://github.com/user-attachments/assets/da4f993d-b1f0-458d-99cd-93f3a7692da0) | ![dark-after-home](https://github.com/user-attachments/assets/15982656-caa8-4a35-b5a2-a26c357d45b4) |
| ![dark-after-page-7](https://github.com/user-attachments/assets/55292f0b-41d4-4f75-a971-b80ecdb6c1b4) | ![dark-after-settings](https://github.com/user-attachments/assets/004eedc8-12a7-4c27-9a1c-d14863ce98fa) |
