### PR TITLE
GOVUKAPP-1523 Notification deep links that cannot be parsed

### DIFF
--- a/app/src/androidTest/kotlin/uk/gov/govuk/MainActivityTest.kt
+++ b/app/src/androidTest/kotlin/uk/gov/govuk/MainActivityTest.kt
@@ -54,23 +54,6 @@ class MainActivityTest {
     }
 
     @Test
-    fun given_the_MainActivity_is_launched_When_onCreate_is_called_then_the_intentFlow_has_a_cached_value() {
-        val scenario = ActivityScenario.launch<MainActivity>(intent)
-        scenario.onActivity { activity ->
-            runTest {
-                val deferredCacheSize = async {
-                    activity.intentFlow.replayCache.size
-                }
-                val deferredIntent = async {
-                    activity.intentFlow.first()
-                }
-                assertEquals(1, deferredCacheSize.await())
-                assertEquals(activity.intent, deferredIntent.await())
-            }
-        }
-    }
-
-    @Test
     fun given_the_MainActivity_is_launched_then_recreated_When_onCreate_is_called_then_the_intentFlow_has_an_empty_cache() {
         val scenario = ActivityScenario.launch<MainActivity>(intent)
         scenario.recreate()

--- a/app/src/main/kotlin/uk/gov/govuk/MainActivity.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/MainActivity.kt
@@ -19,15 +19,13 @@ import uk.gov.govuk.ui.GovUkApp
 class MainActivity : ComponentActivity() {
 
     private val _intentFlow: MutableSharedFlow<Intent> =
-        MutableSharedFlow(replay = 1, extraBufferCapacity = 1)
+        MutableSharedFlow(replay = 1)
     internal val intentFlow = _intentFlow.asSharedFlow()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setIntentFlags()
-
-        emitIntent(savedInstanceState)
 
         setContent {
             GovUkTheme {
@@ -52,12 +50,5 @@ class MainActivity : ComponentActivity() {
         // FLAG_ACTIVITY_CLEAR_TASK prevents activity recreation when app is started from a deep link.
         // It must be used in conjunction with FLAG_ACTIVITY_NEW_TASK.
         intent.flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
-    }
-
-    private fun emitIntent(savedInstanceState: Bundle?) {
-        // Only emit intent when app launched from cold so deep links only ever run once
-        savedInstanceState ?: run {
-            _intentFlow.tryEmit(intent)
-        }
     }
 }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsClient.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsClient.kt
@@ -2,6 +2,7 @@ package uk.gov.govuk.notifications
 
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import androidx.core.net.toUri
 import com.onesignal.OneSignal
@@ -50,14 +51,14 @@ class NotificationsClient @Inject constructor() {
     internal fun handleAdditionalData(
         context: Context,
         additionalDataJson: JSONObject?,
-        intent: Intent = Intent(Intent.ACTION_VIEW)
+        intent: Intent? = context.packageManager.getLaunchIntentForPackage(context.packageName)
     ) {
-        additionalDataJson.asAdditionalData()?.let { additionalData ->
-            intent.apply {
-                data = additionalData.deepLink.toUri()
-                flags = FLAG_ACTIVITY_NEW_TASK
-            }
-            context.startActivity(intent)
+        // If additional data couldn't be parsed, send an empty Uri for the app to handle
+        val deepLink = additionalDataJson.asAdditionalData()?.deepLink ?: ""
+        intent?.let {
+            it.data = deepLink.toUri()
+            it.flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
+            context.startActivity(it)
         }
     }
 }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsClient.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsClient.kt
@@ -53,9 +53,9 @@ class NotificationsClient @Inject constructor() {
         additionalDataJson: JSONObject?,
         intent: Intent? = context.packageManager.getLaunchIntentForPackage(context.packageName)
     ) {
-        // If additional data couldn't be parsed, send an empty Uri for the app to handle
-        val deepLink = additionalDataJson.asAdditionalData()?.deepLink ?: ""
         intent?.let {
+            // If additional data couldn't be parsed, send an empty Uri for the app to handle
+            val deepLink = additionalDataJson.asAdditionalData()?.deepLink ?: ""
             it.data = deepLink.toUri()
             it.flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
             context.startActivity(it)

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsClientTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsClientTest.kt
@@ -2,6 +2,7 @@ package uk.gov.govuk.notifications
 
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.net.Uri
 import com.onesignal.OneSignal
@@ -105,9 +106,11 @@ class NotificationsClientTest {
 
     @Test
     fun `Given we have a notifications client, when add click listener is called, then the correct functions are called`() {
+        val uri = mockk<Uri>()
         val event = mockk<INotificationClickEvent>()
         val notification = mockk<INotification>()
         val clickListener = slot<INotificationClickListener>()
+        every { Uri.parse("") } returns uri
         every { event.notification.additionalData } returns null
         every { event.notification.additionalData.toString() } returns ""
         every { event.notification } returns notification
@@ -125,7 +128,7 @@ class NotificationsClientTest {
             verify(exactly = 1) {
                 OneSignal.Notifications.addClickListener(any())
 
-                notificationsClient.handleAdditionalData(context, notification.additionalData)
+                notificationsClient.handleAdditionalData(context, notification.additionalData, null)
             }
         }
     }
@@ -141,8 +144,8 @@ class NotificationsClientTest {
         every { Uri.parse("scheme://host") } returns uri
         every { intent.setData(uri) } returns intent
         every { intent.data } returns uri
-        every { intent.setFlags(FLAG_ACTIVITY_NEW_TASK) } returns intent
-        every { intent.flags } returns FLAG_ACTIVITY_NEW_TASK
+        every { intent.setFlags(FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK) } returns intent
+        every { intent.flags } returns (FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK)
         every { additionalData.toString() } returns "{\"deeplink\":\"scheme://host\"}"
 
         runTest {
@@ -150,7 +153,7 @@ class NotificationsClientTest {
 
             assertEquals("scheme", intent.data?.scheme)
             assertEquals("host", intent.data?.host)
-            assertEquals(FLAG_ACTIVITY_NEW_TASK, intent.flags)
+            assertEquals(FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK, intent.flags)
 
             verify(exactly = 1) {
                 context.startActivity(intent)
@@ -159,26 +162,55 @@ class NotificationsClientTest {
     }
 
     @Test
-    fun `Given we have a notifications client, when handle additional data function is called with invalid additional data, then a new activity is not started`() {
+    fun `Given we have a notifications client, when handle additional data function is called with invalid additional data, then start activity is called with expected data`() {
+        val uri = mockk<Uri>()
         val intent = spyk<Intent>()
         val additionalData = mockk<JSONObject>()
 
+        every { Uri.parse("") } returns uri
+        every { intent.setData(uri) } returns intent
+        every { intent.data } returns uri
+        every { intent.setFlags(FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK) } returns intent
         every { additionalData.toString() } returns ""
 
         runTest {
             notificationsClient.handleAdditionalData(context, additionalData, intent)
 
-            verify(exactly = 0) {
+            assertEquals(uri, intent.data)
+
+            verify(exactly = 1) {
                 context.startActivity(intent)
             }
         }
     }
 
     @Test
-    fun `Given we have a notifications client, when handle additional data function is called and additional data is null, then start activity is not called`() {
+    fun `Given we have a notifications client, when handle additional data function is called and additional data is null, then start activity is called with expected data`() {
+        val uri = mockk<Uri>()
         val intent = spyk<Intent>()
 
+        every { Uri.parse("") } returns uri
+        every { intent.setData(uri) } returns intent
+        every { intent.data } returns uri
+        every { intent.setFlags(FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK) } returns intent
+
         val additionalData: JSONObject? = null
+
+        runTest {
+            notificationsClient.handleAdditionalData(context, additionalData, intent)
+
+            assertEquals(uri, intent.data)
+
+            verify(exactly = 1) {
+                context.startActivity(intent)
+            }
+        }
+    }
+
+    @Test
+    fun `Given we have a notifications client, when handle additional data function is called and intent is null, then start activity is not called`() {
+        val intent: Intent? = null
+        val additionalData = mockk<JSONObject>()
 
         runTest {
             notificationsClient.handleAdditionalData(context, additionalData, intent)


### PR DESCRIPTION
# Notification deep links that cannot be parsed app behaviour

- If Gson cannot parse the Additional Data sent from One SIgnal notifications then send the app an intent with an empty Uri. This is so the Uri passes through the Uri validation route and results in Page Not Found alert being presented to the user as required.
- Remove redundant `emitIntent()` function from MainActivity as found during testing that it's not needed.

## JIRA ticket(s)
  - [GOVUKAPP-1523](https://govukverify.atlassian.net/browse/GOVUKAPP-1523)

[GOVUKAPP-1523]: https://govukverify.atlassian.net/browse/GOVUKAPP-1523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ