### PR TITLE
GOVUKAPP-1479 Update font size for "off" button

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
@@ -113,17 +113,17 @@ fun InternalLinkListItem(
             MediumHorizontalSpacer()
 
             status?.let {
-                FootnoteRegularLabel(
+                BodyRegularLabel(
                     text = it,
-                    Modifier.padding(horizontal = GovUkTheme.spacing.medium)
+                    color = GovUkTheme.colourScheme.textAndIcons.link
+                )
+            } ?: run {
+                Icon(
+                    painter = painterResource(R.drawable.ic_chevron),
+                    contentDescription = null,
+                    tint = GovUkTheme.colourScheme.textAndIcons.icon
                 )
             }
-
-            Icon(
-                painter = painterResource(R.drawable.ic_chevron),
-                contentDescription = null,
-                tint = GovUkTheme.colourScheme.textAndIcons.icon
-            )
         }
     }
 }


### PR DESCRIPTION
# Update font size for "off" button 

- Update the notifications status font in settings.
- Remove the chevron in notifications in settings.

## JIRA ticket(s)
  - [GOVUKAPP-1479](https://govukverify.atlassian.net/browse/GOVUKAPP-1479)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs)

## Screen shots

| Before | After |
|--------|-------|
| ![Screenshot_1744290975](https://github.com/user-attachments/assets/6f9be823-26ab-4cbc-845e-b6bd38b7a628) | ![Screenshot_1744290490](https://github.com/user-attachments/assets/0d61ac56-3583-4de3-84b2-f46abe93e883) |

[GOVUKAPP-1479]: https://govukverify.atlassian.net/browse/GOVUKAPP-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ