### PR TITLE
GOVUKAPP-1783 Notifications onboarding screen won't progress on Android 12

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -276,7 +276,7 @@ private fun HandleNotificationsPermissionStatus(
                     NotificationManagerCompat.from(context).areNotificationsEnabled()
                 if (isNotificationsEnabledOnResume != isNotificationsEnabled) {
                     val route = when (navController.currentDestination?.route) {
-                        NOTIFICATIONS_ONBOARDING_ROUTE,
+                        NOTIFICATIONS_ONBOARDING_ROUTE -> NOTIFICATIONS_ONBOARDING_ROUTE
                         NOTIFICATIONS_PERMISSION_ROUTE -> return@LaunchedEffect
                         else -> NOTIFICATIONS_CONSENT_GRAPH_ROUTE
                     }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsViewModel.kt
@@ -33,6 +33,7 @@ internal open class NotificationsViewModel @Inject constructor(
             notificationsDataStore.onboardingCompleted()
             notificationsDataStore.firstPermissionRequestCompleted()
         }
+        notificationsClient.giveConsent()
         notificationsClient.requestPermission {
             viewModelScope.launch {
                 onCompleted()

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsViewModelTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsViewModelTest.kt
@@ -110,6 +110,7 @@ class NotificationsViewModelTest {
                 notificationsDataStore.firstPermissionRequestCompleted()
             }
             verify(exactly = 1) {
+                notificationsClient.giveConsent()
                 notificationsClient.requestPermission(onCompleted = any())
 
                 analyticsClient.buttonClick("Title")


### PR DESCRIPTION
# Notifications onboarding screen won't progress on Android 12

- Relaunch onboarding screen when returning to the app from settings so onboarding screen will dismiss

## JIRA ticket(s)
  - [GOVUKAPP-1783](https://govukverify.atlassian.net/browse/GOVUKAPP-1783)