### PR TITLE
GOVUKAPP-1691 Prevent advertising id collection and include debug symbols

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,6 +98,10 @@ android {
                 signingConfigs.getByName("debug")
             }
 
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
+
             buildConfigField("String", "ONE_SIGNAL_APP_ID", "\"bbea84fc-28cc-4712-a6c5-88f5d08b0d0d\"")
         }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,7 @@
           android:theme="@style/LicensesTheme" />
 
         <meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="false" />
+        <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
         <meta-data android:name="firebase_analytics_collection_enabled" android:value="false" />
         <meta-data android:name="firebase_crashlytics_collection_enabled" android:value="false" />
         <meta-data android:name="com.onesignal.suppressLaunchURLs" android:value="true" />


### PR DESCRIPTION
# Prevent advertising id collection and include debug symbols

Prepare app ready for release by resolving Google Play console warnings for:

[Disable collection of advertising ID doc](https://firebase.google.com/docs/analytics/configure-data-collection?platform=android#disable_advertising_id_collection)

[Include debug symbols doc](https://developer.android.com/reference/tools/gradle-api/8.3/null/com/android/build/api/dsl/Ndk)

## JIRA ticket(s)
  - [GOVUKAPP-1691](https://govukverify.atlassian.net/browse/GOVUKAPP-1691)

[GOVUKAPP-1691]: https://govukverify.atlassian.net/browse/GOVUKAPP-1691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ