### PR TITLE
GOVUKAPP-1099 Homepage notification upsell talkback fix

### DIFF
--- a/feature/search/src/main/kotlin/uk/govuk/app/search/ui/PreviousSearches.kt
+++ b/feature/search/src/main/kotlin/uk/govuk/app/search/ui/PreviousSearches.kt
@@ -156,7 +156,7 @@ private fun PreviousSearch(
             ) {
                 Icon(
                     imageVector = Icons.Filled.Clear,
-                    contentDescription = stringResource(R.string.content_desc_remove),
+                    contentDescription = stringResource(R.string.content_desc_remove_from_search_history),
                     modifier = Modifier.size(18.dp),
                     tint = GovUkTheme.colourScheme.textAndIcons.trailingIcon
                 )

--- a/feature/search/src/main/res/values/strings.xml
+++ b/feature/search/src/main/res/values/strings.xml
@@ -14,6 +14,6 @@
     <string name="remove_confirmation_dialog_message">Permanently delete all your previous searches</string>
     <string name="content_desc_delete_all">Delete all previous searches</string>
     <string name="content_desc_search">search</string>
-    <string name="content_desc_remove">Remove from search history</string>
+    <string name="content_desc_remove_from_search_history">Remove from search history</string>
     <string name="search_autocomplete_heading">Suggested searches</string>
 </resources>


### PR DESCRIPTION
# Homepage notification upsell talkback fix

Amend duplicated content description string names in 2 modules to fix incorrect string being used

## JIRA ticket(s)
  - [GOVUKAPP-1099](https://govukverify.atlassian.net/browse/GOVUKAPP-1099)

[GOVUKAPP-1099]: https://govukverify.atlassian.net/browse/GOVUKAPP-1099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ