### PR TITLE
GOVUKAPP-1480 Add back button behaviour for notifications education screen

### DIFF
--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsOnboardingScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsOnboardingScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.window.core.layout.WindowHeightSizeClass
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import uk.gov.govuk.design.ui.component.ChildPageHeader
 import uk.gov.govuk.design.ui.component.HorizontalButtonGroup
 import uk.gov.govuk.design.ui.component.ListDivider
 import uk.gov.govuk.design.ui.component.OnboardingSlide
@@ -92,6 +93,11 @@ internal fun NotificationsOnboardingNoSkipRoute(
                 OnboardingScreen(
                     onPageView = { viewModel.onPageView() },
                     modifier = modifier,
+                    header = {
+                        ChildPageHeader(
+                            onBack = notificationsOnboardingCompleted
+                        )
+                    },
                     footer = {
                         OnboardingScreenFooterNoSkip(
                             onContinue = {
@@ -123,6 +129,7 @@ private fun EmptyScreen() {
 private fun OnboardingScreen(
     onPageView: () -> Unit,
     modifier: Modifier = Modifier,
+    header: (@Composable () -> Unit)? = null,
     footer: @Composable () -> Unit
 ) {
     LaunchedEffect(Unit) {
@@ -130,6 +137,8 @@ private fun OnboardingScreen(
     }
 
     Column(modifier.fillMaxWidth()) {
+        header?.invoke()
+
         OnboardingSlide(
             title = R.string.onboarding_screen_title,
             body = R.string.onboarding_screen_body,
@@ -209,5 +218,8 @@ private fun OnboardingScreenPreview() {
 @Preview
 @Composable
 private fun OnboardingScreenNoSkipPreview() {
-    OnboardingScreen({}, footer = { OnboardingScreenFooterNoSkip({}) })
+    OnboardingScreen(
+        {},
+        header = { ChildPageHeader(onBack = {}) },
+        footer = { OnboardingScreenFooterNoSkip({}) })
 }


### PR DESCRIPTION
# Add back button behaviour for notifications education screen

Add a header with back button to notifications onboarding screen

## JIRA ticket(s)
  - [GOVUKAPP-1480](https://govukverify.atlassian.net/browse/GOVUKAPP-1480)

## Figma
  - [Figma board](https://www.figma.com/design/N4v2GPQhwZ7DwhqucyJqlu/GOV.UK-apps-and-notifications?node-id=22321-13370&t=ogZnHZYMfvcnFQ0e-1)

## Screen shots

| Before | After |
|--------|-------|
| ![Screenshot_1744367028](https://github.com/user-attachments/assets/048e0ed7-de6a-49bd-9cdf-c606aa92cadc) | ![Screenshot_1744366985](https://github.com/user-attachments/assets/0facbb96-dbb3-4b1f-aa5a-028fc4d39dce) |

[GOVUKAPP-1480]: https://govukverify.atlassian.net/browse/GOVUKAPP-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ