### PR TITLE
Fixes a bug where local authorities are not showing in the app

### DIFF
--- a/feature/local/consumer-rules.pro
+++ b/feature/local/consumer-rules.pro
@@ -3,9 +3,6 @@
   @com.google.gson.annotations.SerializedName <fields>;
 }
 
--keep class uk.gov.govuk.local.data.remote.model.Address
--keep class uk.gov.govuk.local.data.remote.model.ApiResponse
--keep class uk.gov.govuk.local.data.remote.model.ApiResponse.LocalResponse
--keep class uk.gov.govuk.local.data.remote.model.ApiResponse.AddressListResponse
--keep class uk.gov.govuk.local.data.remote.model.ApiResponse.MessageResponse
--keep class uk.gov.govuk.local.data.remote.model.LocalAuthority
+-keep class uk.govuk.app.local.data.remote.model.Address
+-keep class uk.govuk.app.local.data.remote.model.ApiResponse
+-keep class uk.govuk.app.local.data.remote.model.LocalAuthority

--- a/feature/local/src/main/kotlin/uk/govuk/app/local/LocalViewModel.kt
+++ b/feature/local/src/main/kotlin/uk/govuk/app/local/LocalViewModel.kt
@@ -106,10 +106,10 @@ internal class LocalViewModel @Inject constructor(
                 }
 
                 is DeviceOffline -> {
-                    println("Device offline: $response")
+                    println(response)
                 }
 
-                else -> println("Another Error: $response")
+                else -> println(response)
             }
         }
     }

--- a/feature/local/src/main/kotlin/uk/govuk/app/local/data/remote/model/LocalAuthority.kt
+++ b/feature/local/src/main/kotlin/uk/govuk/app/local/data/remote/model/LocalAuthority.kt
@@ -7,5 +7,5 @@ data class LocalAuthority(
     @SerializedName("homepage_url") val homePageUrl: String,
     @SerializedName("tier") val tier: String,
     @SerializedName("slug") val slug: String,
-    val parent: LocalAuthority? = null
+    @SerializedName("parent") val parent: LocalAuthority? = null
 )


### PR DESCRIPTION
This is mostly due to the local authority parent and consumer-rules.pro file paths being incorrect and the local authority parent not being serialised.