### PR TITLE
GOVUKAPP-1712 : Remove first paragraph on local postcode entry screen

### DIFF
--- a/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalEntryScreen.kt
+++ b/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalEntryScreen.kt
@@ -200,9 +200,7 @@ private fun LocalEntryScreen(
             LargeVerticalSpacer()
             BodyBoldLabel(stringResource(R.string.local_postcode_use_title))
             LargeVerticalSpacer()
-            BodyRegularLabel(stringResource(R.string.local_postcode_use_description_1))
-            LargeVerticalSpacer()
-            BodyRegularLabel(stringResource(R.string.local_postcode_use_description_2))
+            BodyRegularLabel(stringResource(R.string.local_postcode_use_description))
         }
     }
 }

--- a/feature/local/src/main/res/values/strings.xml
+++ b/feature/local/src/main/res/values/strings.xml
@@ -10,8 +10,7 @@
   <string name="local_postcode_example">For example SW1A 2AA</string>
   <string name="local_postcode_default_text">Postcode</string>
   <string name="local_postcode_use_title">How we use this information</string>
-  <string name="local_postcode_use_description_1">We only use your postcode to find out what your local council is. It’s not saved or shared anywhere.</string>
-  <string name="local_postcode_use_description_2">Your local council is only kept on your phone. It’s not saved online or shared with any other organisations. You can update it at any time on the app home page.</string>
+  <string name="local_postcode_use_description">Your local council is only kept on your phone. It’s not saved online or shared with any other organisations. You can update it at any time on the app home page.</string>
   <string name="local_widget_title">Your local services</string>
   <string name="local_edit_button">Edit</string>
   <string name="local_edit_button_alt_text">Edit your local council</string>


### PR DESCRIPTION
## JIRA ticket(s)
  - [GOVUKAPP-1712](https://govukverify.atlassian.net/browse/GOVUKAPP-1712)

## Screen shots

| Before | After |
|--------|-------|
| ![Screenshot_20250519_084729](https://github.com/user-attachments/assets/52197b34-27a5-4d3c-a7f7-f470dbcd4681) | ![Screenshot_20250519_084256](https://github.com/user-attachments/assets/6f2d8b06-af4d-4d12-a43b-42c40c469055) |


[GOVUKAPP-1712]: https://govukverify.atlassian.net/browse/GOVUKAPP-1712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ