### PR TITLE
Add service not responding error message

### DIFF
--- a/feature/local/src/main/kotlin/uk/govuk/app/local/LocalViewModel.kt
+++ b/feature/local/src/main/kotlin/uk/govuk/app/local/LocalViewModel.kt
@@ -146,7 +146,7 @@ internal class LocalViewModel @Inject constructor(
                 _uiState.value = createAndLogError(R.string.local_not_found_postcode_message)
             is LocalAuthorityResult.PostcodeEmptyOrNull ->
                 _uiState.value = createAndLogError(R.string.local_no_postcode_message)
-            is LocalAuthorityResult.PostcodeRateLimit ->
+            is LocalAuthorityResult.ApiNotResponding ->
                 _uiState.value = createAndLogError(R.string.local_rate_limit_message)
             is LocalAuthorityResult.DeviceNotConnected ->
                 _uiState.value = createAndLogError(R.string.local_not_connected_message)

--- a/feature/local/src/main/kotlin/uk/govuk/app/local/data/remote/LocalApiCall.kt
+++ b/feature/local/src/main/kotlin/uk/govuk/app/local/data/remote/LocalApiCall.kt
@@ -4,17 +4,16 @@ import retrofit2.HttpException
 import retrofit2.Response
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.data.model.Result.Error
-import uk.gov.govuk.data.model.Result.ServiceNotResponding
 import uk.gov.govuk.data.model.Result.Success
 import uk.govuk.app.local.data.remote.model.LocalAuthorityResponse
 import uk.govuk.app.local.data.remote.model.LocalAuthorityResult
 import uk.govuk.app.local.data.remote.model.LocalAuthorityResult.Addresses
+import uk.govuk.app.local.data.remote.model.LocalAuthorityResult.ApiNotResponding
 import uk.govuk.app.local.data.remote.model.LocalAuthorityResult.DeviceNotConnected
 import uk.govuk.app.local.data.remote.model.LocalAuthorityResult.InvalidPostcode
 import uk.govuk.app.local.data.remote.model.LocalAuthorityResult.LocalAuthority
 import uk.govuk.app.local.data.remote.model.LocalAuthorityResult.PostcodeEmptyOrNull
 import uk.govuk.app.local.data.remote.model.LocalAuthorityResult.PostcodeNotFound
-import uk.govuk.app.local.data.remote.model.LocalAuthorityResult.PostcodeRateLimit
 import java.net.UnknownHostException
 
 internal suspend fun safeLocalApiCall(
@@ -36,14 +35,14 @@ internal suspend fun safeLocalApiCall(
                     400 -> Success(InvalidPostcode)
                     404 -> Success(PostcodeNotFound)
                     418 -> Success(PostcodeEmptyOrNull)
-                    429 -> Success(PostcodeRateLimit)
+                    429 -> Success(ApiNotResponding)
                     else -> Error()
                 }
         }
     } catch (e: Exception) {
         when (e) {
             is UnknownHostException -> Success(DeviceNotConnected)
-            is HttpException -> ServiceNotResponding()
+            is HttpException -> Success(ApiNotResponding)
             else -> Error()
         }
     }

--- a/feature/local/src/main/kotlin/uk/govuk/app/local/data/remote/model/LocalAuthorityResult.kt
+++ b/feature/local/src/main/kotlin/uk/govuk/app/local/data/remote/model/LocalAuthorityResult.kt
@@ -6,6 +6,6 @@ internal sealed class LocalAuthorityResult {
     data object InvalidPostcode: LocalAuthorityResult()
     data object PostcodeNotFound: LocalAuthorityResult()
     data object PostcodeEmptyOrNull: LocalAuthorityResult()
-    data object PostcodeRateLimit: LocalAuthorityResult()
+    data object ApiNotResponding: LocalAuthorityResult()
     data object DeviceNotConnected: LocalAuthorityResult()
 }

--- a/feature/local/src/test/kotlin/uk/govuk/app/local/LocalViewModelTest.kt
+++ b/feature/local/src/test/kotlin/uk/govuk/app/local/LocalViewModelTest.kt
@@ -228,7 +228,7 @@ class LocalViewModelTest {
 
         coEvery {
             localRepo.performGetLocalPostcode(postcode)
-        } returns Success(LocalAuthorityResult.PostcodeRateLimit)
+        } returns Success(LocalAuthorityResult.ApiNotResponding)
 
         val errorMessage = "rate limiting error"
 

--- a/feature/local/src/test/kotlin/uk/govuk/app/local/data/remote/LocalApiCallTest.kt
+++ b/feature/local/src/test/kotlin/uk/govuk/app/local/data/remote/LocalApiCallTest.kt
@@ -152,7 +152,7 @@ class LocalApiCallTest {
 
     @Test
     fun `API call returns 429`() = runTest {
-        val apiResponse = LocalAuthorityResult.PostcodeRateLimit
+        val apiResponse = LocalAuthorityResult.ApiNotResponding
 
         coEvery {
             localApi.getLocalPostcode("")
@@ -189,6 +189,8 @@ class LocalApiCallTest {
 
     @Test
     fun `API call throws HttpException`() = runTest {
+        val apiResponse = LocalAuthorityResult.ApiNotResponding
+
         coEvery {
             localApi.getLocalPostcode("E18QS")
         } throws retrofit2.HttpException(
@@ -200,6 +202,6 @@ class LocalApiCallTest {
 
         val actual = safeLocalApiCall { localApi.getLocalPostcode("E18QS") }
 
-        assertEquals("ServiceNotResponding", actual.javaClass.kotlin.simpleName)
+        assertEquals(Result.Success(apiResponse), actual)
     }
 }


### PR DESCRIPTION
Add service not responding error message and rename rate limit error message to be more generic.

Instead of two separate messages - one for rate limiting and one for service not responding. I has been decided to combine the two. The change reflects that decision.