### PR TITLE
GOVUKAPP-1759 Privacy notice link

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Onboarding.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Onboarding.kt
@@ -74,7 +74,10 @@ fun OnboardingSlide(
             textAlign = TextAlign.Center
         )
         LargeVerticalSpacer()
-        PrivacyPolicyLink { text, url -> onPrivacyPolicyClick?.invoke(text, url) }
+        PrivacyPolicyLink(
+            modifier = Modifier
+                .padding(horizontal = GovUkTheme.spacing.extraLarge)
+        ) { text, url -> onPrivacyPolicyClick?.invoke(text, url) }
         MediumVerticalSpacer()
     }
 }

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Onboarding.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Onboarding.kt
@@ -29,7 +29,7 @@ fun OnboardingSlide(
     @StringRes title: Int,
     @StringRes body: Int,
     modifier: Modifier = Modifier,
-    onPrivacyPolicyClick: ((text: String, url: String) -> Unit)? = null,
+    privacyPolicy: (@Composable () -> Unit)? = null,
     @DrawableRes image: Int? = null,
     focusRequester: FocusRequester = remember { FocusRequester() }
 ) {
@@ -73,11 +73,10 @@ fun OnboardingSlide(
                 .padding(horizontal = GovUkTheme.spacing.extraLarge),
             textAlign = TextAlign.Center
         )
-        LargeVerticalSpacer()
-        PrivacyPolicyLink(
-            modifier = Modifier
-                .padding(horizontal = GovUkTheme.spacing.extraLarge)
-        ) { text, url -> onPrivacyPolicyClick?.invoke(text, url) }
+        privacyPolicy?.let {
+            LargeVerticalSpacer()
+            it()
+        }
         MediumVerticalSpacer()
     }
 }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsOnboardingScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsOnboardingScreen.kt
@@ -27,6 +27,7 @@ import uk.gov.govuk.design.ui.component.ChildPageHeader
 import uk.gov.govuk.design.ui.component.FixedDoubleButtonGroup
 import uk.gov.govuk.design.ui.component.FixedPrimaryButton
 import uk.gov.govuk.design.ui.component.OnboardingSlide
+import uk.gov.govuk.design.ui.component.PrivacyPolicyLink
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 import uk.gov.govuk.notifications.NotificationsOnboardingUiState
 import uk.gov.govuk.notifications.NotificationsOnboardingViewModel
@@ -194,7 +195,12 @@ private fun OnboardingScreen(
             title = R.string.onboarding_screen_title,
             body = body,
             image = image,
-            onPrivacyPolicyClick = onPrivacyPolicyClick,
+            privacyPolicy = {
+                PrivacyPolicyLink(
+                    modifier = Modifier.padding(horizontal = GovUkTheme.spacing.extraLarge),
+                    onClick = onPrivacyPolicyClick
+                )
+            },
             modifier = Modifier
                 .weight(1f, fill = false)
                 .padding(horizontal = GovUkTheme.spacing.medium)


### PR DESCRIPTION
# Privacy notice link 

Remove privacy notice link from onboarding screens as accidentally added by notifications onboarding task

## JIRA ticket(s)
  - [GOVUKAPP-1759](https://govukverify.atlassian.net/browse/GOVUKAPP-1759)

## Screen shots

| Before | After |
|--------|-------|
| ![Screenshot_1747835463](https://github.com/user-attachments/assets/5321c8df-5f89-43f4-93f0-c9077eaa8b76) | ![Screenshot_1747835294](https://github.com/user-attachments/assets/7abb963a-307c-4d48-8334-3f9b2d13a7f0) | 



[GOVUKAPP-1759]: https://govukverify.atlassian.net/browse/GOVUKAPP-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ