### PR TITLE
GOVUKAPP-1769 Remove advertising id permission added by GA

### DIFF
--- a/analytics/src/main/AndroidManifest.xml
+++ b/analytics/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
-
     <application
         android:name=".GovUkApplication"
         android:allowBackup="false"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
+
     <application
         android:name=".GovUkApplication"
         android:allowBackup="false"


### PR DESCRIPTION
# Remove advertising id permission added by GA

Remove advertising id permission added by Google Analytics as redundant

## JIRA ticket(s)
  - [GOVUKAPP-1769](https://govukverify.atlassian.net/browse/GOVUKAPP-1769)

[GOVUKAPP-1769]: https://govukverify.atlassian.net/browse/GOVUKAPP-1769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ