### PR TITLE
Home widget edit button fix

### DIFF
--- a/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalWidget.kt
+++ b/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalWidget.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -83,10 +82,11 @@ private fun LocalAuthorityCard(
         ) {
             Title3BoldLabel(
                 text = stringResource(R.string.local_widget_title),
-                modifier = Modifier.semantics { heading() }
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = GovUkTheme.spacing.large)
+                    .semantics { heading() }
             )
-
-            Spacer(Modifier.weight(1f))
 
             val editButtonText = stringResource(R.string.local_edit_button)
             val editButtonAltText = stringResource(R.string.local_edit_button_alt_text)

--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/widget/TopicsWidget.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/widget/TopicsWidget.kt
@@ -2,7 +2,6 @@ package uk.gov.govuk.topics.ui.widget
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.TextButton
@@ -83,10 +82,11 @@ private fun TopicsWidgetContent(
             }
             Title3BoldLabel(
                 text = title,
-                modifier = Modifier.semantics { heading() }
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = GovUkTheme.spacing.large)
+                    .semantics { heading() }
             )
-
-            Spacer(Modifier.weight(1f))
 
             if (!uiState.isError) {
                 val editButtonText = stringResource(R.string.editButton)


### PR DESCRIPTION
Fix for edit button on topics and local widget when font and display size is increased

## Screen shots

# Before 
![Screenshot_20250417_123246](https://github.com/user-attachments/assets/3dcf3d42-45a0-40cc-8cf1-98f0fecf2e37)

# After   
![Screenshot_20250417_123149](https://github.com/user-attachments/assets/d97030dd-235c-454f-b0e2-ce2905453fc6)

