### PR TITLE
GOVUKAPP-1594 Update notifications consent behaviour

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -30,8 +30,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -52,6 +54,7 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.drop
 import uk.gov.govuk.AppUiState
 import uk.gov.govuk.AppViewModel
 import uk.gov.govuk.BuildConfig
@@ -258,12 +261,16 @@ private fun showDeepLinkNotFoundAlert(context: Context) {
 @Composable
 private fun HandleNotificationsPermissionStatus(navController: NavHostController) {
     val notificationsPermissionStatus = getNotificationsPermissionStatus()
-    LaunchedEffect(notificationsPermissionStatus) {
-        if (notificationsPermissionStatus.isGranted) {
-            navController.navigate(NOTIFICATIONS_GRAPH_ROUTE) {
-                launchSingleTop = true
+    LaunchedEffect(Unit) {
+        snapshotFlow { notificationsPermissionStatus }
+            .drop(1)
+            .collect { status ->
+                if (status.isGranted) {
+                    navController.navigate(NOTIFICATIONS_GRAPH_ROUTE) {
+                        launchSingleTop = true
+                    }
+                }
             }
-        }
     }
 }
 

--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -44,8 +44,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.NavDeepLinkRequest
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions

--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow

--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.NavDeepLinkRequest
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
@@ -116,6 +118,7 @@ internal fun GovUkApp(intentFlow: Flow<Intent>) {
                             intentFlow = intentFlow,
                             onboardingCompleted = { viewModel.onboardingCompleted() },
                             topicSelectionCompleted = { viewModel.topicSelectionCompleted() },
+                            shouldDisplayNotificationsOnboarding = it.shouldDisplayNotificationsOnboarding,
                             onTabClick = { tabText -> viewModel.onTabClick(tabText) },
                             homeWidgets = homeWidgets,
                             onInternalWidgetClick = { text ->
@@ -168,6 +171,7 @@ private fun BottomNavScaffold(
     intentFlow: Flow<Intent>,
     onboardingCompleted: () -> Unit,
     topicSelectionCompleted: () -> Unit,
+    shouldDisplayNotificationsOnboarding: Boolean,
     onTabClick: (String) -> Unit,
     homeWidgets: List<HomeWidget>?,
     onInternalWidgetClick: (String) -> Unit,
@@ -207,7 +211,9 @@ private fun BottomNavScaffold(
         navController = navController,
         onDeepLinkReceived = onDeepLinkReceived
     )
-    HandleNotificationsPermissionStatus(navController)
+    if (shouldDisplayNotificationsOnboarding) {
+        HandleNotificationsPermissionStatus(navController)
+    }
 }
 
 @Composable
@@ -265,9 +271,7 @@ private fun HandleNotificationsPermissionStatus(navController: NavHostController
             .drop(1)
             .collect { status ->
                 if (status.isGranted) {
-                    navController.navigate(NOTIFICATIONS_GRAPH_ROUTE) {
-                        launchSingleTop = true
-                    }
+                    navController.navigate(NOTIFICATIONS_GRAPH_ROUTE)
                 }
             }
     }

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/flags/FlagRepo.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/flags/FlagRepo.kt
@@ -74,8 +74,8 @@ class FlagRepo @Inject constructor(
     fun isNotificationsEnabled(): Boolean {
         return isEnabled(
             debugEnabled = debugEnabled,
-            debugFlag = debugFlags.isNotificationsEnabled,
-            remoteFlag = false // TODO - GOVUKAPP-1095 requires this is hardcoded 'off' for now
+            debugFlag = false, // Dev only flag, only set to true when actively working on notifications
+            remoteFlag = false // Dev only flag, always off for production builds!!!
         )
     }
 

--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/navigation/SettingsNavigation.kt
@@ -12,7 +12,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
-import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_ONBOARDING_NO_SKIP_ROUTE
+import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_ONBOARDING_FROM_SETTINGS_ROUTE
 import uk.gov.govuk.settings.BuildConfig.ACCESSIBILITY_STATEMENT_URL
 import uk.gov.govuk.settings.BuildConfig.ACCOUNT_URL
 import uk.gov.govuk.settings.BuildConfig.HELP_AND_FEEDBACK_URL
@@ -55,7 +55,7 @@ fun NavGraphBuilder.settingsGraph(
                         navigateTo(SIGN_OUT_GRAPH_ROUTE)
                     },
                     onNotificationsClick = {
-                        navigateTo(NOTIFICATIONS_ONBOARDING_NO_SKIP_ROUTE)
+                        navigateTo(NOTIFICATIONS_ONBOARDING_FROM_SETTINGS_ROUTE)
                     },
                     onPrivacyPolicyClick = {
                         openInBrowser(context, PRIVACY_POLICY_URL)

--- a/notifications/build.gradle.kts
+++ b/notifications/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.ui.tooling)
     implementation(libs.google.accompanist)
+    implementation(libs.androidx.datastore.preferences)
 
     ksp(libs.hilt.compiler)
 

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsOnboardingViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsOnboardingViewModel.kt
@@ -1,20 +1,25 @@
 package uk.gov.govuk.notifications
 
+import android.os.Build
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.isGranted
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import uk.gov.govuk.analytics.AnalyticsClient
+import uk.gov.govuk.notifications.data.local.NotificationsDataStore
 import javax.inject.Inject
 
 @OptIn(ExperimentalPermissionsApi::class)
 @HiltViewModel
 internal class NotificationsOnboardingViewModel @Inject constructor(
     private val analyticsClient: AnalyticsClient,
-    private val notificationsClient: NotificationsClient
+    private val notificationsClient: NotificationsClient,
+    private val notificationsDataStore: NotificationsDataStore
 ) : ViewModel() {
 
     companion object {
@@ -25,15 +30,38 @@ internal class NotificationsOnboardingViewModel @Inject constructor(
     private val _uiState: MutableStateFlow<NotificationsOnboardingUiState?> = MutableStateFlow(null)
     internal val uiState = _uiState.asStateFlow()
 
-    internal fun updateUiState(status: PermissionStatus) {
-        _uiState.value = if (status.isGranted) {
-            if (notificationsClient.consentGiven()) {
-                NotificationsOnboardingUiState.Finish
+    internal fun updateUiState(
+        status: PermissionStatus,
+        androidVersion: Int = Build.VERSION.SDK_INT,
+        fromSettings: Boolean = false,
+    ) {
+        viewModelScope.launch {
+            _uiState.value = if (fromSettings) {
+                NotificationsOnboardingUiState.Default
+            } else if (status.isGranted) {
+                when {
+                    (!notificationsDataStore.isOnboardingSeen()
+                            && androidVersion < Build.VERSION_CODES.TIRAMISU) -> {
+                        notificationsDataStore.onboardingSeen()
+                        NotificationsOnboardingUiState.NoConsent
+                    }
+
+                    !notificationsClient.consentGiven() -> NotificationsOnboardingUiState.NoConsent
+                    notificationsDataStore.isOnboardingSeen() -> NotificationsOnboardingUiState.Finish
+                    else -> {
+                        notificationsDataStore.onboardingSeen()
+                        NotificationsOnboardingUiState.Default
+                    }
+                }
             } else {
-                NotificationsOnboardingUiState.NoConsent
+                when {
+                    !notificationsDataStore.isOnboardingSeen() -> {
+                        notificationsDataStore.onboardingSeen()
+                        NotificationsOnboardingUiState.Default
+                    }
+                    else -> NotificationsOnboardingUiState.Finish
+                }
             }
-        } else {
-            NotificationsOnboardingUiState.Default
         }
     }
 

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/data/NotificationsRepo.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/data/NotificationsRepo.kt
@@ -1,0 +1,14 @@
+package uk.gov.govuk.notifications.data
+
+import uk.gov.govuk.notifications.data.local.NotificationsDataStore
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class NotificationsRepo @Inject constructor(
+    private val notificationsDataStore: NotificationsDataStore
+) {
+    internal suspend fun isOnboardingSeen() = notificationsDataStore.isOnboardingSeen()
+
+    internal suspend fun onboardingSeen() = notificationsDataStore.onboardingSeen()
+}

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/data/local/NotificationsDataStore.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/data/local/NotificationsDataStore.kt
@@ -1,0 +1,29 @@
+package uk.gov.govuk.notifications.data.local
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.firstOrNull
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NotificationsDataStore @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) {
+
+    companion object {
+        internal const val NOTIFICATIONS_ONBOARDING_SEEN_KEY = "notifications_onboarding_seen"
+    }
+
+    internal suspend fun isOnboardingSeen(): Boolean {
+        return dataStore.data.firstOrNull()
+            ?.get(booleanPreferencesKey(NOTIFICATIONS_ONBOARDING_SEEN_KEY)) == true
+    }
+
+    internal suspend fun onboardingSeen() {
+        dataStore.edit { preferences -> preferences[booleanPreferencesKey(NOTIFICATIONS_ONBOARDING_SEEN_KEY)] = true
+        }
+    }
+}

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/navigation/NotificationsNavigation.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/navigation/NotificationsNavigation.kt
@@ -4,12 +4,12 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
-import uk.gov.govuk.notifications.ui.NotificationsOnboardingNoSkipRoute
+import uk.gov.govuk.notifications.ui.NotificationsOnboardingFromSettingsRoute
 import uk.gov.govuk.notifications.ui.NotificationsOnboardingRoute
 
 const val NOTIFICATIONS_GRAPH_ROUTE = "notifications_graph_route"
 private const val NOTIFICATIONS_ONBOARDING_ROUTE = "notifications_onboarding_route"
-const val NOTIFICATIONS_ONBOARDING_NO_SKIP_ROUTE = "notifications_onboarding_no_skip_route"
+const val NOTIFICATIONS_ONBOARDING_FROM_SETTINGS_ROUTE = "notifications_onboarding_from_settings_route"
 
 fun NavGraphBuilder.notificationsGraph(
     notificationsOnboardingCompleted: () -> Unit,
@@ -26,8 +26,8 @@ fun NavGraphBuilder.notificationsGraph(
             )
         }
 
-        composable(NOTIFICATIONS_ONBOARDING_NO_SKIP_ROUTE) {
-            NotificationsOnboardingNoSkipRoute(
+        composable(NOTIFICATIONS_ONBOARDING_FROM_SETTINGS_ROUTE) {
+            NotificationsOnboardingFromSettingsRoute(
                 notificationsOnboardingCompleted = notificationsOnboardingCompleted,
                 modifier = modifier
             )

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsOnboardingScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsOnboardingScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -106,7 +107,7 @@ internal fun NotificationsOnboardingRoute(
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-internal fun NotificationsOnboardingNoSkipRoute(
+internal fun NotificationsOnboardingFromSettingsRoute(
     notificationsOnboardingCompleted: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -115,7 +116,7 @@ internal fun NotificationsOnboardingNoSkipRoute(
 
     val permissionStatus = getNotificationsPermissionStatus()
     LaunchedEffect(permissionStatus) {
-        viewModel.updateUiState(permissionStatus)
+        viewModel.updateUiState(permissionStatus, fromSettings = true)
     }
 
     uiState?.let { state ->
@@ -181,7 +182,9 @@ private fun OnboardingScreen(
     }
 
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = GovUkTheme.spacing.medium),
         verticalArrangement = Arrangement.SpaceBetween
     ) {
         header?.invoke() ?: run {

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsOnboardingScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsOnboardingScreen.kt
@@ -183,8 +183,7 @@ private fun OnboardingScreen(
 
     Column(
         modifier = modifier
-            .fillMaxSize()
-            .padding(horizontal = GovUkTheme.spacing.medium),
+            .fillMaxSize(),
         verticalArrangement = Arrangement.SpaceBetween
     ) {
         header?.invoke() ?: run {
@@ -196,7 +195,9 @@ private fun OnboardingScreen(
             body = body,
             image = image,
             onPrivacyPolicyClick = onPrivacyPolicyClick,
-            modifier = Modifier.weight(1f, fill = false)
+            modifier = Modifier
+                .weight(1f, fill = false)
+                .padding(horizontal = GovUkTheme.spacing.medium)
         )
         footer()
     }

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/data/NotificationsRepoTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/data/NotificationsRepoTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.govuk.notifications.data
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import uk.gov.govuk.notifications.data.local.NotificationsDataStore
+
+class NotificationsRepoTest {
+
+    private val notificationsDataStore = mockk<NotificationsDataStore>(relaxed = true)
+
+    @Test
+    fun `Given the user has not previously seen onboarding, When is onboarding seen, then return false`() {
+        val repo = NotificationsRepo(notificationsDataStore)
+
+        coEvery { notificationsDataStore.isOnboardingSeen() } returns false
+
+        runTest {
+
+            assertFalse(repo.isOnboardingSeen())
+        }
+    }
+
+    @Test
+    fun `Given the user has previously seen onboarding, When is onboarding seen, then return true`() {
+        val repo = NotificationsRepo(notificationsDataStore)
+
+        coEvery { notificationsDataStore.isOnboardingSeen() } returns true
+
+        runTest {
+            assertTrue(repo.isOnboardingSeen())
+        }
+    }
+
+    @Test
+    fun `Given the user has seen onboarding, When onboarding seen, then update data store`() {
+        val repo = NotificationsRepo(notificationsDataStore)
+
+        runTest {
+            repo.onboardingSeen()
+
+            coVerify { notificationsDataStore.onboardingSeen() }
+        }
+    }
+}

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/data/local/NotificationsDataStoreTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/data/local/NotificationsDataStoreTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.govuk.notifications.data.local
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class NotificationsDataStoreTest {
+
+    private val dataStore = mockk<DataStore<Preferences>>()
+    private val preferences = mockk<Preferences>()
+
+    private lateinit var notificationsDataStore: NotificationsDataStore
+
+    @Before
+    fun setup() {
+        notificationsDataStore = NotificationsDataStore(dataStore)
+    }
+
+    @Test
+    fun `Given the data store is empty, then return false`() {
+        every { dataStore.data } returns emptyFlow()
+
+        runTest {
+            assertFalse(notificationsDataStore.isOnboardingSeen())
+        }
+    }
+
+    @Test
+    fun `Given notifications onboarding seen is null, then return false`() {
+        every { dataStore.data } returns flowOf(preferences)
+        every { preferences[booleanPreferencesKey(NotificationsDataStore.NOTIFICATIONS_ONBOARDING_SEEN_KEY)] } returns null
+
+        runTest {
+            assertFalse(notificationsDataStore.isOnboardingSeen())
+        }
+    }
+
+    @Test
+    fun `Given notifications onboarding seen is true, then return true`() {
+        every { dataStore.data } returns flowOf(preferences)
+        every { preferences[booleanPreferencesKey(NotificationsDataStore.NOTIFICATIONS_ONBOARDING_SEEN_KEY)] } returns true
+
+        runTest {
+            assertTrue(notificationsDataStore.isOnboardingSeen())
+        }
+    }
+}


### PR DESCRIPTION
# Update notifications consent behaviour

- Only show the notifications consent screen on app launch once
- Add notifications consent logic for Android < 33 devices
- Ensure notifications onboarding screen not shown when feature flag is turned off

## JIRA ticket(s)
  - [GOVUKAPP-1594](https://govukverify.atlassian.net/browse/GOVUKAPP-1594)

[GOVUKAPP-1594]: https://govukverify.atlassian.net/browse/GOVUKAPP-1594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ