### PR TITLE
Update colour tokens to bring them in-line with Figma

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
@@ -84,7 +84,7 @@ data class GovUkColourScheme(
         val logo: Color,
         val logoDot: Color,
         val logoCrown: Color,
-        val localIcon: Color
+        val iconGreen: Color
     )
 
     data class Surfaces(
@@ -117,9 +117,9 @@ data class GovUkColourScheme(
         val toggleHandle: Color,
         val icon: Color,
         val homeHeader: Color,
-        val localBackground: Color,
+        val cardGreen: Color,
         val textFieldBackground: Color,
-        val highlightedTextField: Color
+        val textFieldHighlighted: Color
     )
 
     data class Strokes(
@@ -132,7 +132,7 @@ data class GovUkColourScheme(
         val switchOn: Color,
         val switchOff: Color,
         val buttonCompactHighlight: Color,
-        val localBorder: Color,
+        val cardGreen: Color,
         val textFieldCursor: Color
     )
 }
@@ -166,7 +166,7 @@ internal val LightColorScheme = GovUkColourScheme(
         logo = White,
         logoDot = TealAccent,
         logoCrown = BlackLighter50,
-        localIcon = GreenDarker25
+        iconGreen = GreenDarker25
     ),
     surfaces = Surfaces(
         background = White,
@@ -198,9 +198,9 @@ internal val LightColorScheme = GovUkColourScheme(
         toggleHandle = White,
         icon = BluePrimary,
         homeHeader = BluePrimary,
-        localBackground = GreenLighter95,
+        cardGreen = GreenLighter95,
         textFieldBackground = Grey60,
-        highlightedTextField = BlueLighter50
+        textFieldHighlighted = BlueLighter50
     ),
     strokes = Strokes(
         fixedContainer = BlackAlpha30,
@@ -212,7 +212,7 @@ internal val LightColorScheme = GovUkColourScheme(
         switchOn = GreenPrimary,
         switchOff = BlackLighter50,
         buttonCompactHighlight = BlueLighter25,
-        localBorder = GreenLighter50,
+        cardGreen = GreenLighter50,
         textFieldCursor = Grey700
     )
 )
@@ -246,7 +246,7 @@ internal val DarkColorScheme = GovUkColourScheme(
         logo = White,
         logoDot = TealAccent,
         logoCrown = BlackLighter50,
-        localIcon = White
+        iconGreen = White
     ),
     surfaces = Surfaces(
         background = Black,
@@ -278,9 +278,9 @@ internal val DarkColorScheme = GovUkColourScheme(
         toggleHandle = White,
         icon = BlueAccent,
         homeHeader = BlueDarker50,
-        localBackground = GreenDarker50,
+        cardGreen = GreenDarker50,
         textFieldBackground = Grey800,
-        highlightedTextField = BlueDarker25
+        textFieldHighlighted = BlueDarker25
     ),
     strokes = Strokes(
         fixedContainer = WhiteAlpha30,
@@ -292,7 +292,7 @@ internal val DarkColorScheme = GovUkColourScheme(
         switchOn = GreenPrimary,
         switchOff = BlackLighter50,
         buttonCompactHighlight = BlueDarker25,
-        localBorder = GreenLighter25,
+        cardGreen = GreenLighter25,
         textFieldCursor = Grey300
     )
 )
@@ -327,7 +327,7 @@ internal val LocalColourScheme = staticCompositionLocalOf {
             logo = Color.Unspecified,
             logoDot = Color.Unspecified,
             logoCrown = Color.Unspecified,
-            localIcon = Color.Unspecified
+            iconGreen = Color.Unspecified
         ),
         surfaces = Surfaces(
             background = Color.Unspecified,
@@ -359,9 +359,9 @@ internal val LocalColourScheme = staticCompositionLocalOf {
             toggleHandle = Color.Unspecified,
             icon = Color.Unspecified,
             homeHeader = Color.Unspecified,
-            localBackground = Color.Unspecified,
+            cardGreen = Color.Unspecified,
             textFieldBackground = Color.Unspecified,
-            highlightedTextField = Color.Unspecified
+            textFieldHighlighted = Color.Unspecified
         ),
         strokes = Strokes(
             fixedContainer = Color.Unspecified,
@@ -373,7 +373,7 @@ internal val LocalColourScheme = staticCompositionLocalOf {
             switchOn = Color.Unspecified,
             switchOff = Color.Unspecified,
             buttonCompactHighlight = Color.Unspecified,
-            localBorder = Color.Unspecified,
+            cardGreen = Color.Unspecified,
             textFieldCursor = Color.Unspecified
         )
     )

--- a/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalEntryScreen.kt
+++ b/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalEntryScreen.kt
@@ -150,8 +150,8 @@ private fun LocalEntryScreen(
 //                        focusedSupportingTextColor = Color.Green,
                     focusedTextColor = GovUkTheme.colourScheme.textAndIcons.primary,
                     selectionColors = TextSelectionColors(
-                        handleColor = GovUkTheme.colourScheme.surfaces.highlightedTextField,
-                        backgroundColor = GovUkTheme.colourScheme.surfaces.highlightedTextField
+                        handleColor = GovUkTheme.colourScheme.surfaces.textFieldHighlighted,
+                        backgroundColor = GovUkTheme.colourScheme.surfaces.textFieldHighlighted
                     ),
                     unfocusedContainerColor = GovUkTheme.colourScheme.surfaces.textFieldBackground,
                     unfocusedIndicatorColor = GovUkTheme.colourScheme.textAndIcons.secondary,

--- a/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalWidget.kt
+++ b/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalWidget.kt
@@ -52,10 +52,10 @@ private fun LocalNavigationCard(
 
     OutlinedCard(
         modifier = modifier,
-        colors = CardDefaults.cardColors(containerColor = GovUkTheme.colourScheme.surfaces.localBackground),
+        colors = CardDefaults.cardColors(containerColor = GovUkTheme.colourScheme.surfaces.cardGreen),
         border = BorderStroke(
             width = 1.dp,
-            color = GovUkTheme.colourScheme.strokes.localBorder
+            color = GovUkTheme.colourScheme.strokes.cardGreen
         )
     ) {
         Column(
@@ -75,7 +75,7 @@ private fun LocalNavigationCard(
                 Title3BoldLabel(stringResource(R.string.local_section_title))
             }
             SmallVerticalSpacer()
-            HorizontalDivider(color = GovUkTheme.colourScheme.strokes.localBorder)
+            HorizontalDivider(color = GovUkTheme.colourScheme.strokes.cardGreen)
             MediumVerticalSpacer()
             Row(
                 modifier = Modifier
@@ -88,7 +88,7 @@ private fun LocalNavigationCard(
                     painterResource(R.drawable.outline_pin_drop_24),
                     contentDescription = null,
                     modifier = Modifier.size(40.dp),
-                    tint = GovUkTheme.colourScheme.textAndIcons.localIcon
+                    tint = GovUkTheme.colourScheme.textAndIcons.iconGreen
                 )
                 SmallHorizontalSpacer()
                 Column(
@@ -106,7 +106,7 @@ private fun LocalNavigationCard(
                 Icon(
                     painterResource(uk.gov.govuk.design.R.drawable.ic_chevron),
                     contentDescription = null,
-                    tint = GovUkTheme.colourScheme.textAndIcons.localIcon
+                    tint = GovUkTheme.colourScheme.textAndIcons.iconGreen
                 )
             }
         }


### PR DESCRIPTION
# Update colour tokens to bring them in-line with Figma

Renames, where needed, the colour tokens used and applies the appropriate section and Android naming convention.

### text and icons tokens:
  - localIcon renamed to iconGreen

### surfaces tokens:
  - localBackground renamed to cardGreen
  - textFieldBackground no change needed
  - highlightedTextField renamed to textFieldHighlighted

### strokes tokens:
  - localBorder renamed to cardGreen
  - textFieldCursor no change needed

## Figma
  - [Figma board](https://www.figma.com/design/N4v2GPQhwZ7DwhqucyJqlu/GOV.UK-apps-and-notifications?node-id=20393-21993&p=f&t=JMkRrXdgeNT0PUsI-0)
