### PR TITLE
GOVUKAPP-1594 Change to notifications onboarding completed

### DIFF
--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsOnboardingViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsOnboardingViewModel.kt
@@ -40,23 +40,20 @@ internal class NotificationsOnboardingViewModel @Inject constructor(
                 NotificationsOnboardingUiState.Default
             } else if (status.isGranted) {
                 when {
-                    (!notificationsDataStore.isOnboardingSeen()
+                    (!notificationsDataStore.isOnboardingCompleted()
                             && androidVersion < Build.VERSION_CODES.TIRAMISU) -> {
-                        notificationsDataStore.onboardingSeen()
                         NotificationsOnboardingUiState.NoConsent
                     }
 
                     !notificationsClient.consentGiven() -> NotificationsOnboardingUiState.NoConsent
-                    notificationsDataStore.isOnboardingSeen() -> NotificationsOnboardingUiState.Finish
+                    notificationsDataStore.isOnboardingCompleted() -> NotificationsOnboardingUiState.Finish
                     else -> {
-                        notificationsDataStore.onboardingSeen()
                         NotificationsOnboardingUiState.Default
                     }
                 }
             } else {
                 when {
-                    !notificationsDataStore.isOnboardingSeen() -> {
-                        notificationsDataStore.onboardingSeen()
+                    !notificationsDataStore.isOnboardingCompleted() -> {
                         NotificationsOnboardingUiState.Default
                     }
                     else -> NotificationsOnboardingUiState.Finish
@@ -74,6 +71,9 @@ internal class NotificationsOnboardingViewModel @Inject constructor(
     }
 
     internal fun onContinueClick(text: String) {
+        viewModelScope.launch {
+            notificationsDataStore.onboardingCompleted()
+        }
         notificationsClient.giveConsent()
         notificationsClient.requestPermission {
             _uiState.value = NotificationsOnboardingUiState.Finish
@@ -84,12 +84,18 @@ internal class NotificationsOnboardingViewModel @Inject constructor(
     }
 
     internal fun onSkipClick(text: String) {
+        viewModelScope.launch {
+            notificationsDataStore.onboardingCompleted()
+        }
         analyticsClient.buttonClick(
             text = text
         )
     }
 
     internal fun onGiveConsentClick(text: String) {
+        viewModelScope.launch {
+            notificationsDataStore.onboardingCompleted()
+        }
         notificationsClient.giveConsent()
         analyticsClient.buttonClick(
             text = text

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/data/NotificationsRepo.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/data/NotificationsRepo.kt
@@ -8,7 +8,7 @@ import javax.inject.Singleton
 internal class NotificationsRepo @Inject constructor(
     private val notificationsDataStore: NotificationsDataStore
 ) {
-    internal suspend fun isOnboardingSeen() = notificationsDataStore.isOnboardingSeen()
+    internal suspend fun isOnboardingCompleted() = notificationsDataStore.isOnboardingCompleted()
 
-    internal suspend fun onboardingSeen() = notificationsDataStore.onboardingSeen()
+    internal suspend fun onboardingCompleted() = notificationsDataStore.onboardingCompleted()
 }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/data/local/NotificationsDataStore.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/data/local/NotificationsDataStore.kt
@@ -18,12 +18,12 @@ class NotificationsDataStore @Inject constructor(
         internal const val NOTIFICATIONS_ONBOARDING_SEEN_KEY = "notifications_onboarding_seen"
     }
 
-    internal suspend fun isOnboardingSeen(): Boolean {
+    internal suspend fun isOnboardingCompleted(): Boolean {
         return dataStore.data.firstOrNull()
             ?.get(booleanPreferencesKey(NOTIFICATIONS_ONBOARDING_SEEN_KEY)) == true
     }
 
-    internal suspend fun onboardingSeen() {
+    internal suspend fun onboardingCompleted() {
         dataStore.edit { preferences -> preferences[booleanPreferencesKey(NOTIFICATIONS_ONBOARDING_SEEN_KEY)] = true
         }
     }

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsOnboardingViewModelTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsOnboardingViewModelTest.kt
@@ -62,7 +62,8 @@ class NotificationsOnboardingViewModelTest {
     }
 
     @Test
-    fun `Given continue button click, then request permission and log analytics`() {
+    fun `Given continue button click, then onboarding completed, request permission and log analytics`() {
+        coEvery { notificationsDataStore.onboardingCompleted() } returns Unit
         every { notificationsClient.giveConsent() } returns Unit
 
         val onCompleted = slot<() -> Unit>()
@@ -75,6 +76,9 @@ class NotificationsOnboardingViewModelTest {
         viewModel.onContinueClick("Title")
 
         runTest {
+            coVerify(exactly = 1) {
+                notificationsDataStore.onboardingCompleted()
+            }
             verify(exactly = 1) {
                 notificationsClient.requestPermission(onCompleted = any())
 
@@ -86,10 +90,15 @@ class NotificationsOnboardingViewModelTest {
     }
 
     @Test
-    fun `Given Skip button click, then log analytics`() {
+    fun `Given Skip button click, then onboarding completed and log analytics`() {
+        coEvery { notificationsDataStore.onboardingCompleted() } returns Unit
+
         viewModel.onSkipClick("Title")
 
         runTest {
+            coVerify(exactly = 1) {
+                notificationsDataStore.onboardingCompleted()
+            }
             verify(exactly = 1) {
                 analyticsClient.buttonClick("Title")
             }
@@ -97,12 +106,16 @@ class NotificationsOnboardingViewModelTest {
     }
 
     @Test
-    fun `Given Allow notifications button click, then give consent and log analytics`() {
+    fun `Given Allow notifications button click, then onboarding completed, give consent and log analytics`() {
+        coEvery { notificationsDataStore.onboardingCompleted() } returns Unit
         every { notificationsClient.giveConsent() } returns Unit
 
         viewModel.onGiveConsentClick("Title")
 
         runTest {
+            coVerify(exactly = 1) {
+                notificationsDataStore.onboardingCompleted()
+            }
             verify(exactly = 1) {
                 notificationsClient.giveConsent()
                 analyticsClient.buttonClick("Title")
@@ -142,11 +155,11 @@ class NotificationsOnboardingViewModelTest {
     }
 
     @Test
-    fun `Given the permission status is granted and onboarding seen, When init, then ui state should be finish`() {
+    fun `Given the permission status is granted and onboarding completed, When init, then ui state should be finish`() {
         every { permissionStatus.isGranted } returns true
         every { notificationsClient.giveConsent() } returns Unit
         every { notificationsClient.consentGiven() } returns true
-        coEvery { notificationsDataStore.isOnboardingSeen() } returns true
+        coEvery { notificationsDataStore.isOnboardingCompleted() } returns true
 
         runTest {
             viewModel.updateUiState(permissionStatus)
@@ -157,21 +170,16 @@ class NotificationsOnboardingViewModelTest {
     }
 
     @Test
-    fun `Given the permission status is not granted and onboarding not seen, When init, then the ui state should be default and onboarding seen called`() {
+    fun `Given the permission status is not granted and onboarding not seen, When init, then the ui state should be default`() {
         every { permissionStatus.isGranted } returns false
         every { notificationsClient.requestPermission() } returns Unit
-        coEvery { notificationsDataStore.isOnboardingSeen() } returns false
-        coEvery { notificationsDataStore.onboardingSeen() } returns Unit
+        coEvery { notificationsDataStore.isOnboardingCompleted() } returns false
 
         runTest {
             viewModel.updateUiState(permissionStatus)
 
             val result = viewModel.uiState.first()
             assertTrue(result is NotificationsOnboardingUiState.Default)
-
-            coVerify(exactly = 1) {
-                notificationsDataStore.onboardingSeen()
-            }
         }
     }
 
@@ -179,7 +187,7 @@ class NotificationsOnboardingViewModelTest {
     fun `Given the permission status is granted, consent is given and onboarding is seen, When init, then ui state should be finish`() {
         every { permissionStatus.isGranted } returns true
         every { notificationsClient.consentGiven() } returns true
-        coEvery { notificationsDataStore.isOnboardingSeen() } returns true
+        coEvery { notificationsDataStore.isOnboardingCompleted() } returns true
 
         runTest {
             viewModel.updateUiState(permissionStatus)
@@ -193,7 +201,7 @@ class NotificationsOnboardingViewModelTest {
     fun `Given the permission status is granted, onboarding is seen but consent is not given, When init, then ui state should be no consent`() {
         every { permissionStatus.isGranted } returns true
         every { notificationsClient.consentGiven() } returns false
-        coEvery { notificationsDataStore.isOnboardingSeen() } returns true
+        coEvery { notificationsDataStore.isOnboardingCompleted() } returns true
 
         runTest {
             viewModel.updateUiState(permissionStatus)
@@ -204,28 +212,23 @@ class NotificationsOnboardingViewModelTest {
     }
 
     @Test
-    fun `Given the permission status is granted, onboarding is not seen and Android version is less than Tiramisu, When init, then ui state should be no consent and onboarding seen called`() {
+    fun `Given the permission status is granted, onboarding is not seen and Android version is less than Tiramisu, When init, then ui state should be no consent`() {
         every { permissionStatus.isGranted } returns true
         every { notificationsClient.consentGiven() } returns false
-        coEvery { notificationsDataStore.isOnboardingSeen() } returns false
-        coEvery { notificationsDataStore.onboardingSeen() } returns Unit
+        coEvery { notificationsDataStore.isOnboardingCompleted() } returns false
 
         runTest {
             viewModel.updateUiState(permissionStatus, Build.VERSION_CODES.S_V2)
 
             val result = viewModel.uiState.first()
             assertTrue(result is NotificationsOnboardingUiState.NoConsent)
-
-            coVerify(exactly = 1) {
-                notificationsDataStore.onboardingSeen()
-            }
         }
     }
 
     @Test
     fun `Given the permission status is not granted, onboarding is seen, When init, then ui state should be finish`() {
         every { permissionStatus.isGranted } returns false
-        coEvery { notificationsDataStore.isOnboardingSeen() } returns true
+        coEvery { notificationsDataStore.isOnboardingCompleted() } returns true
 
         runTest {
             viewModel.updateUiState(permissionStatus)
@@ -236,21 +239,16 @@ class NotificationsOnboardingViewModelTest {
     }
 
     @Test
-    fun `Given the permission status is granted, Android version is Tiramisu, consent is given and onboarding is not seen, When init, then ui state should be default and onboarding seen called`() {
+    fun `Given the permission status is granted, Android version is Tiramisu, consent is given and onboarding is not seen, When init, then ui state should be default`() {
         every { permissionStatus.isGranted } returns true
         every { notificationsClient.consentGiven() } returns true
-        coEvery { notificationsDataStore.isOnboardingSeen() } returns false
-        coEvery { notificationsDataStore.onboardingSeen() } returns Unit
+        coEvery { notificationsDataStore.isOnboardingCompleted() } returns false
 
         runTest {
             viewModel.updateUiState(permissionStatus, Build.VERSION_CODES.TIRAMISU)
 
             val result = viewModel.uiState.first()
             assertTrue(result is NotificationsOnboardingUiState.Default)
-
-            coVerify(exactly = 1) {
-                notificationsDataStore.onboardingSeen()
-            }
         }
     }
 

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/data/NotificationsRepoTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/data/NotificationsRepoTest.kt
@@ -14,36 +14,36 @@ class NotificationsRepoTest {
     private val notificationsDataStore = mockk<NotificationsDataStore>(relaxed = true)
 
     @Test
-    fun `Given the user has not previously seen onboarding, When is onboarding seen, then return false`() {
+    fun `Given the user has not previously completed onboarding, When is onboarding completed, then return false`() {
         val repo = NotificationsRepo(notificationsDataStore)
 
-        coEvery { notificationsDataStore.isOnboardingSeen() } returns false
+        coEvery { notificationsDataStore.isOnboardingCompleted() } returns false
 
         runTest {
 
-            assertFalse(repo.isOnboardingSeen())
+            assertFalse(repo.isOnboardingCompleted())
         }
     }
 
     @Test
-    fun `Given the user has previously seen onboarding, When is onboarding seen, then return true`() {
+    fun `Given the user has previously completed onboarding, When is onboarding completed, then return true`() {
         val repo = NotificationsRepo(notificationsDataStore)
 
-        coEvery { notificationsDataStore.isOnboardingSeen() } returns true
+        coEvery { notificationsDataStore.isOnboardingCompleted() } returns true
 
         runTest {
-            assertTrue(repo.isOnboardingSeen())
+            assertTrue(repo.isOnboardingCompleted())
         }
     }
 
     @Test
-    fun `Given the user has seen onboarding, When onboarding seen, then update data store`() {
+    fun `Given the user has completed onboarding, When onboarding completed, then update data store`() {
         val repo = NotificationsRepo(notificationsDataStore)
 
         runTest {
-            repo.onboardingSeen()
+            repo.onboardingCompleted()
 
-            coVerify { notificationsDataStore.onboardingSeen() }
+            coVerify { notificationsDataStore.onboardingCompleted() }
         }
     }
 }

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/data/local/NotificationsDataStoreTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/data/local/NotificationsDataStoreTest.kt
@@ -30,27 +30,27 @@ class NotificationsDataStoreTest {
         every { dataStore.data } returns emptyFlow()
 
         runTest {
-            assertFalse(notificationsDataStore.isOnboardingSeen())
+            assertFalse(notificationsDataStore.isOnboardingCompleted())
         }
     }
 
     @Test
-    fun `Given notifications onboarding seen is null, then return false`() {
+    fun `Given notifications onboarding completed is null, then return false`() {
         every { dataStore.data } returns flowOf(preferences)
         every { preferences[booleanPreferencesKey(NotificationsDataStore.NOTIFICATIONS_ONBOARDING_SEEN_KEY)] } returns null
 
         runTest {
-            assertFalse(notificationsDataStore.isOnboardingSeen())
+            assertFalse(notificationsDataStore.isOnboardingCompleted())
         }
     }
 
     @Test
-    fun `Given notifications onboarding seen is true, then return true`() {
+    fun `Given notifications onboarding completed is true, then return true`() {
         every { dataStore.data } returns flowOf(preferences)
         every { preferences[booleanPreferencesKey(NotificationsDataStore.NOTIFICATIONS_ONBOARDING_SEEN_KEY)] } returns true
 
         runTest {
-            assertTrue(notificationsDataStore.isOnboardingSeen())
+            assertTrue(notificationsDataStore.isOnboardingCompleted())
         }
     }
 }


### PR DESCRIPTION
# Change to notifications onboarding completed

- Change logic and naming from notifications onboarding seen to notifications onboarding completed so onboarding screen persists until the user has selected an option.

## JIRA ticket(s)
  - [GOVUKAPP-1594](https://govukverify.atlassian.net/browse/GOVUKAPP-1594)