### PR TITLE
GOVUKAPP-1143: select_item event index is not represented correctly

### DIFF
--- a/analytics/src/main/kotlin/uk/govuk/app/analytics/AnalyticsClient.kt
+++ b/analytics/src/main/kotlin/uk/govuk/app/analytics/AnalyticsClient.kt
@@ -135,10 +135,11 @@ class AnalyticsClient @Inject constructor(
         firebaseAnalyticsClient.setUserProperty("topics_customised", "true")
     }
 
-    fun selectItemEvent(ecommerceEvent: EcommerceEvent) {
+    fun selectItemEvent(ecommerceEvent: EcommerceEvent, selectedItemIndex: Int) {
         logEcommerceEvent(
             event = FirebaseAnalytics.Event.SELECT_ITEM,
-            ecommerceEvent = ecommerceEvent
+            ecommerceEvent = ecommerceEvent,
+            selectedItemIndex = selectedItemIndex
         )
     }
 
@@ -207,9 +208,9 @@ class AnalyticsClient @Inject constructor(
         }
     }
 
-    private fun logEcommerceEvent(event: String, ecommerceEvent: EcommerceEvent) {
+    private fun logEcommerceEvent(event: String, ecommerceEvent: EcommerceEvent, selectedItemIndex: Int? = null) {
         if (isAnalyticsEnabled()) {
-            firebaseAnalyticsClient.logEcommerceEvent(event, ecommerceEvent)
+            firebaseAnalyticsClient.logEcommerceEvent(event, ecommerceEvent, selectedItemIndex)
         }
     }
 }

--- a/analytics/src/main/kotlin/uk/govuk/app/analytics/FirebaseAnalyticsClient.kt
+++ b/analytics/src/main/kotlin/uk/govuk/app/analytics/FirebaseAnalyticsClient.kt
@@ -31,7 +31,8 @@ class FirebaseAnalyticsClient @Inject constructor(
 
     fun logEcommerceEvent(
         event: String,
-        ecommerceEvent: EcommerceEvent
+        ecommerceEvent: EcommerceEvent,
+        selectedItemIndex: Int? = null
     ) {
         val bundle = Bundle()
 
@@ -42,7 +43,7 @@ class FirebaseAnalyticsClient @Inject constructor(
         val itemsArrayList = ArrayList<Bundle>()
         ecommerceEvent.items.forEachIndexed { index, item ->
             val itemsBundle = Bundle()
-            itemsBundle.putInt("index", index + 1)
+            itemsBundle.putInt("index", selectedItemIndex ?: index + 1)
             itemsBundle.putString(FirebaseAnalytics.Param.ITEM_NAME, item.itemName)
             itemsBundle.putString(FirebaseAnalytics.Param.ITEM_CATEGORY, item.itemCategory)
             itemsBundle.putString(FirebaseAnalytics.Param.LOCATION_ID, item.locationId)

--- a/analytics/src/test/kotlin/uk/govuk/app/analytics/AnalyticsClientTest.kt
+++ b/analytics/src/test/kotlin/uk/govuk/app/analytics/AnalyticsClientTest.kt
@@ -72,7 +72,8 @@ class AnalyticsClientTest {
                 itemListName = "Topics",
                 itemListId = "Benefits",
                 items = emptyList()
-            )
+            ),
+            selectedItemIndex = 42
         )
 
         verify(exactly = 0) {
@@ -89,7 +90,8 @@ class AnalyticsClientTest {
                 itemListName = "Topics",
                 itemListId = "Benefits",
                 items = emptyList()
-            )
+            ),
+            selectedItemIndex = 42
         )
 
         verify(exactly = 0) {
@@ -625,14 +627,18 @@ class AnalyticsClientTest {
             items = topicItems
         )
 
+        println(ecommerceEvent)
+
         analyticsClient.selectItemEvent(
-            ecommerceEvent = ecommerceEvent
+            ecommerceEvent = ecommerceEvent,
+            selectedItemIndex = 42
         )
 
         verify {
             firebaseAnalyticClient.logEcommerceEvent(
                 event = FirebaseAnalytics.Event.SELECT_ITEM,
-                ecommerceEvent = ecommerceEvent
+                ecommerceEvent = ecommerceEvent,
+                selectedItemIndex = 42
             )
         }
     }

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/AllStepByStepsViewModel.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/AllStepByStepsViewModel.kt
@@ -43,7 +43,8 @@ internal class AllStepByStepsViewModel @Inject constructor(
     fun onStepByStepClick(
         section: String,
         text: String,
-        url: String
+        url: String,
+        selectedItemIndex: Int
     ) {
         analyticsClient.buttonClick(
             text = text,
@@ -56,7 +57,8 @@ internal class AllStepByStepsViewModel @Inject constructor(
             title = text,
             section = section,
             text = text,
-            url = url
+            url = url,
+            selectedItemIndex = selectedItemIndex
         )
 
         viewModelScope.launch {
@@ -68,7 +70,8 @@ internal class AllStepByStepsViewModel @Inject constructor(
         section: String,
         text: String,
         title: String?,
-        url: String?
+        url: String?,
+        selectedItemIndex: Int
     ) {
         analyticsClient.selectItemEvent(
             ecommerceEvent = EcommerceEvent(
@@ -81,7 +84,8 @@ internal class AllStepByStepsViewModel @Inject constructor(
                         locationId = url ?: ""
                     )
                 )
-            )
+            ),
+            selectedItemIndex = selectedItemIndex
         )
     }
 

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/AllStepByStepsViewModel.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/AllStepByStepsViewModel.kt
@@ -93,7 +93,7 @@ internal class AllStepByStepsViewModel @Inject constructor(
         stepBySteps: List<TopicContent>,
         title: String
     ) {
-        var topicItems = mutableListOf<EcommerceEvent.Item>()
+        var topicItems = listOf<EcommerceEvent.Item>()
 
         if (stepBySteps.isNotEmpty()) {
             val stepByStepsTitle = "Step by step guides"
@@ -108,7 +108,7 @@ internal class AllStepByStepsViewModel @Inject constructor(
                         locationId = item.url
                     )
                 }
-            }.toMutableList()
+            }
         }
 
         analyticsClient.viewItemListEvent(

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/TopicViewModel.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/TopicViewModel.kt
@@ -75,7 +75,8 @@ internal class TopicViewModel @Inject constructor(
         title: String,
         section: String,
         text: String,
-        url: String
+        url: String,
+        selectedItemIndex: Int
     ) {
         analyticsClient.buttonClick(
             text = text,
@@ -88,7 +89,8 @@ internal class TopicViewModel @Inject constructor(
             title = title,
             section = section,
             text = text,
-            url = url
+            url = url,
+            selectedItemIndex = selectedItemIndex
         )
 
         viewModelScope.launch {
@@ -99,6 +101,7 @@ internal class TopicViewModel @Inject constructor(
     fun onSeeAllClick(
         section: String,
         text: String,
+        selectedItemIndex: Int
     ) {
         analyticsClient.buttonClick(
             text = text,
@@ -110,12 +113,14 @@ internal class TopicViewModel @Inject constructor(
             title = text,
             section = section,
             text = text,
-            url = null
+            url = null,
+            selectedItemIndex = selectedItemIndex
         )
     }
 
     fun onSubtopicClick(
-        text: String
+        text: String,
+        selectedItemIndex: Int
     ) {
         analyticsClient.buttonClick(
             text = text,
@@ -127,7 +132,8 @@ internal class TopicViewModel @Inject constructor(
             title = null,
             section = SUBTOPIC_SECTION,
             text = text,
-            url = null
+            url = null,
+            selectedItemIndex = selectedItemIndex
         )
     }
 
@@ -135,7 +141,8 @@ internal class TopicViewModel @Inject constructor(
         section: String,
         text: String,
         title: String?,
-        url: String?
+        url: String?,
+        selectedItemIndex: Int
     ) {
         analyticsClient.selectItemEvent(
             ecommerceEvent = EcommerceEvent(
@@ -148,7 +155,8 @@ internal class TopicViewModel @Inject constructor(
                         locationId = url ?: ""
                     )
                 )
-            )
+            ),
+            selectedItemIndex = selectedItemIndex
         )
     }
 

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/navigation/TopicsNavigation.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/navigation/TopicsNavigation.kt
@@ -53,7 +53,7 @@ fun NavGraphBuilder.topicsGraph(
 
             TopicRoute(
                 onBack = { navController.popBackStack() },
-                onExternalLink = { url -> launchExternalLink(context, url) },
+                onExternalLink = { url, _ -> launchExternalLink(context, url) },
                 onStepByStepSeeAll = { navController.navigate(TOPICS_ALL_STEP_BY_STEPS_ROUTE) },
                 onSubtopic = { ref -> navController.navigateToTopic(ref, true) },
                 modifier = modifier

--- a/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllStepByStepsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/govuk/app/topics/ui/AllStepByStepsScreen.kt
@@ -35,11 +35,12 @@ internal fun AllStepByStepRoute(
         stepBySteps = stepBySteps,
         onPageView = { title -> viewModel.onPageView(stepBySteps, title) },
         onBack = onBack,
-        onExternalLink = { section, text, url ->
+        onExternalLink = { section, text, url, selectedItemIndex ->
             viewModel.onStepByStepClick(
                 section = section,
                 text = text,
-                url = url
+                url = url,
+                selectedItemIndex = selectedItemIndex
             )
             onClick(url)
         },
@@ -52,7 +53,7 @@ private fun AllStepByStepsScreen(
     stepBySteps: List<TopicContent>,
     onPageView: (String) -> Unit,
     onBack: () -> Unit,
-    onExternalLink: (section: String, text: String, url: String) -> Unit,
+    onExternalLink: (section: String, text: String, url: String, selectedItemIndex: Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier.fillMaxSize()) {
@@ -73,9 +74,10 @@ private fun AllStepByStepsScreen(
             }
 
             stepBySteps(
+                selectedItemIndex = 1,
                 stepBySteps = stepBySteps,
-                onClick = { text, url ->
-                    onExternalLink(title, text, url)
+                onClick = { text, url, selectedItemIndex ->
+                    onExternalLink(title, text, url, selectedItemIndex)
                 }
             )
         }
@@ -83,13 +85,14 @@ private fun AllStepByStepsScreen(
 }
 
 private fun LazyListScope.stepBySteps(
+    selectedItemIndex: Int,
     stepBySteps: List<TopicContent>,
-    onClick: (text:String, url:String) -> Unit
+    onClick: (text: String, url: String, selectedItemIndex: Int) -> Unit
 ) {
     itemsIndexed(stepBySteps) { index, content ->
         ExternalLinkListItem(
             title = content.title,
-            onClick = { onClick(content.title, content.url) },
+            onClick = { onClick(content.title, content.url, selectedItemIndex + index) },
             isFirst = index == 0,
             isLast = index == stepBySteps.lastIndex
         )

--- a/feature/topics/src/test/kotlin/uk/govuk/app/topics/AllStepByStepsViewModelTest.kt
+++ b/feature/topics/src/test/kotlin/uk/govuk/app/topics/AllStepByStepsViewModelTest.kt
@@ -136,7 +136,8 @@ class AllStepByStepsViewModelTest {
         viewModel.onStepByStepClick(
             section = "section",
             text = "text",
-            url = "url"
+            url = "url",
+            selectedItemIndex = 42
         )
 
         verify {
@@ -156,7 +157,8 @@ class AllStepByStepsViewModelTest {
         viewModel.onStepByStepClick(
             section = "section",
             text = "text",
-            url = "url"
+            url = "url",
+            selectedItemIndex = 42
         )
 
         verify {
@@ -171,7 +173,8 @@ class AllStepByStepsViewModelTest {
                             locationId = "url"
                         )
                     )
-                )
+                ),
+                selectedItemIndex = 42
             )
         }
     }
@@ -183,7 +186,8 @@ class AllStepByStepsViewModelTest {
         viewModel.onStepByStepClick(
             section = "section",
             text = "text",
-            url = "url"
+            url = "url",
+            selectedItemIndex = 42
         )
 
         coVerify {

--- a/feature/topics/src/test/kotlin/uk/govuk/app/topics/TopicViewModelTest.kt
+++ b/feature/topics/src/test/kotlin/uk/govuk/app/topics/TopicViewModelTest.kt
@@ -227,7 +227,8 @@ class TopicViewModelTest {
             section = "section",
             text = "text",
             url = "url",
-            title = "title"
+            title = "title",
+            selectedItemIndex = 42
         )
 
         verify {
@@ -250,7 +251,8 @@ class TopicViewModelTest {
             section = "section",
             text = "text",
             url = "url",
-            title = "title"
+            title = "title",
+            selectedItemIndex = 42
         )
 
         verify {
@@ -265,7 +267,8 @@ class TopicViewModelTest {
                             locationId = "url"
                         )
                     )
-                )
+                ),
+                selectedItemIndex = 42
             )
         }
     }
@@ -280,7 +283,8 @@ class TopicViewModelTest {
             section = "section",
             text = "text",
             url = "url",
-            title = "title"
+            title = "title",
+            selectedItemIndex = 42
         )
 
         coVerify {
@@ -297,6 +301,7 @@ class TopicViewModelTest {
         viewModel.onSeeAllClick(
             section = "section",
             text = "text",
+            selectedItemIndex = 42
         )
 
         verify {
@@ -314,7 +319,7 @@ class TopicViewModelTest {
 
         val viewModel = TopicViewModel(topicsRepo, analyticsClient, visited, savedStateHandle)
 
-        viewModel.onSubtopicClick("text")
+        viewModel.onSubtopicClick("text", selectedItemIndex = 42)
 
         verify {
             analyticsClient.buttonClick(
@@ -331,7 +336,7 @@ class TopicViewModelTest {
 
         val viewModel = TopicViewModel(topicsRepo, analyticsClient, visited, savedStateHandle)
 
-        viewModel.onSubtopicClick("text")
+        viewModel.onSubtopicClick("text", selectedItemIndex = 42)
 
         verify {
             analyticsClient.selectItemEvent(
@@ -345,7 +350,8 @@ class TopicViewModelTest {
                             locationId = ""
                         )
                     )
-                )
+                ),
+                selectedItemIndex = 42
             )
         }
     }


### PR DESCRIPTION
# GOVUKAPP-1143: select_item event index is not represented correctly

Fixes an issue where the `select_item` event `index` value is not represented correctly. It should be the position of the item that was clicked (in the previous `visited_item_list` for example), and not its position in the result set (which would always be 1).

This requirement was initially missing in the ticket, and did not surface in conversations with performance analysts.

## JIRA ticket(s)
  - [GOVUKAPP-1143](https://govukverify.atlassian.net/browse/GOVUKAPP-1143)

## Example Events

### Before
```shell
name=select_item,
params=Bundle[
  {
    item_list_name=Topics,
    item_list_id=Benefits,
    items=[
      Bundle[
        {
          item_name=Universal Credit,
          index=1,
          item_category=Popular pages in this topic,
          location_id=https://www.gov.uk/universal-credit
        }
      ]
    ],
    results=1
  }
```

## After
```shell
name=select_item,
params=Bundle[
  {
    item_list_name=Topics,
    item_list_id=Benefits,
    items=[
      Bundle[
        {
          item_name=Universal Credit,
          index=4,
          item_category=Popular pages in this topic,
          location_id=https://www.gov.uk/universal-credit
        }
      ]
    ],
    results=1
  }
]
```

[GOVUKAPP-1143]: https://govukverify.atlassian.net/browse/GOVUKAPP-1143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ