### PR TITLE
Fix error state text colour

### DIFF
--- a/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalEntryScreen.kt
+++ b/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalEntryScreen.kt
@@ -165,7 +165,7 @@ private fun LocalEntryScreen(
                     errorPlaceholderColor = GovUkTheme.colourScheme.textAndIcons.textFieldError,
                     errorSuffixColor = GovUkTheme.colourScheme.textAndIcons.textFieldError,
                     errorSupportingTextColor = GovUkTheme.colourScheme.textAndIcons.textFieldError,
-                    errorTextColor = GovUkTheme.colourScheme.textAndIcons.textFieldError,
+                    errorTextColor = GovUkTheme.colourScheme.textAndIcons.primary,
                     focusedContainerColor = GovUkTheme.colourScheme.surfaces.textFieldBackground,
                     focusedIndicatorColor = GovUkTheme.colourScheme.textAndIcons.secondary,
                     focusedLabelColor = GovUkTheme.colourScheme.textAndIcons.secondary,


### PR DESCRIPTION
## Figma
  - [Figma board](https://www.figma.com/design/N4v2GPQhwZ7DwhqucyJqlu/GOV.UK-apps-and-notifications?node-id=20393-21993&p=f&t=XIz8NXrPzjRIgWgL-0)

## Screen shots

| Before | After |
|--------|-------|
| ![invalid-before-light](https://github.com/user-attachments/assets/ee1b292e-ed03-4ad9-9d36-31b0e6bd3a74) | ![invalid-after-light](https://github.com/user-attachments/assets/c7aeaa2e-64d8-4861-ae26-cf3832e97b07) |
| ![invalid-before-dark](https://github.com/user-attachments/assets/300983fe-c1b2-4d5a-87ec-e4dfd189a102) | ![invalid-after-dark](https://github.com/user-attachments/assets/031e13b1-068d-46f2-a253-b20293757586) |
| ![not-found-before-light](https://github.com/user-attachments/assets/d4e6805a-3d7e-4dc8-98c7-3e2f232d0fc5) | ![not-found-after-light](https://github.com/user-attachments/assets/440eab41-4fe9-4c74-bd46-b852da6f9f6a) |
| ![not-found-before-dark](https://github.com/user-attachments/assets/debb634c-3fa4-4d50-9a76-b748372aa966) | ![not-found-after-dark](https://github.com/user-attachments/assets/27b1469b-f927-4186-8db6-945239f39bcd) |

