### PR TITLE
GOVUKAPP-1659 : Disable confirm postcode button until the user has entered at least one character

### DIFF
--- a/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalEntryScreen.kt
+++ b/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalEntryScreen.kt
@@ -217,7 +217,8 @@ private fun BottomNavBar(
         val buttonText = stringResource(R.string.local_confirm_button)
         FixedPrimaryButton(
             text = buttonText,
-            onClick = { onPostcodeLookup(buttonText, postcode) }
+            onClick = { onPostcodeLookup(buttonText, postcode) },
+            enabled = postcode.isNotBlank(),
         )
     }
 }


### PR DESCRIPTION
## JIRA ticket(s)
  - [GOVUKAPP-1659](https://govukverify.atlassian.net/browse/GOVUKAPP-1659)

## Screen shots

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/9969b5d9-99b9-43c3-834d-dadecbd27a0b) | ![after](https://github.com/user-attachments/assets/ec39b95a-8dee-47d3-b5e8-b149a6564298) |


[GOVUKAPP-1659]: https://govukverify.atlassian.net/browse/GOVUKAPP-1659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ