### PR TITLE
GOVUKAPP-1604 Notifications GOV app and Settings alignment (when initially ON)

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/navigation/AppLaunchNavigation.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/navigation/AppLaunchNavigation.kt
@@ -9,7 +9,7 @@ import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.home.navigation.HOME_GRAPH_ROUTE
 import uk.gov.govuk.login.navigation.BIOMETRIC_ROUTE
 import uk.gov.govuk.login.navigation.LOGIN_GRAPH_ROUTE
-import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_GRAPH_ROUTE
+import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE
 import uk.gov.govuk.onboarding.navigation.ONBOARDING_GRAPH_ROUTE
 import uk.gov.govuk.topics.navigation.TOPIC_SELECTION_GRAPH_ROUTE
 import java.util.Stack
@@ -37,7 +37,7 @@ internal class AppLaunchNavigation @Inject constructor(
         _launchRoutes.push(HOME_GRAPH_ROUTE)
 
         if (flagRepo.isNotificationsEnabled()) {
-            _launchRoutes.push(NOTIFICATIONS_GRAPH_ROUTE)
+            _launchRoutes.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
         }
 
         if (flagRepo.isTopicsEnabled()
@@ -73,7 +73,7 @@ internal class AppLaunchNavigation @Inject constructor(
         _launchRoutes.push(HOME_GRAPH_ROUTE)
 
         if (flagRepo.isNotificationsEnabled()) {
-            _launchRoutes.push(NOTIFICATIONS_GRAPH_ROUTE)
+            _launchRoutes.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
         }
 
         if (flagRepo.isTopicsEnabled()
@@ -94,7 +94,7 @@ internal class AppLaunchNavigation @Inject constructor(
         _launchRoutes.push(HOME_GRAPH_ROUTE)
 
         if (flagRepo.isNotificationsEnabled()) {
-            _launchRoutes.push(NOTIFICATIONS_GRAPH_ROUTE)
+            _launchRoutes.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
         }
 
         if (authRepo.isAuthenticationEnabled()) {

--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -73,6 +73,7 @@ import uk.gov.govuk.navigation.TopLevelDestination
 import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_CONSENT_ROUTE
 import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE
 import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_ONBOARDING_ROUTE
+import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_PERMISSION_ROUTE
 import uk.gov.govuk.notifications.navigation.notificationsGraph
 import uk.gov.govuk.notifications.navigation.notificationsOnboardingGraph
 import uk.gov.govuk.onboarding.navigation.onboardingGraph
@@ -291,6 +292,7 @@ private fun HandleNotificationsPermissionStatus(
                 if (isNotificationsEnabledOnResume != isNotificationsEnabled) {
                     val route = when(navController.currentDestination?.route) {
                         NOTIFICATIONS_ONBOARDING_ROUTE -> NOTIFICATIONS_ONBOARDING_ROUTE
+                        NOTIFICATIONS_PERMISSION_ROUTE -> NOTIFICATIONS_PERMISSION_ROUTE
                         else -> NOTIFICATIONS_CONSENT_ROUTE
                     }
                     navController.navigate(route) {

--- a/app/src/test/kotlin/uk/gov/govuk/navigation/AppLaunchNavigationTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/navigation/AppLaunchNavigationTest.kt
@@ -17,7 +17,7 @@ import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.home.navigation.HOME_GRAPH_ROUTE
 import uk.gov.govuk.login.navigation.BIOMETRIC_ROUTE
 import uk.gov.govuk.login.navigation.LOGIN_GRAPH_ROUTE
-import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_GRAPH_ROUTE
+import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE
 import uk.gov.govuk.onboarding.navigation.ONBOARDING_GRAPH_ROUTE
 import uk.gov.govuk.topics.navigation.TOPIC_SELECTION_GRAPH_ROUTE
 import java.util.Stack
@@ -72,7 +72,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(TOPIC_SELECTION_GRAPH_ROUTE)
             expected.push(BIOMETRIC_ROUTE)
             expected.push(LOGIN_GRAPH_ROUTE)
@@ -93,7 +93,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(TOPIC_SELECTION_GRAPH_ROUTE)
             expected.push(BIOMETRIC_ROUTE)
             expected.push(LOGIN_GRAPH_ROUTE)
@@ -111,7 +111,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(TOPIC_SELECTION_GRAPH_ROUTE)
             expected.push(BIOMETRIC_ROUTE)
             expected.push(LOGIN_GRAPH_ROUTE)
@@ -129,7 +129,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(TOPIC_SELECTION_GRAPH_ROUTE)
             expected.push(BIOMETRIC_ROUTE)
             expected.push(LOGIN_GRAPH_ROUTE)
@@ -147,7 +147,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(TOPIC_SELECTION_GRAPH_ROUTE)
             expected.push(ONBOARDING_GRAPH_ROUTE)
 
@@ -164,7 +164,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(TOPIC_SELECTION_GRAPH_ROUTE)
             expected.push(LOGIN_GRAPH_ROUTE)
             expected.push(ONBOARDING_GRAPH_ROUTE)
@@ -182,7 +182,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(TOPIC_SELECTION_GRAPH_ROUTE)
             expected.push(LOGIN_GRAPH_ROUTE)
             expected.push(ONBOARDING_GRAPH_ROUTE)
@@ -200,7 +200,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(BIOMETRIC_ROUTE)
             expected.push(LOGIN_GRAPH_ROUTE)
             expected.push(ONBOARDING_GRAPH_ROUTE)
@@ -218,7 +218,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(BIOMETRIC_ROUTE)
             expected.push(LOGIN_GRAPH_ROUTE)
             expected.push(ONBOARDING_GRAPH_ROUTE)
@@ -234,7 +234,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(BIOMETRIC_ROUTE)
             expected.push(LOGIN_GRAPH_ROUTE)
             expected.push(ONBOARDING_GRAPH_ROUTE)
@@ -268,7 +268,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(TOPIC_SELECTION_GRAPH_ROUTE)
             expected.push(BIOMETRIC_ROUTE)
             expected.push(ANALYTICS_GRAPH_ROUTE)
@@ -286,7 +286,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(TOPIC_SELECTION_GRAPH_ROUTE)
             expected.push(ANALYTICS_GRAPH_ROUTE)
 
@@ -303,7 +303,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(BIOMETRIC_ROUTE)
             expected.push(ANALYTICS_GRAPH_ROUTE)
 
@@ -318,7 +318,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(BIOMETRIC_ROUTE)
             expected.push(ANALYTICS_GRAPH_ROUTE)
 
@@ -350,7 +350,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
             expected.push(BIOMETRIC_ROUTE)
 
             assertEquals(expected, appLaunchNav.launchRoutes)
@@ -366,7 +366,7 @@ class AppLaunchNavigationTest {
 
             val expected = Stack<String>()
             expected.push(HOME_GRAPH_ROUTE)
-            expected.push(NOTIFICATIONS_GRAPH_ROUTE)
+            expected.push(NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE)
 
             assertEquals(expected, appLaunchNav.launchRoutes)
         }

--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/navigation/SettingsNavigation.kt
@@ -12,7 +12,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
-import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_ONBOARDING_FROM_SETTINGS_ROUTE
+import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_PERMISSION_ROUTE
 import uk.gov.govuk.settings.BuildConfig.ACCESSIBILITY_STATEMENT_URL
 import uk.gov.govuk.settings.BuildConfig.ACCOUNT_URL
 import uk.gov.govuk.settings.BuildConfig.HELP_AND_FEEDBACK_URL
@@ -58,7 +58,7 @@ fun NavGraphBuilder.settingsGraph(
                         navigateTo(SIGN_OUT_GRAPH_ROUTE)
                     },
                     onNotificationsClick = {
-                        navigateTo(NOTIFICATIONS_ONBOARDING_FROM_SETTINGS_ROUTE)
+                        navigateTo(NOTIFICATIONS_PERMISSION_ROUTE)
                     },
                     onPrivacyPolicyClick = {
                         openInBrowser(context, PRIVACY_POLICY_URL)

--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/ui/SettingsScreen.kt
@@ -1,10 +1,5 @@
 package uk.gov.govuk.settings.ui
 
-import android.app.Activity
-import android.app.AlertDialog
-import android.content.Context
-import android.content.Intent
-import android.provider.Settings
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -43,7 +38,6 @@ import uk.gov.govuk.design.ui.component.SubheadlineRegularLabel
 import uk.gov.govuk.design.ui.component.TabHeader
 import uk.gov.govuk.design.ui.component.ToggleListItem
 import uk.gov.govuk.design.ui.theme.GovUkTheme
-import uk.gov.govuk.notifications.notificationsPermissionShouldShowRationale
 import uk.gov.govuk.settings.R
 import uk.gov.govuk.settings.SettingsUiState
 import uk.gov.govuk.settings.SettingsViewModel
@@ -84,11 +78,7 @@ internal fun SettingsRoute(
                 },
                 onNotificationsClick = {
                     viewModel.onNotificationsClick()
-                    if (notificationsPermissionShouldShowRationale(context as Activity)) {
-                        actions.onNotificationsClick()
-                    } else {
-                        showNotificationsAlert(context, viewModel)
-                    }
+                    actions.onNotificationsClick()
                 },
                 onAnalyticsConsentChange = { enabled -> viewModel.onAnalyticsConsentChanged(enabled) },
                 onPrivacyPolicyClick = {
@@ -419,39 +409,4 @@ private fun TermsAndConditions(
         isFirst = false,
         isLast = true,
     )
-}
-
-private fun showNotificationsAlert(context: Context, viewModel: SettingsViewModel) {
-    val isNotificationsOn = NotificationManagerCompat.from(context).areNotificationsEnabled()
-    val alertTitle =
-        if (isNotificationsOn) R.string.notifications_alert_title_off else R.string.notifications_alert_title_on
-    val alertMessage =
-        if (isNotificationsOn) R.string.notifications_alert_message_off else R.string.notifications_alert_message_on
-    val neutralButton = context.getString(R.string.cancel_button)
-    val positiveButton = context.getString(R.string.continue_button)
-
-    AlertDialog.Builder(context).apply {
-        setTitle(context.getString(alertTitle))
-        setMessage(context.getString(alertMessage))
-        setNeutralButton(neutralButton) { dialog, _ ->
-            viewModel.onButtonClick(neutralButton)
-            dialog.dismiss()
-        }
-        setPositiveButton(positiveButton) { dialog, _ ->
-            viewModel.onButtonClick(positiveButton)
-            openDeviceSettings(context)
-            dialog.dismiss()
-        }
-    }.also { notificationsAlert ->
-        notificationsAlert.show()
-    }
-}
-
-private fun openDeviceSettings(context: Context) {
-    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
-        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
-        .also { intent ->
-            context.startActivity(intent)
-        }
 }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -24,18 +24,8 @@
 
   <string name="feedback_prompt_widget_title">Give feedback to help improve this app</string>
 
-  <string name="notifications_alert_title_on">Turn on notifications</string>
-  <string name="notifications_alert_title_off">Turn off notifications</string>
-  <string name="notifications_alert_message_on">
-    Continue to your phone’s notifications settings to turn on notifications from GOV.UK
-  </string>
-  <string name="notifications_alert_message_off">
-    Continue to your phone’s notifications settings to turn off notifications from GOV.UK
-  </string>
-  <string name="continue_button">Continue</string>
   <string name="on_button">On</string>
   <string name="off_button">Off</string>
-  <string name="cancel_button">Cancel</string>
 
   <string name="sign_out_title">Are you sure you want to sign out?</string>
   <string name="sign_out_bullet_title">This means:</string>

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsOnboardingUiState.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsOnboardingUiState.kt
@@ -1,7 +1,0 @@
-package uk.gov.govuk.notifications
-
-internal sealed class NotificationsOnboardingUiState {
-    internal data object Default : NotificationsOnboardingUiState()
-    internal data object NoConsent : NotificationsOnboardingUiState()
-    internal data object Finish : NotificationsOnboardingUiState()
-}

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsPromptWidgetViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsPromptWidgetViewModel.kt
@@ -1,15 +1,22 @@
 package uk.gov.govuk.notifications
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import uk.gov.govuk.notifications.data.local.NotificationsDataStore
 import javax.inject.Inject
 
 @HiltViewModel
 internal class NotificationsPromptWidgetViewModel @Inject constructor(
-    private val notificationsClient: NotificationsClient
+    private val notificationsClient: NotificationsClient,
+    private val notificationsDataStore: NotificationsDataStore
 ) : ViewModel() {
 
     internal fun onClick() {
+        viewModelScope.launch {
+            notificationsDataStore.firstPermissionRequestCompleted()
+        }
         notificationsClient.requestPermission()
     }
 }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsSettingsProvider.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsSettingsProvider.kt
@@ -1,0 +1,16 @@
+package uk.gov.govuk.notifications
+
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+
+internal fun openDeviceSettings(
+    context: Context,
+    intent: Intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+) {
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+        .also {
+            context.startActivity(intent)
+        }
+}

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsUiState.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsUiState.kt
@@ -1,0 +1,7 @@
+package uk.gov.govuk.notifications
+
+internal sealed class NotificationsUiState {
+    internal data object Default : NotificationsUiState()
+    internal data object Alert : NotificationsUiState()
+    internal data object Finish : NotificationsUiState()
+}

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/data/NotificationsRepo.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/data/NotificationsRepo.kt
@@ -11,4 +11,10 @@ internal class NotificationsRepo @Inject constructor(
     internal suspend fun isOnboardingCompleted() = notificationsDataStore.isOnboardingCompleted()
 
     internal suspend fun onboardingCompleted() = notificationsDataStore.onboardingCompleted()
+
+    internal suspend fun isFirstPermissionRequestCompleted() =
+        notificationsDataStore.isFirstPermissionRequestCompleted()
+
+    internal suspend fun firstPermissionRequestCompleted() =
+        notificationsDataStore.firstPermissionRequestCompleted()
 }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/data/local/NotificationsDataStore.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/data/local/NotificationsDataStore.kt
@@ -16,6 +16,7 @@ class NotificationsDataStore @Inject constructor(
 
     companion object {
         internal const val NOTIFICATIONS_ONBOARDING_COMPLETED_KEY = "notifications_onboarding_completed"
+        internal const val NOTIFICATIONS_FIRST_PERMISSION_REQUEST_COMPLETED_KEY = "notifications_first_permission_request_completed"
     }
 
     internal suspend fun isOnboardingCompleted(): Boolean {
@@ -25,6 +26,16 @@ class NotificationsDataStore @Inject constructor(
 
     internal suspend fun onboardingCompleted() {
         dataStore.edit { preferences -> preferences[booleanPreferencesKey(NOTIFICATIONS_ONBOARDING_COMPLETED_KEY)] = true
+        }
+    }
+
+    internal suspend fun isFirstPermissionRequestCompleted(): Boolean {
+        return dataStore.data.firstOrNull()
+            ?.get(booleanPreferencesKey(NOTIFICATIONS_FIRST_PERMISSION_REQUEST_COMPLETED_KEY)) == true
+    }
+
+    internal suspend fun firstPermissionRequestCompleted() {
+        dataStore.edit { preferences -> preferences[booleanPreferencesKey(NOTIFICATIONS_FIRST_PERMISSION_REQUEST_COMPLETED_KEY)] = true
         }
     }
 }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/navigation/NotificationsNavigation.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/navigation/NotificationsNavigation.kt
@@ -4,19 +4,22 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
-import uk.gov.govuk.notifications.ui.NotificationsOnboardingFromSettingsRoute
+import uk.gov.govuk.notifications.ui.NotificationsConsentRoute
 import uk.gov.govuk.notifications.ui.NotificationsOnboardingRoute
+import uk.gov.govuk.notifications.ui.NotificationsPermissionRoute
 
+const val NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE = "notifications_onboarding_graph_route"
 const val NOTIFICATIONS_GRAPH_ROUTE = "notifications_graph_route"
-private const val NOTIFICATIONS_ONBOARDING_ROUTE = "notifications_onboarding_route"
-const val NOTIFICATIONS_ONBOARDING_FROM_SETTINGS_ROUTE = "notifications_onboarding_from_settings_route"
+const val NOTIFICATIONS_ONBOARDING_ROUTE = "notifications_onboarding_route"
+const val NOTIFICATIONS_PERMISSION_ROUTE = "notifications_permission_route"
+const val NOTIFICATIONS_CONSENT_ROUTE = "notifications_consent_route"
 
-fun NavGraphBuilder.notificationsGraph(
+fun NavGraphBuilder.notificationsOnboardingGraph(
     notificationsOnboardingCompleted: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     navigation(
-        route = NOTIFICATIONS_GRAPH_ROUTE,
+        route = NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE,
         startDestination = NOTIFICATIONS_ONBOARDING_ROUTE
     ) {
         composable(NOTIFICATIONS_ONBOARDING_ROUTE) {
@@ -25,10 +28,26 @@ fun NavGraphBuilder.notificationsGraph(
                 modifier = modifier
             )
         }
+    }
+}
 
-        composable(NOTIFICATIONS_ONBOARDING_FROM_SETTINGS_ROUTE) {
-            NotificationsOnboardingFromSettingsRoute(
-                notificationsOnboardingCompleted = notificationsOnboardingCompleted,
+fun NavGraphBuilder.notificationsGraph(
+    notificationsCompleted: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    navigation(
+        route = NOTIFICATIONS_GRAPH_ROUTE,
+        startDestination = NOTIFICATIONS_PERMISSION_ROUTE
+    ) {
+        composable(NOTIFICATIONS_PERMISSION_ROUTE) {
+            NotificationsPermissionRoute(
+                notificationsCompleted = notificationsCompleted,
+                modifier = modifier
+            )
+        }
+        composable(NOTIFICATIONS_CONSENT_ROUTE) {
+            NotificationsConsentRoute(
+                notificationsCompleted = notificationsCompleted,
                 modifier = modifier
             )
         }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/EmptyScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/EmptyScreen.kt
@@ -1,0 +1,17 @@
+package uk.gov.govuk.notifications.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+internal fun EmptyScreen() {
+    Box(
+        Modifier
+            .fillMaxSize()
+            .background(Color.Transparent)
+    )
+}

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsConsentScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsConsentScreen.kt
@@ -1,0 +1,65 @@
+package uk.gov.govuk.notifications.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import uk.gov.govuk.design.ui.component.FixedDoubleButtonGroup
+import uk.gov.govuk.notifications.NotificationsConsentViewModel
+import uk.gov.govuk.notifications.NotificationsUiState
+import uk.gov.govuk.notifications.R
+import uk.gov.govuk.notifications.openDeviceSettings
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+internal fun NotificationsConsentRoute(
+    notificationsCompleted: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val viewModel: NotificationsConsentViewModel = hiltViewModel()
+    val uiState by viewModel.uiState.collectAsState()
+
+    val permissionStatus = getNotificationsPermissionStatus()
+    LaunchedEffect(Unit) {
+        viewModel.updateUiState(permissionStatus)
+    }
+
+    uiState?.let { state ->
+        when (state) {
+            NotificationsUiState.Default -> {
+                OnboardingScreen(
+                    onPageView = { viewModel.onPageView() },
+                    body = R.string.onboarding_screen_no_consent_body,
+                    onPrivacyPolicyClick = { text, url ->
+                        viewModel.onPrivacyPolicyClick(text, url)
+                    },
+                    modifier = modifier,
+                    footer = {
+                        val context = LocalContext.current
+                        val primaryText = stringResource(R.string.allow_notifications_button)
+                        val secondaryText = stringResource(R.string.turn_off_notifications_button)
+                        FixedDoubleButtonGroup(
+                            primaryText = primaryText,
+                            onPrimary = { viewModel.onGiveConsentClick(primaryText) },
+                            secondaryText = secondaryText,
+                            onSecondary = {
+                                viewModel.onTurnOffNotificationsClick(secondaryText)
+                                openDeviceSettings(context)
+                            }
+                        )
+                    }
+                )
+            }
+
+            else -> {
+                EmptyScreen()
+                notificationsCompleted()
+            }
+        }
+    }
+}

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsOnboardingScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsOnboardingScreen.kt
@@ -1,36 +1,20 @@
 package uk.gov.govuk.notifications.ui
 
-import android.content.Context
-import android.content.Intent
-import android.provider.Settings
-import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import uk.gov.govuk.design.ui.component.ChildPageHeader
+import com.google.accompanist.permissions.isGranted
 import uk.gov.govuk.design.ui.component.FixedDoubleButtonGroup
-import uk.gov.govuk.design.ui.component.FixedPrimaryButton
-import uk.gov.govuk.design.ui.component.OnboardingSlide
-import uk.gov.govuk.design.ui.theme.GovUkTheme
-import uk.gov.govuk.notifications.NotificationsOnboardingUiState
 import uk.gov.govuk.notifications.NotificationsOnboardingViewModel
+import uk.gov.govuk.notifications.NotificationsUiState
 import uk.gov.govuk.notifications.R
+import uk.gov.govuk.notifications.openDeviceSettings
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
@@ -42,110 +26,47 @@ internal fun NotificationsOnboardingRoute(
     val uiState by viewModel.uiState.collectAsState()
 
     val permissionStatus = getNotificationsPermissionStatus()
-    LaunchedEffect(permissionStatus) {
+    LaunchedEffect(Unit) {
         viewModel.updateUiState(permissionStatus)
     }
 
     uiState?.let { state ->
         when (state) {
-            NotificationsOnboardingUiState.Default -> {
+            NotificationsUiState.Default -> {
                 OnboardingScreen(
                     onPageView = { viewModel.onPageView() },
                     body = R.string.onboarding_screen_body,
                     onPrivacyPolicyClick = { text, url ->
                         viewModel.onPrivacyPolicyClick(text, url)
                     },
+                    modifier = modifier,
                     image = R.drawable.notifications_bell,
                     footer = {
                         val primaryText = stringResource(R.string.allow_notifications_button)
-                        val secondaryText = stringResource(R.string.not_now_button)
-                        FixedDoubleButtonGroup(
-                            primaryText = primaryText,
-                            onPrimary = { viewModel.onContinueClick(primaryText) },
-                            secondaryText = secondaryText,
-                            onSecondary = {
-                                viewModel.onSkipClick(secondaryText)
-                                notificationsOnboardingCompleted()
-                            }
-                        )
-                    }
-                )
-            }
-
-            NotificationsOnboardingUiState.NoConsent -> {
-                OnboardingScreen(
-                    onPageView = { viewModel.onPageView() },
-                    body = R.string.onboarding_screen_no_consent_body,
-                    onPrivacyPolicyClick = { text, url ->
-                        viewModel.onPrivacyPolicyClick(text, url)
-                    },
-                    modifier = modifier,
-                    footer = {
-                        val context = LocalContext.current
-                        val primaryText = stringResource(R.string.allow_notifications_button)
-                        val secondaryText = stringResource(R.string.turn_off_notifications_button)
-                        FixedDoubleButtonGroup(
-                            primaryText = primaryText,
-                            onPrimary = { viewModel.onGiveConsentClick(primaryText) },
-                            secondaryText = secondaryText,
-                            onSecondary = {
-                                viewModel.onTurnOffNotificationsClick(secondaryText)
-                                openDeviceSettings(context)
-                            }
-                        )
-                    }
-                )
-            }
-
-            NotificationsOnboardingUiState.Finish -> {
-                EmptyScreen()
-                notificationsOnboardingCompleted()
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalPermissionsApi::class)
-@Composable
-internal fun NotificationsOnboardingFromSettingsRoute(
-    notificationsOnboardingCompleted: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val viewModel: NotificationsOnboardingViewModel = hiltViewModel()
-    val uiState by viewModel.uiState.collectAsState()
-
-    val permissionStatus = getNotificationsPermissionStatus()
-    LaunchedEffect(permissionStatus) {
-        viewModel.updateUiState(permissionStatus, fromSettings = true)
-    }
-
-    uiState?.let { state ->
-        when (state) {
-            NotificationsOnboardingUiState.Default -> {
-                OnboardingScreen(
-                    onPageView = { viewModel.onPageView() },
-                    body = R.string.onboarding_screen_body,
-                    onPrivacyPolicyClick = { text, url ->
-                        viewModel.onPrivacyPolicyClick(text, url)
-                    },
-                    modifier = modifier,
-                    header = {
-                        ChildPageHeader(
-                            onBack = notificationsOnboardingCompleted
-                        )
-                    },
-                    footer = {
-                        val primaryText = stringResource(R.string.allow_notifications_button)
-                        val secondaryText = stringResource(R.string.not_now_button)
-                        FixedDoubleButtonGroup(
-                            primaryText = primaryText,
-                            onPrimary = { viewModel.onContinueClick(primaryText) },
-                            secondaryText = secondaryText,
-                            onSecondary = {
-                                viewModel.onSkipClick(secondaryText)
-                                notificationsOnboardingCompleted()
-                            }
-                        )
+                        if (permissionStatus.isGranted) {
+                            val context = LocalContext.current
+                            val secondaryText = stringResource(R.string.turn_off_notifications_button)
+                            FixedDoubleButtonGroup(
+                                primaryText = primaryText,
+                                onPrimary = { viewModel.onGiveConsentClick(primaryText) },
+                                secondaryText = secondaryText,
+                                onSecondary = {
+                                    viewModel.onTurnOffNotificationsClick(secondaryText)
+                                    openDeviceSettings(context)
+                                }
+                            )
+                        } else {
+                            val secondaryText = stringResource(R.string.not_now_button)
+                            FixedDoubleButtonGroup(
+                                primaryText = primaryText,
+                                onPrimary = { viewModel.onContinueClick(primaryText) },
+                                secondaryText = secondaryText,
+                                onSecondary = {
+                                    viewModel.onSkipClick(secondaryText)
+                                    notificationsOnboardingCompleted()
+                                }
+                            )
+                        }
                     }
                 )
             }
@@ -155,88 +76,5 @@ internal fun NotificationsOnboardingFromSettingsRoute(
                 notificationsOnboardingCompleted()
             }
         }
-    }
-}
-
-@Composable
-private fun EmptyScreen() {
-    Box(
-        Modifier
-            .fillMaxSize()
-            .background(Color.Transparent)
-    )
-}
-
-@Composable
-private fun OnboardingScreen(
-    onPageView: () -> Unit,
-    @StringRes body: Int,
-    onPrivacyPolicyClick: (text: String, url: String) -> Unit,
-    modifier: Modifier = Modifier,
-    @DrawableRes image: Int? = null,
-    header: (@Composable () -> Unit)? = null,
-    footer: @Composable () -> Unit
-) {
-    LaunchedEffect(Unit) {
-        onPageView()
-    }
-
-    Column(
-        modifier = modifier
-            .fillMaxSize(),
-        verticalArrangement = Arrangement.SpaceBetween
-    ) {
-        header?.invoke() ?: run {
-            image ?: Spacer(Modifier)
-        }
-
-        OnboardingSlide(
-            title = R.string.onboarding_screen_title,
-            body = body,
-            image = image,
-            onPrivacyPolicyClick = onPrivacyPolicyClick,
-            modifier = Modifier
-                .weight(1f, fill = false)
-                .padding(horizontal = GovUkTheme.spacing.medium)
-        )
-        footer()
-    }
-}
-
-private fun openDeviceSettings(context: Context) {
-    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
-        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
-        .also { intent ->
-            context.startActivity(intent)
-        }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun OnboardingScreenOneButtonPreview() {
-    GovUkTheme {
-        OnboardingScreen(
-            {},
-            body = R.string.onboarding_screen_no_consent_body,
-            onPrivacyPolicyClick = { _, _ -> },
-            header = { ChildPageHeader(onBack = {}) },
-            footer = { FixedPrimaryButton("Primary button", {}) })
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun OnboardingScreenTwoButtonsPreview() {
-    GovUkTheme {
-        OnboardingScreen(
-            {},
-            body = R.string.onboarding_screen_body,
-            onPrivacyPolicyClick = { _, _ -> },
-            image = R.drawable.ic_bell,
-            header = { ChildPageHeader(onBack = {}) },
-            footer = {
-                FixedDoubleButtonGroup("Primary button", {}, "Secondary button", {})
-            })
     }
 }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsPermissionScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsPermissionScreen.kt
@@ -1,0 +1,105 @@
+package uk.gov.govuk.notifications.ui
+
+import android.app.AlertDialog
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.core.app.NotificationManagerCompat
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import uk.gov.govuk.design.ui.component.ChildPageHeader
+import uk.gov.govuk.design.ui.component.FixedDoubleButtonGroup
+import uk.gov.govuk.notifications.NotificationsUiState
+import uk.gov.govuk.notifications.NotificationsPermissionViewModel
+import uk.gov.govuk.notifications.R
+import uk.gov.govuk.notifications.openDeviceSettings
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+internal fun NotificationsPermissionRoute(
+    notificationsCompleted: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val viewModel: NotificationsPermissionViewModel = hiltViewModel()
+    val uiState by viewModel.uiState.collectAsState()
+
+    val permissionStatus = getNotificationsPermissionStatus()
+    LaunchedEffect(Unit) {
+        viewModel.updateUiState(permissionStatus)
+    }
+
+    uiState?.let { state ->
+        when (state) {
+            NotificationsUiState.Default -> {
+                OnboardingScreen(
+                    onPageView = { viewModel.onPageView() },
+                    body = R.string.onboarding_screen_body,
+                    onPrivacyPolicyClick = { text, url ->
+                        viewModel.onPrivacyPolicyClick(text, url)
+                    },
+                    modifier = modifier,
+                    header = {
+                        ChildPageHeader(
+                            onBack = notificationsCompleted
+                        )
+                    },
+                    footer = {
+                        val primaryText = stringResource(R.string.allow_notifications_button)
+                        val secondaryText = stringResource(R.string.not_now_button)
+                        FixedDoubleButtonGroup(
+                            primaryText = primaryText,
+                            onPrimary = { viewModel.onContinueClick(primaryText) },
+                            secondaryText = secondaryText,
+                            onSecondary = {
+                                viewModel.onSkipClick(secondaryText)
+                                notificationsCompleted()
+                            }
+                        )
+                    }
+                )
+            }
+            NotificationsUiState.Alert -> {
+                val context = LocalContext.current
+                showNotificationsAlert(context, viewModel)
+                EmptyScreen()
+                notificationsCompleted()
+            }
+
+            NotificationsUiState.Finish -> {
+                EmptyScreen()
+                notificationsCompleted()
+            }
+        }
+    }
+}
+
+private fun showNotificationsAlert(context: Context, viewModel: NotificationsPermissionViewModel) {
+    val isNotificationsOn = NotificationManagerCompat.from(context).areNotificationsEnabled()
+    val alertTitle =
+        if (isNotificationsOn) R.string.notifications_alert_title_off else R.string.notifications_alert_title_on
+    val alertMessage =
+        if (isNotificationsOn) R.string.notifications_alert_message_off else R.string.notifications_alert_message_on
+    val neutralButton = context.getString(R.string.cancel_button)
+    val positiveButton = context.getString(R.string.continue_button)
+
+    AlertDialog.Builder(context).apply {
+        setTitle(context.getString(alertTitle))
+        setMessage(context.getString(alertMessage))
+        setNeutralButton(neutralButton) { dialog, _ ->
+            viewModel.onAlertButtonClick(neutralButton)
+            dialog.dismiss()
+        }
+        setPositiveButton(positiveButton) { dialog, _ ->
+            viewModel.onAlertButtonClick(positiveButton)
+            openDeviceSettings(context)
+            dialog.dismiss()
+        }
+    }.also { notificationsAlert ->
+        notificationsAlert.show()
+    }
+}

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/OnboardingScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/OnboardingScreen.kt
@@ -1,0 +1,68 @@
+package uk.gov.govuk.notifications.ui
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import uk.gov.govuk.design.ui.component.FixedDoubleButtonGroup
+import uk.gov.govuk.design.ui.component.OnboardingSlide
+import uk.gov.govuk.design.ui.theme.GovUkTheme
+import uk.gov.govuk.notifications.R
+
+@Composable
+internal fun OnboardingScreen(
+    onPageView: () -> Unit,
+    @StringRes body: Int,
+    onPrivacyPolicyClick: (text: String, url: String) -> Unit,
+    modifier: Modifier = Modifier,
+    @DrawableRes image: Int? = null,
+    header: (@Composable () -> Unit)? = null,
+    footer: @Composable () -> Unit
+) {
+    LaunchedEffect(Unit) {
+        onPageView()
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize(),
+        verticalArrangement = Arrangement.SpaceBetween
+    ) {
+        header?.invoke() ?: run {
+            image ?: Spacer(Modifier)
+        }
+
+        OnboardingSlide(
+            title = R.string.onboarding_screen_title,
+            body = body,
+            image = image,
+            onPrivacyPolicyClick = onPrivacyPolicyClick,
+            modifier = Modifier
+                .weight(1f, fill = false)
+                .padding(horizontal = GovUkTheme.spacing.medium)
+        )
+        footer()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun OnboardingScreenPreview() {
+    GovUkTheme {
+        OnboardingScreen(
+            {},
+            body = R.string.onboarding_screen_body,
+            onPrivacyPolicyClick = { _, _ -> },
+            image = R.drawable.notifications_bell,
+            footer = {
+                FixedDoubleButtonGroup("Primary button", {}, "Secondary button", {})
+            })
+    }
+}

--- a/notifications/src/main/res/values/strings.xml
+++ b/notifications/src/main/res/values/strings.xml
@@ -18,4 +18,15 @@
         You can change your preferences at any time in your phone’s notifications settings.
     </string>
     <string name="prompt_widget_title">Turn on notifications</string>
+
+    <string name="notifications_alert_title_on">Turn on notifications</string>
+    <string name="notifications_alert_title_off">Turn off notifications</string>
+    <string name="notifications_alert_message_on">
+    Continue to your phone’s notifications settings to turn on notifications from GOV.UK
+  </string>
+    <string name="notifications_alert_message_off">
+    Continue to your phone’s notifications settings to turn off notifications from GOV.UK
+  </string>
+    <string name="cancel_button">Cancel</string>
+    <string name="continue_button">Continue</string>
 </resources>

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsPromptWidgetViewModelTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsPromptWidgetViewModelTest.kt
@@ -1,30 +1,52 @@
 package uk.gov.govuk.notifications
 
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import uk.gov.govuk.notifications.data.local.NotificationsDataStore
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class NotificationsPromptWidgetViewModelTest {
+    private val dispatcher = UnconfinedTestDispatcher()
     private val notificationsClient = mockk<NotificationsClient>()
+    private val notificationsDataStore = mockk<NotificationsDataStore>()
 
     private lateinit var viewModel: NotificationsPromptWidgetViewModel
 
     @Before
     fun setup() {
-        viewModel = NotificationsPromptWidgetViewModel(notificationsClient)
+        Dispatchers.setMain(dispatcher)
+        viewModel = NotificationsPromptWidgetViewModel(notificationsClient, notificationsDataStore)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
     }
 
     @Test
     fun `Given on click, then call request permission`() {
         every { notificationsClient.requestPermission() } returns Unit
+        coEvery { notificationsDataStore.firstPermissionRequestCompleted() } returns Unit
 
         runTest {
             viewModel.onClick()
 
-            verify {
+            coVerify(exactly = 1) {
+                notificationsDataStore.firstPermissionRequestCompleted()
+            }
+            verify(exactly = 1) {
                 notificationsClient.requestPermission()
             }
         }

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsSettingsProviderTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsSettingsProviderTest.kt
@@ -1,0 +1,24 @@
+package uk.gov.govuk.notifications
+
+import android.content.Context
+import android.content.Intent
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class NotificationsSettingsProviderTest {
+    private val context = mockk<Context>(relaxed = true)
+    private val intent = mockk<Intent>(relaxed = true)
+
+    @Test
+    fun openDeviceSettingsTest() {
+        runTest {
+            openDeviceSettings(context, intent)
+
+            verify(exactly = 1) {
+                context.startActivity(intent)
+            }
+        }
+    }
+}

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/data/NotificationsRepoTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/data/NotificationsRepoTest.kt
@@ -46,4 +46,38 @@ class NotificationsRepoTest {
             coVerify { notificationsDataStore.onboardingCompleted() }
         }
     }
+
+    @Test
+    fun `Given the user has not previously requested permission, When is first permission request completed, then return false`() {
+        val repo = NotificationsRepo(notificationsDataStore)
+
+        coEvery { notificationsDataStore.isFirstPermissionRequestCompleted() } returns false
+
+        runTest {
+
+            assertFalse(repo.isFirstPermissionRequestCompleted())
+        }
+    }
+
+    @Test
+    fun `Given the user has previously requested permission, When is first permission request completed, then return true`() {
+        val repo = NotificationsRepo(notificationsDataStore)
+
+        coEvery { notificationsDataStore.isFirstPermissionRequestCompleted() } returns true
+
+        runTest {
+            assertTrue(repo.isFirstPermissionRequestCompleted())
+        }
+    }
+
+    @Test
+    fun `Given the user has completed first permission request, When first permission request completed, then update data store`() {
+        val repo = NotificationsRepo(notificationsDataStore)
+
+        runTest {
+            repo.firstPermissionRequestCompleted()
+
+            coVerify { notificationsDataStore.firstPermissionRequestCompleted()}
+        }
+    }
 }

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/data/local/NotificationsDataStoreTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/data/local/NotificationsDataStoreTest.kt
@@ -26,7 +26,7 @@ class NotificationsDataStoreTest {
     }
 
     @Test
-    fun `Given the data store is empty, then return false`() {
+    fun `Given the data store is empty, then is onboarding completed returns false`() {
         every { dataStore.data } returns emptyFlow()
 
         runTest {
@@ -51,6 +51,35 @@ class NotificationsDataStoreTest {
 
         runTest {
             assertTrue(notificationsDataStore.isOnboardingCompleted())
+        }
+    }
+
+    @Test
+    fun `Given the data store is empty, then is first permission request completed returns false`() {
+        every { dataStore.data } returns emptyFlow()
+
+        runTest {
+            assertFalse(notificationsDataStore.isFirstPermissionRequestCompleted())
+        }
+    }
+
+    @Test
+    fun `Given first permission request completed is null, then return false`() {
+        every { dataStore.data } returns flowOf(preferences)
+        every { preferences[booleanPreferencesKey(NotificationsDataStore.NOTIFICATIONS_FIRST_PERMISSION_REQUEST_COMPLETED_KEY)] } returns null
+
+        runTest {
+            assertFalse(notificationsDataStore.isFirstPermissionRequestCompleted())
+        }
+    }
+
+    @Test
+    fun `Given first permission request completed is true, then return true`() {
+        every { dataStore.data } returns flowOf(preferences)
+        every { preferences[booleanPreferencesKey(NotificationsDataStore.NOTIFICATIONS_FIRST_PERMISSION_REQUEST_COMPLETED_KEY)] } returns true
+
+        runTest {
+            assertTrue(notificationsDataStore.isFirstPermissionRequestCompleted())
         }
     }
 }


### PR DESCRIPTION
# Notifications GOV app and Settings alignment (when initially ON)

- Add notification permissions logic for pre and post Android 13 to align with latest requirements
- Break down notifications screens and navigation into Onboarding, Permission and Consent to simplify as was getting complicated

## JIRA ticket(s)
  - [GOVUKAPP-1604](https://govukverify.atlassian.net/browse/GOVUKAPP-1604)

## Figma (to see journeys)
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=7593-15311&t=MH5q85DxGWZkWRZB-1)