### PR TITLE
GOVUKAPP-1206: Update delete text colour in delete previous searches dialog

### DIFF
--- a/feature/search/src/main/kotlin/uk/govuk/app/search/ui/PreviousSearches.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/ui/PreviousSearches.kt
@@ -179,7 +179,7 @@ private fun RemoveAllConfirmationDialog(
             ) {
                 BodyRegularLabel(
                     text = stringResource(R.string.remove_confirmation_dialog_button),
-                    color = GovUkTheme.colourScheme.textAndIcons.buttonRemove
+                    color = GovUkTheme.colourScheme.textAndIcons.buttonDestructive
                 )
             }
         },


### PR DESCRIPTION
# GOVUKAPP-1206: Update delete text colour in delete previous searches dialog

`Delete` in the "Delete previous searches?" dialog was `buttonRemove` or `Red1` (D4351C) in light and dark mode. 

This has now been changed to `buttonDestructive`. So is now `RedPrimary` (CA3535) in light mode and `RedAccent` (FF5E5E) in dark mode.

## JIRA ticket(s)
  - [GOVUKAPP-1206](https://govukverify.atlassian.net/browse/GOVUKAPP-1206)

## Screen shots

| Before | After |
|---|---|
|   |   |
| ![before-light](https://github.com/user-attachments/assets/43e0b623-9fdb-4145-9b31-e7ca20575273) | ![after-light](https://github.com/user-attachments/assets/c1bcbb1a-4449-4a89-a307-4198037d28fd) |
| ![before-dark](https://github.com/user-attachments/assets/7dd9658a-4c56-4bf4-861b-b2b87433c3ef) | ![after-dark](https://github.com/user-attachments/assets/787045f0-1e54-4be6-ab86-32ad5df711c6) |

[GOVUKAPP-1206]: https://govukverify.atlassian.net/browse/GOVUKAPP-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ