### PR TITLE
GOVUKAPP-1604 Notifications permission navigation

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -72,6 +72,7 @@ import uk.gov.govuk.navigation.DeepLink
 import uk.gov.govuk.navigation.TopLevelDestination
 import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_CONSENT_GRAPH_ROUTE
 import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_ONBOARDING_ROUTE
+import uk.gov.govuk.notifications.navigation.NOTIFICATIONS_PERMISSION_ROUTE
 import uk.gov.govuk.notifications.navigation.notificationsConsentGraph
 import uk.gov.govuk.notifications.navigation.notificationsOnboardingGraph
 import uk.gov.govuk.notifications.navigation.notificationsPermissionGraph
@@ -289,8 +290,9 @@ private fun HandleNotificationsPermissionStatus(
                 val isNotificationsEnabledOnResume =
                     NotificationManagerCompat.from(context).areNotificationsEnabled()
                 if (isNotificationsEnabledOnResume != isNotificationsEnabled) {
-                    val route = when(navController.currentDestination?.route) {
-                        NOTIFICATIONS_ONBOARDING_ROUTE -> NOTIFICATIONS_ONBOARDING_ROUTE
+                    val route = when (navController.currentDestination?.route) {
+                        NOTIFICATIONS_ONBOARDING_ROUTE,
+                        NOTIFICATIONS_PERMISSION_ROUTE -> return@LaunchedEffect
                         else -> NOTIFICATIONS_CONSENT_GRAPH_ROUTE
                     }
                     navController.navigate(route) {
@@ -299,7 +301,6 @@ private fun HandleNotificationsPermissionStatus(
                     isNotificationsEnabled = isNotificationsEnabledOnResume
                 }
             }
-
             else -> { /* Do nothing */ }
         }
     }
@@ -429,6 +430,7 @@ private fun GovUkNavHost(
             notificationsOnboardingCompleted = {
                 navController.popBackStack()
                 appLaunchNavigation.onNext(navController)
+                navController.navigate(NOTIFICATIONS_CONSENT_GRAPH_ROUTE)
             }
         )
         notificationsPermissionGraph(
@@ -438,7 +440,7 @@ private fun GovUkNavHost(
         )
         notificationsConsentGraph(
             notificationsConsentCompleted = {
-                navController.popBackStack()
+                navController.navigateUp()
             }
         )
         loginGraph(

--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -438,7 +438,7 @@ private fun GovUkNavHost(
         )
         notificationsConsentGraph(
             notificationsConsentCompleted = {
-                navController.navigateUp()
+                navController.popBackStack()
             }
         )
         loginGraph(

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsClient.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsClient.kt
@@ -32,6 +32,10 @@ class NotificationsClient @Inject constructor() {
         OneSignal.consentGiven = true
     }
 
+    fun removeConsent() {
+        OneSignal.consentGiven = false
+    }
+
     fun consentGiven() = OneSignal.consentGiven
 
     fun requestPermission(
@@ -39,7 +43,8 @@ class NotificationsClient @Inject constructor() {
         onCompleted: (() -> Unit)? = null
     ) {
         CoroutineScope(dispatcher).launch {
-            OneSignal.Notifications.requestPermission(false)
+            val consentGiven = OneSignal.Notifications.requestPermission(false)
+            OneSignal.consentGiven = consentGiven
             onCompleted?.invoke()
         }
     }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModel.kt
@@ -24,7 +24,10 @@ internal class NotificationsConsentViewModel @Inject constructor(
         status: PermissionStatus
     ) {
         viewModelScope.launch {
-            _uiState.value = if (!status.isGranted || notificationsClient.consentGiven()) {
+            _uiState.value = if (!status.isGranted) {
+                notificationsClient.removeConsent()
+                NotificationsUiState.Finish
+            } else if (notificationsClient.consentGiven()) {
                 NotificationsUiState.Finish
             } else {
                 NotificationsUiState.Default

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModel.kt
@@ -31,4 +31,8 @@ internal class NotificationsConsentViewModel @Inject constructor(
             }
         }
     }
+
+    internal fun finish() {
+        _uiState.value = NotificationsUiState.Finish
+    }
 }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsOnboardingViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsOnboardingViewModel.kt
@@ -43,4 +43,8 @@ internal class NotificationsOnboardingViewModel @Inject constructor(
             }
         }
     }
+
+    internal fun finish() {
+        _uiState.value = NotificationsUiState.Finish
+    }
 }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsPermissionViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsPermissionViewModel.kt
@@ -49,4 +49,8 @@ internal class NotificationsPermissionViewModel @Inject constructor(
     internal fun onAlertButtonClick(text: String) {
         analyticsClient.buttonClick(text)
     }
+
+    internal fun finish() {
+        _uiState.value = NotificationsUiState.Finish
+    }
 }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsViewModel.kt
@@ -2,9 +2,6 @@ package uk.gov.govuk.notifications
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.PermissionStatus
-import com.google.accompanist.permissions.isGranted
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import uk.gov.govuk.analytics.AnalyticsClient
@@ -21,13 +18,6 @@ internal open class NotificationsViewModel @Inject constructor(
     companion object {
         private const val SCREEN_CLASS = "NotificationsOnboardingScreen"
         private const val TITLE = "NotificationsOnboardingScreen"
-    }
-
-    @OptIn(ExperimentalPermissionsApi::class)
-    internal fun updateConsent(status: PermissionStatus) {
-        if (!status.isGranted) {
-            notificationsClient.removeConsent()
-        }
     }
 
     internal fun onPageView() {

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsViewModel.kt
@@ -2,6 +2,9 @@ package uk.gov.govuk.notifications
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.PermissionStatus
+import com.google.accompanist.permissions.isGranted
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import uk.gov.govuk.analytics.AnalyticsClient
@@ -20,6 +23,13 @@ internal open class NotificationsViewModel @Inject constructor(
         private const val TITLE = "NotificationsOnboardingScreen"
     }
 
+    @OptIn(ExperimentalPermissionsApi::class)
+    internal fun updateConsent(status: PermissionStatus) {
+        if (!status.isGranted) {
+            notificationsClient.removeConsent()
+        }
+    }
+
     internal fun onPageView() {
         analyticsClient.screenView(
             screenClass = SCREEN_CLASS,
@@ -33,7 +43,6 @@ internal open class NotificationsViewModel @Inject constructor(
             notificationsDataStore.onboardingCompleted()
             notificationsDataStore.firstPermissionRequestCompleted()
         }
-        notificationsClient.giveConsent()
         notificationsClient.requestPermission {
             viewModelScope.launch {
                 onCompleted()

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/navigation/NotificationsNavigation.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/navigation/NotificationsNavigation.kt
@@ -12,7 +12,7 @@ const val NOTIFICATIONS_ONBOARDING_GRAPH_ROUTE = "notifications_onboarding_graph
 const val NOTIFICATIONS_PERMISSION_GRAPH_ROUTE = "notifications_permission_graph_route"
 const val NOTIFICATIONS_CONSENT_GRAPH_ROUTE = "notifications_consent_graph_route"
 const val NOTIFICATIONS_ONBOARDING_ROUTE = "notifications_onboarding_route"
-private const val NOTIFICATIONS_PERMISSION_ROUTE = "notifications_permission_route"
+const val NOTIFICATIONS_PERMISSION_ROUTE = "notifications_permission_route"
 private const val NOTIFICATIONS_CONSENT_ROUTE = "notifications_consent_route"
 
 fun NavGraphBuilder.notificationsOnboardingGraph(

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsConsentScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsConsentScreen.kt
@@ -49,7 +49,7 @@ internal fun NotificationsConsentRoute(
                             primaryText = primaryText,
                             onPrimary = {
                                 notificationsViewModel.onGiveConsentClick(primaryText) {
-                                    notificationsConsentCompleted()
+                                    viewModel.finish()
                                 }
                             },
                             secondaryText = secondaryText,

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsConsentScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsConsentScreen.kt
@@ -29,7 +29,6 @@ internal fun NotificationsConsentRoute(
     val permissionStatus = getNotificationsPermissionStatus()
     LaunchedEffect(Unit) {
         viewModel.updateUiState(permissionStatus)
-        notificationsViewModel.updateConsent(permissionStatus)
     }
 
     uiState?.let { state ->

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsConsentScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsConsentScreen.kt
@@ -29,6 +29,7 @@ internal fun NotificationsConsentRoute(
     val permissionStatus = getNotificationsPermissionStatus()
     LaunchedEffect(Unit) {
         viewModel.updateUiState(permissionStatus)
+        notificationsViewModel.updateConsent(permissionStatus)
     }
 
     uiState?.let { state ->

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsOnboardingScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsOnboardingScreen.kt
@@ -50,7 +50,7 @@ internal fun NotificationsOnboardingRoute(
                             val secondaryText = stringResource(R.string.turn_off_notifications_button)
                             FixedDoubleButtonGroup(
                                 primaryText = primaryText,
-                                onPrimary = { notificationsViewModel.onGiveConsentClick(primaryText) { notificationsOnboardingCompleted() } },
+                                onPrimary = { notificationsViewModel.onGiveConsentClick(primaryText) { viewModel.finish() } },
                                 secondaryText = secondaryText,
                                 onSecondary = {
                                     notificationsViewModel.onTurnOffNotificationsClick(secondaryText)
@@ -63,12 +63,12 @@ internal fun NotificationsOnboardingRoute(
                                 primaryText = primaryText,
                                 onPrimary = {
                                     notificationsViewModel.onAllowNotificationsClick(primaryText)
-                                    { notificationsOnboardingCompleted() }
+                                    { viewModel.finish() }
                                 },
                                 secondaryText = secondaryText,
                                 onSecondary = {
                                     notificationsViewModel.onNotNowClick(secondaryText)
-                                    notificationsOnboardingCompleted()
+                                    viewModel.finish()
                                 }
                             )
                         }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsPermissionScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsPermissionScreen.kt
@@ -57,13 +57,13 @@ internal fun NotificationsPermissionRoute(
                             primaryText = primaryText, onPrimary = {
                                 notificationsViewModel.onAllowNotificationsClick(primaryText)
                                 {
-                                    notificationsPermissionCompleted()
+                                    viewModel.finish()
                                 }
                             },
                             secondaryText = secondaryText,
                             onSecondary = {
                                 notificationsViewModel.onNotNowClick(secondaryText)
-                                notificationsPermissionCompleted()
+                                viewModel.finish()
                             }
                         )
                     }
@@ -72,8 +72,7 @@ internal fun NotificationsPermissionRoute(
             NotificationsUiState.Alert -> {
                 val context = LocalContext.current
                 showNotificationsAlert(context) { viewModel.onAlertButtonClick(it) }
-                EmptyScreen()
-                notificationsPermissionCompleted()
+                viewModel.finish()
             }
 
             NotificationsUiState.Finish -> {

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsClientTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsClientTest.kt
@@ -88,6 +88,15 @@ class NotificationsClientTest {
     }
 
     @Test
+    fun `Given we have a notifications client, when remove consent is called, then One Signal consent given is false`() {
+        runTest {
+            notificationsClient.removeConsent()
+
+            assertFalse(OneSignal.consentGiven)
+        }
+    }
+
+    @Test
     fun `Given we have a notifications client, when consent given is called and One Signal consent is true, then consent given returns true`() {
         every {OneSignal.consentGiven} returns true
 

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModelTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModelTest.kt
@@ -87,4 +87,14 @@ class NotificationsConsentViewModelTest {
             assertTrue(result is NotificationsUiState.Finish)
         }
     }
+
+    @Test
+    fun `Given finish is called, then ui state should be finish`() {
+        runTest {
+            viewModel.finish()
+
+            val result = viewModel.uiState.first()
+            assertTrue(result is NotificationsUiState.Finish)
+        }
+    }
 }

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModelTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModelTest.kt
@@ -5,6 +5,7 @@ import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.isGranted
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -37,12 +38,16 @@ class NotificationsConsentViewModelTest {
     }
 
     @Test
-    fun `Given the permission status is not granted and consent is not given, When init, then ui state should be finish`() {
+    fun `Given the permission status is not granted, When init, then remove consent called and ui state should be finish`() {
         every { permissionStatus.isGranted } returns false
-        every { notificationsClient.consentGiven() } returns false
+        every { notificationsClient.removeConsent() } returns Unit
 
         runTest {
             viewModel.updateUiState(permissionStatus)
+
+            verify(exactly = 1) {
+                notificationsClient.removeConsent()
+            }
 
             val result = viewModel.uiState.first()
             assertTrue(result is NotificationsUiState.Finish)
@@ -50,8 +55,8 @@ class NotificationsConsentViewModelTest {
     }
 
     @Test
-    fun `Given the permission status is not granted and consent is given, When init, then ui state should be finish`() {
-        every { permissionStatus.isGranted } returns false
+    fun `Given the permission status is granted and consent is given, When init, then ui state should be finish`() {
+        every { permissionStatus.isGranted } returns true
         every { notificationsClient.consentGiven() } returns true
 
         runTest {
@@ -72,19 +77,6 @@ class NotificationsConsentViewModelTest {
 
             val result = viewModel.uiState.first()
             assertTrue(result is NotificationsUiState.Default)
-        }
-    }
-
-    @Test
-    fun `Given the permission status is granted and consent is given, When init, then ui state should be finish`() {
-        every { permissionStatus.isGranted } returns true
-        every { notificationsClient.consentGiven() } returns true
-
-        runTest {
-            viewModel.updateUiState(permissionStatus)
-
-            val result = viewModel.uiState.first()
-            assertTrue(result is NotificationsUiState.Finish)
         }
     }
 

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsOnboardingViewModelTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsOnboardingViewModelTest.kt
@@ -115,4 +115,14 @@ class NotificationsOnboardingViewModelTest {
             assertTrue(result is NotificationsUiState.Finish)
         }
     }
+
+    @Test
+    fun `Given finish is called, then ui state should be finish`() {
+        runTest {
+            viewModel.finish()
+
+            val result = viewModel.uiState.first()
+            assertTrue(result is NotificationsUiState.Finish)
+        }
+    }
 }

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsPermissionViewModelTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsPermissionViewModelTest.kt
@@ -121,4 +121,14 @@ class NotificationsPermissionViewModelTest {
             assertTrue(result is NotificationsUiState.Alert)
         }
     }
+
+    @Test
+    fun `Given finish is called, then ui state should be finish`() {
+        runTest {
+            viewModel.finish()
+
+            val result = viewModel.uiState.first()
+            assertTrue(result is NotificationsUiState.Finish)
+        }
+    }
 }

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsViewModelTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsViewModelTest.kt
@@ -1,8 +1,5 @@
 package uk.gov.govuk.notifications
 
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.PermissionStatus
-import com.google.accompanist.permissions.isGranted
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -21,13 +18,12 @@ import org.junit.Test
 import uk.gov.govuk.analytics.AnalyticsClient
 import uk.gov.govuk.notifications.data.local.NotificationsDataStore
 
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalPermissionsApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class NotificationsViewModelTest {
     private val dispatcher = UnconfinedTestDispatcher()
     private val analyticsClient = mockk<AnalyticsClient>(relaxed = true)
     private val notificationsClient = mockk<NotificationsClient>()
     private val notificationsDataStore = mockk<NotificationsDataStore>()
-    private val permissionStatus = mockk<PermissionStatus>()
 
     private lateinit var viewModel: NotificationsViewModel
 
@@ -40,33 +36,6 @@ class NotificationsViewModelTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
-    }
-
-    @Test
-    fun `Given the notifications permission status is granted, When update consent is called, then remove consent should not be called`() {
-        every { permissionStatus.isGranted } returns true
-
-        runTest {
-            viewModel.updateConsent(permissionStatus)
-
-            verify(exactly = 0) {
-                notificationsClient.removeConsent()
-            }
-        }
-    }
-
-    @Test
-    fun `Given the notifications permission status is not granted, When update consent is called, then remove consent should be called`() {
-        every { permissionStatus.isGranted } returns false
-        every { notificationsClient.removeConsent() } returns Unit
-
-        runTest {
-            viewModel.updateConsent(permissionStatus)
-
-            verify(exactly = 1) {
-                notificationsClient.removeConsent()
-            }
-        }
     }
 
     @Test


### PR DESCRIPTION
# Notifications permission navigation

- Add finish function to view models to avoid callbacks being fired twice
- Add remove consent function and check and set it on app launch and on notification permission changes

## JIRA ticket(s)
  - [GOVUKAPP-1604](https://govukverify.atlassian.net/browse/GOVUKAPP-1604)


[GOVUKAPP-1604]: https://govukverify.atlassian.net/browse/GOVUKAPP-1604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ