### PR TITLE
GOVUKAPP-1697 Create Modal in-app browser page

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -5,7 +5,8 @@ import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import androidx.browser.customtabs.CustomTabsIntent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -60,6 +61,7 @@ import uk.gov.govuk.BuildConfig
 import uk.gov.govuk.R
 import uk.gov.govuk.analytics.navigation.analyticsGraph
 import uk.gov.govuk.design.ui.component.error.AppUnavailableScreen
+import uk.gov.govuk.design.ui.extension.getCustomTabsIntent
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 import uk.gov.govuk.extension.asDeepLinks
 import uk.gov.govuk.extension.getUrlParam
@@ -217,6 +219,8 @@ private fun HandleReceivedIntents(
     onDeepLinkReceived: (hasDeepLink: Boolean, url: String) -> Unit
 ) {
     val context = LocalContext.current
+    val launcher =
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {}
     LaunchedEffect(intentFlow) {
         intentFlow.collectLatest { intent ->
             intent.data?.let { uri ->
@@ -232,8 +236,8 @@ private fun HandleReceivedIntents(
                 } else {
                     uri.getUrlParam(DeepLink.allowedAppUrls, DeepLink.allowedGovUkUrls)?.let {
                         onDeepLinkReceived(true, uri.toString())
-                        val customTabsIntent = CustomTabsIntent.Builder().build()
-                        customTabsIntent.launchUrl(context, it)
+                        val customTabsIntent = context.getCustomTabsIntent(it.toString())
+                        launcher.launch(customTabsIntent)
                     } ?: run {
                         onDeepLinkReceived(false, uri.toString())
                         showDeepLinkNotFoundAlert(context = context)

--- a/app/src/main/kotlin/uk/gov/govuk/ui/HomeWidgets.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/HomeWidgets.kt
@@ -1,14 +1,16 @@
 package uk.gov.govuk.ui
 
 import android.content.Context
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import uk.gov.govuk.BuildConfig
 import uk.gov.govuk.design.ui.component.LargeVerticalSpacer
+import uk.gov.govuk.design.ui.extension.getCustomTabsIntent
 import uk.gov.govuk.notifications.ui.NotificationsPromptWidget
 import uk.gov.govuk.notifications.ui.notificationsPermissionShouldShowRationale
-import uk.gov.govuk.settings.navigation.navigateToHelpAndFeedback
 import uk.gov.govuk.settings.ui.FeedbackPromptWidget
 import uk.gov.govuk.topics.navigation.navigateToTopic
 import uk.gov.govuk.topics.navigation.navigateToTopicsAll
@@ -53,10 +55,14 @@ internal fun homeWidgets(
 
             HomeWidget.FEEDBACK_PROMPT -> {
                 widgets.add { modifier ->
+                    val launcher =
+                        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {}
                     FeedbackPromptWidget(
                         onClick = { text ->
                             onExternalClick(text, null)
-                            navigateToHelpAndFeedback(context, BuildConfig.VERSION_NAME_USER_FACING)
+                            val customTabsIntent =
+                                context.getCustomTabsIntent(BuildConfig.VERSION_NAME_USER_FACING)
+                            launcher.launch(customTabsIntent)
                         },
                         modifier = modifier
                     )

--- a/app/src/main/kotlin/uk/gov/govuk/ui/RecommendUpdateScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/RecommendUpdateScreen.kt
@@ -1,7 +1,6 @@
 package uk.gov.govuk.ui
 
 import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.net.toUri
 import uk.gov.govuk.BuildConfig.PLAY_STORE_URL
 import uk.gov.govuk.R
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
@@ -43,7 +43,7 @@ internal fun RecommendUpdateScreen(
         val context = LocalContext.current
         val onUpdateClick: () -> Unit = {
             val intent = Intent(Intent.ACTION_VIEW)
-            intent.data = Uri.parse(PLAY_STORE_URL)
+            intent.data = PLAY_STORE_URL.toUri()
             context.startActivity(intent)
         }
 

--- a/design/build.gradle.kts
+++ b/design/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.adaptive.android)
     implementation(libs.androidx.ui.tooling)
+    implementation(libs.androidx.browser)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Card.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Card.kt
@@ -1,6 +1,7 @@
 package uk.gov.govuk.design.ui.component
 
-import android.content.Intent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
@@ -27,8 +28,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import uk.gov.govuk.design.R
+import uk.gov.govuk.design.ui.extension.getCustomTabsIntent
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 
 @Composable
@@ -148,14 +149,14 @@ fun SearchResultCard(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val intent = Intent(Intent.ACTION_VIEW)
-    intent.data = url.toUri()
-
+    val launcher =
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {}
     GovUkCard(
         modifier = modifier,
         onClick = {
             onClick(title, url)
-            context.startActivity(intent)
+            val customTabsIntent = context.getCustomTabsIntent(url)
+            launcher.launch(customTabsIntent)
         }
     ) {
         Row(

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/PrivacyPolicy.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/PrivacyPolicy.kt
@@ -1,7 +1,7 @@
 package uk.gov.govuk.design.ui.component
 
-import android.content.Context
-import android.content.Intent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.Icon
@@ -14,7 +14,7 @@ import androidx.compose.ui.res.stringResource
 import uk.gov.govuk.design.BuildConfig.PRIVACY_POLICY_URL
 import uk.gov.govuk.design.R
 import uk.gov.govuk.design.ui.theme.GovUkTheme
-import androidx.core.net.toUri
+import uk.gov.govuk.design.ui.extension.getCustomTabsIntent
 
 @Composable
 fun PrivacyPolicyLink(
@@ -24,11 +24,14 @@ fun PrivacyPolicyLink(
     val context = LocalContext.current
     val text = stringResource(R.string.privacy_policy_read_more)
     val url = PRIVACY_POLICY_URL
+    val launcher =
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {}
     Row(
         modifier
             .clickable {
                 onClick?.invoke(text, url)
-                openPrivacyPolicyInBrowser(context, url)
+                val customTabsIntent = context.getCustomTabsIntent(url)
+                launcher.launch(customTabsIntent)
             }
     ) {
         BodyRegularLabel(
@@ -46,10 +49,4 @@ fun PrivacyPolicyLink(
             modifier = Modifier.align(Alignment.CenterVertically)
         )
     }
-}
-
-private fun openPrivacyPolicyInBrowser(context: Context, url: String) {
-    val intent = Intent(Intent.ACTION_VIEW)
-    intent.data = url.toUri()
-    context.startActivity(intent)
 }

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/error/ProblemMessage.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/error/ProblemMessage.kt
@@ -1,13 +1,13 @@
 package uk.gov.govuk.design.ui.component.error
 
 import android.content.Intent
-import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.net.toUri
 import uk.gov.govuk.design.R
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 
@@ -25,7 +25,7 @@ fun ProblemMessage(
         buttonTitle = stringResource(R.string.go_to_the_gov_uk_website),
         onButtonClick = {
             Intent(Intent.ACTION_VIEW).let { intent ->
-                intent.data = Uri.parse(ErrorConstants.GOV_UK_URL)
+                intent.data = ErrorConstants.GOV_UK_URL.toUri()
                 context.startActivity(intent)
             }
         },

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/extension/ContextExtension.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/extension/ContextExtension.kt
@@ -1,7 +1,11 @@
 package uk.gov.govuk.design.ui.extension
 
 import android.content.Context
+import android.content.Intent
 import android.provider.Settings
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsIntent.ACTIVITY_HEIGHT_FIXED
+import androidx.core.net.toUri
 
 fun Context.areAnimationsEnabled(): Boolean {
     val animatorDurationScale = Settings.Global.getFloat(
@@ -10,4 +14,15 @@ fun Context.areAnimationsEnabled(): Boolean {
         1f
     )
     return animatorDurationScale > 0f
+}
+
+fun Context.getCustomTabsIntent(url: String): Intent {
+    val displayMetrics = resources.displayMetrics
+    val screenHeight = displayMetrics.heightPixels
+    val customTabsIntent = CustomTabsIntent.Builder().setInitialActivityHeightPx(
+        screenHeight,
+        ACTIVITY_HEIGHT_FIXED
+    ).build()
+    customTabsIntent.intent.data = url.toUri()
+    return customTabsIntent.intent
 }

--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/navigation/TopicsNavigation.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/navigation/TopicsNavigation.kt
@@ -1,10 +1,9 @@
 package uk.gov.govuk.topics.navigation
 
-import android.content.Context
-import android.content.Intent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.net.toUri
 import androidx.navigation.NavController
 import androidx.navigation.NavDeepLink
 import androidx.navigation.NavGraphBuilder
@@ -12,6 +11,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.navigation
+import uk.gov.govuk.design.ui.extension.getCustomTabsIntent
 import uk.gov.govuk.topics.ui.AllStepByStepRoute
 import uk.gov.govuk.topics.ui.AllTopicsRoute
 import uk.gov.govuk.topics.ui.EditTopicsRoute
@@ -61,11 +61,15 @@ fun NavGraphBuilder.topicsGraph(
                 navArgument(TOPIC_SUBTOPIC_ARG) { type = NavType.BoolType },
             ), deepLinks = deepLinks("/topics$topicPath")
         ) {
+            val launcher =
+                rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {}
             val context = LocalContext.current
-
             TopicRoute(
                 onBack = { navController.popBackStack() },
-                onExternalLink = { url, _ -> launchExternalLink(context, url) },
+                onExternalLink = { url, _ ->
+                    val customTabsIntent = context.getCustomTabsIntent(url)
+                    launcher.launch(customTabsIntent)
+                },
                 onStepByStepSeeAll = { navController.navigate(TOPICS_ALL_STEP_BY_STEPS_ROUTE) },
                 onSubtopic = { ref -> navController.navigateToTopic(ref, true) },
                 modifier = modifier
@@ -90,21 +94,19 @@ fun NavGraphBuilder.topicsGraph(
         composable(
             TOPICS_ALL_STEP_BY_STEPS_ROUTE
         ) {
+            val launcher =
+                rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {}
             val context = LocalContext.current
-
             AllStepByStepRoute(
                 onBack = { navController.popBackStack()},
-                onClick = { url -> launchExternalLink(context, url) },
+                onClick = { url ->
+                    val customTabsIntent = context.getCustomTabsIntent(url)
+                    launcher.launch(customTabsIntent)
+                 },
                 modifier = modifier
             )
         }
     }
-}
-
-private fun launchExternalLink(context: Context, url: String) {
-    val intent = Intent(Intent.ACTION_VIEW)
-    intent.data = url.toUri()
-    context.startActivity(intent)
 }
 
 fun NavController.navigateToTopic(ref: String, isSubtopic: Boolean = false) {

--- a/feature/visited/src/main/kotlin/uk/gov/govuk/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/gov/govuk/visited/ui/VisitedScreen.kt
@@ -1,8 +1,8 @@
 package uk.gov.govuk.visited.ui
 
 import android.annotation.SuppressLint
-import android.content.Intent
-import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -36,6 +36,7 @@ import uk.gov.govuk.design.ui.component.LargeVerticalSpacer
 import uk.gov.govuk.design.ui.component.ListHeadingLabel
 import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
 import uk.gov.govuk.design.ui.component.SmallVerticalSpacer
+import uk.gov.govuk.design.ui.extension.getCustomTabsIntent
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 import uk.gov.govuk.visited.R
 import uk.gov.govuk.visited.VisitedUiState
@@ -172,8 +173,8 @@ private fun ShowVisitedItems(
                 val lastVisited = item.lastVisited
                 val url = item.url
                 val context = LocalContext.current
-                val intent = Intent(Intent.ACTION_VIEW)
-                intent.data = Uri.parse(url)
+                val launcher =
+                    rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {}
 
                 ExternalLinkListItem(
                     title = title,
@@ -182,7 +183,8 @@ private fun ShowVisitedItems(
                             delay(500)
                             onClick(title, url)
                         }
-                        context.startActivity(intent)
+                        val customTabsIntent = context.getCustomTabsIntent(url)
+                        launcher.launch(customTabsIntent)
                     },
                     isFirst = index == 0,
                     isLast = index == visitedItems.size - 1,


### PR DESCRIPTION
# Create Modal in-app browser page

Launch all external webpages in Custom Tabs presented modally (except for 'app unavailable' and 'problem' screens)

## JIRA ticket(s)
  - [GOVUKAPP-1697](https://govukverify.atlassian.net/browse/GOVUKAPP-1697)

## Figma
  - [Figma board](https://www.figma.com/proto/3FfswHzQS6T6I1Y4Hca7HX/GOV.UK-app-public-beta-prototype--iOS-?page-id=0%3A1&node-id=55-6637&p=f&viewport=1086%2C-254%2C0.43&t=EoOt9Q8qbzmwF2wq-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=1%3A3339)

## Screen shots

| Before | After |
|--------|-------|
| ![Screenshot_1748361521](https://github.com/user-attachments/assets/7e9c64be-58a9-41e8-9a41-58ff39a11d08) | ![Screenshot 2025-05-27 at 16 30 43](https://github.com/user-attachments/assets/0eb0229c-7916-4189-bce1-562ed2935db8) |

