### PR TITLE
GOVUKAPP-1757 Topic description colour change to match designs

### DIFF
--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/TopicScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/TopicScreen.kt
@@ -3,6 +3,7 @@ package uk.gov.govuk.topics.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -30,6 +31,7 @@ import uk.gov.govuk.design.ui.component.LargeTitleBoldLabel
 import uk.gov.govuk.design.ui.component.LargeVerticalSpacer
 import uk.gov.govuk.design.ui.component.ListHeader
 import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
+import uk.gov.govuk.design.ui.component.SmallVerticalSpacer
 import uk.gov.govuk.design.ui.component.error.OfflineMessage
 import uk.gov.govuk.design.ui.component.error.ProblemMessage
 import uk.gov.govuk.design.ui.theme.GovUkTheme
@@ -142,23 +144,30 @@ private fun TopicScreen(
         LazyColumn {
             item {
                 Column(
-                    Modifier
-                        .fillMaxWidth()
-                        .background(GovUkTheme.colourScheme.surfaces.homeHeader)
-                        .padding(horizontal = GovUkTheme.spacing.medium)
+                    Modifier.fillMaxWidth()
                 ) {
-                    LargeTitleBoldLabel(
-                        text = topic.title,
-                        modifier = Modifier.semantics { heading() },
-                        color = GovUkTheme.colourScheme.textAndIcons.header
-                    )
-                    MediumVerticalSpacer()
-                    topic.description?.let { description ->
-                        BodyRegularLabel(
-                            text = description,
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(GovUkTheme.colourScheme.surfaces.homeHeader)
+                    ) {
+                        LargeTitleBoldLabel(
+                            text = topic.title,
+                            modifier = Modifier
+                                .padding(horizontal = GovUkTheme.spacing.medium)
+                                .semantics { heading() },
                             color = GovUkTheme.colourScheme.textAndIcons.header
                         )
+                        SmallVerticalSpacer()
+                    }
+                    topic.description?.let { description ->
                         MediumVerticalSpacer()
+                        BodyRegularLabel(
+                            text = description,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = GovUkTheme.spacing.medium)
+                        )
                     }
                 }
             }

--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/TopicScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/TopicScreen.kt
@@ -31,7 +31,6 @@ import uk.gov.govuk.design.ui.component.LargeTitleBoldLabel
 import uk.gov.govuk.design.ui.component.LargeVerticalSpacer
 import uk.gov.govuk.design.ui.component.ListHeader
 import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
-import uk.gov.govuk.design.ui.component.SmallVerticalSpacer
 import uk.gov.govuk.design.ui.component.error.OfflineMessage
 import uk.gov.govuk.design.ui.component.error.ProblemMessage
 import uk.gov.govuk.design.ui.theme.GovUkTheme
@@ -158,7 +157,6 @@ private fun TopicScreen(
                                 .semantics { heading() },
                             color = GovUkTheme.colourScheme.textAndIcons.header
                         )
-                        SmallVerticalSpacer()
                     }
                     topic.description?.let { description ->
                         MediumVerticalSpacer()


### PR DESCRIPTION
# Topic description colour change to match designs

Change topic description colours and spacing to match designs

## JIRA ticket(s)
  - [GOVUKAPP-1757](https://govukverify.atlassian.net/browse/GOVUKAPP-1757)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=2540-16871&t=wm8Fpa0PrONSwAAN-0)

## Screen shots

| Before | After |
|--------|-------|
| ![Screenshot_1747825735](https://github.com/user-attachments/assets/4654257c-9b3f-474e-8a44-b94052b3d33a) | ![Screenshot_1747827065](https://github.com/user-attachments/assets/49bfb62f-cf29-4f19-a6bd-e5ab2da1ff03) |



[GOVUKAPP-1757]: https://govukverify.atlassian.net/browse/GOVUKAPP-1757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ