### PR TITLE
GOVUKAPP-1853 Turn OneSignal consent off when continue to device settings clicked

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.core.app.NotificationManagerCompat
 import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle

--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -266,28 +266,17 @@ private fun HandleNotificationsPermissionStatus(
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val lifecycleState by lifecycleOwner.lifecycle.currentStateFlow.collectAsState()
-    val context = LocalContext.current
-    var isNotificationsEnabled by rememberSaveable { mutableStateOf(false) }
-
-    LaunchedEffect(Unit) {
-        isNotificationsEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled()
-    }
 
     LaunchedEffect(lifecycleState) {
         when (lifecycleState) {
             Lifecycle.State.RESUMED -> {
-                val isNotificationsEnabledOnResume =
-                    NotificationManagerCompat.from(context).areNotificationsEnabled()
-                if (isNotificationsEnabledOnResume != isNotificationsEnabled) {
-                    val route = when (navController.currentDestination?.route) {
-                        NOTIFICATIONS_ONBOARDING_ROUTE -> NOTIFICATIONS_ONBOARDING_ROUTE
-                        NOTIFICATIONS_PERMISSION_ROUTE -> return@LaunchedEffect
-                        else -> NOTIFICATIONS_CONSENT_GRAPH_ROUTE
-                    }
-                    navController.navigate(route) {
-                        launchSingleTop = true
-                    }
-                    isNotificationsEnabled = isNotificationsEnabledOnResume
+                val route = when (navController.currentDestination?.route) {
+                    NOTIFICATIONS_ONBOARDING_ROUTE -> NOTIFICATIONS_ONBOARDING_ROUTE
+                    NOTIFICATIONS_PERMISSION_ROUTE -> return@LaunchedEffect
+                    else -> NOTIFICATIONS_CONSENT_GRAPH_ROUTE
+                }
+                navController.navigate(route) {
+                    launchSingleTop = true
                 }
             }
             else -> { /* Do nothing */ }

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/flags/FlagRepo.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/flags/FlagRepo.kt
@@ -74,7 +74,7 @@ class FlagRepo @Inject constructor(
     fun isNotificationsEnabled(): Boolean {
         return isEnabled(
             debugEnabled = debugEnabled,
-            debugFlag = false, // Dev only flag, only set to true when actively working on notifications
+            debugFlag = debugFlags.isNotificationsEnabled,
             remoteFlag = false // Dev only flag, always off for production builds!!!
         )
     }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModel.kt
@@ -26,15 +26,14 @@ internal class NotificationsConsentViewModel @Inject constructor(
         status: PermissionStatus
     ) {
         viewModelScope.launch {
-            _uiState.value = if (!status.isGranted) {
-                notificationsClient.removeConsent()
-                NotificationsUiState.Finish
-            } else if (!notificationsDataStore.isOnboardingCompleted()) {
-                NotificationsUiState.Finish
-            } else if (notificationsClient.consentGiven()) {
-                NotificationsUiState.Finish
-            } else {
-                NotificationsUiState.Default
+            _uiState.value = when {
+                !status.isGranted -> {
+                    notificationsClient.removeConsent()
+                    NotificationsUiState.Finish
+                }
+                !notificationsDataStore.isOnboardingCompleted() -> NotificationsUiState.Finish
+                notificationsClient.consentGiven() -> NotificationsUiState.Finish
+                else -> NotificationsUiState.Default
             }
         }
     }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModel.kt
@@ -9,11 +9,13 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import uk.gov.govuk.notifications.data.local.NotificationsDataStore
 import javax.inject.Inject
 
 @HiltViewModel
 internal class NotificationsConsentViewModel @Inject constructor(
-    private val notificationsClient: NotificationsClient
+    private val notificationsClient: NotificationsClient,
+    private val notificationsDataStore: NotificationsDataStore
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<NotificationsUiState?> = MutableStateFlow(null)
@@ -26,6 +28,8 @@ internal class NotificationsConsentViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.value = if (!status.isGranted) {
                 notificationsClient.removeConsent()
+                NotificationsUiState.Finish
+            } else if (!notificationsDataStore.isOnboardingCompleted()) {
                 NotificationsUiState.Finish
             } else if (notificationsClient.consentGiven()) {
                 NotificationsUiState.Finish

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsPermissionViewModel.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsPermissionViewModel.kt
@@ -18,6 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 internal class NotificationsPermissionViewModel @Inject constructor(
     private val analyticsClient: AnalyticsClient,
+    private val notificationsClient: NotificationsClient,
     private val notificationsDataStore: NotificationsDataStore
 ) : ViewModel() {
 
@@ -46,7 +47,12 @@ internal class NotificationsPermissionViewModel @Inject constructor(
         }
     }
 
-    internal fun onAlertButtonClick(text: String) {
+    internal fun onContinueButtonClick(text: String) {
+        notificationsClient.removeConsent()
+        analyticsClient.buttonClick(text)
+    }
+
+    internal fun onCancelButtonClick(text: String) {
         analyticsClient.buttonClick(text)
     }
 

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsPermissionScreen.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/ui/NotificationsPermissionScreen.kt
@@ -73,7 +73,10 @@ internal fun NotificationsPermissionRoute(
             }
             NotificationsUiState.Alert -> {
                 val context = LocalContext.current
-                showNotificationsAlert(context) { viewModel.onAlertButtonClick(it) }
+                showNotificationsAlert(
+                    context,
+                    onCancelButtonClick = { viewModel.onCancelButtonClick(it) },
+                    onContinueButtonClick = { viewModel.onContinueButtonClick(it) })
                 viewModel.finish()
             }
 
@@ -85,24 +88,28 @@ internal fun NotificationsPermissionRoute(
     }
 }
 
-private fun showNotificationsAlert(context: Context, onAlertButtonClick: (String) -> Unit) {
+private fun showNotificationsAlert(
+    context: Context,
+    onContinueButtonClick: (String) -> Unit,
+    onCancelButtonClick: (String) -> Unit
+) {
     val isNotificationsOn = NotificationManagerCompat.from(context).areNotificationsEnabled()
     val alertTitle =
         if (isNotificationsOn) R.string.notifications_alert_title_off else R.string.notifications_alert_title_on
     val alertMessage =
         if (isNotificationsOn) R.string.notifications_alert_message_off else R.string.notifications_alert_message_on
-    val neutralButton = context.getString(R.string.cancel_button)
-    val positiveButton = context.getString(R.string.continue_button)
+    val cancelButton = context.getString(R.string.cancel_button)
+    val continueButton = context.getString(R.string.continue_button)
 
     AlertDialog.Builder(context).apply {
         setTitle(context.getString(alertTitle))
         setMessage(context.getString(alertMessage))
-        setNeutralButton(neutralButton) { dialog, _ ->
-            onAlertButtonClick(neutralButton)
+        setNeutralButton(cancelButton) { dialog, _ ->
+            onCancelButtonClick(cancelButton)
             dialog.dismiss()
         }
-        setPositiveButton(positiveButton) { dialog, _ ->
-            onAlertButtonClick(positiveButton)
+        setPositiveButton(continueButton) { dialog, _ ->
+            onContinueButtonClick(continueButton)
             openDeviceSettings(context)
             dialog.dismiss()
         }

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModelTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModelTest.kt
@@ -60,7 +60,6 @@ class NotificationsConsentViewModelTest {
     @Test
     fun `Given the permission status is granted and onboarding is not completed, When init, then ui state should be finish`() {
         every { permissionStatus.isGranted } returns true
-        every { notificationsClient.consentGiven() } returns true
         coEvery { notificationsDataStore.isOnboardingCompleted() } returns false
 
         runTest {

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModelTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/NotificationsConsentViewModelTest.kt
@@ -3,6 +3,7 @@ package uk.gov.govuk.notifications
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.isGranted
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -17,19 +18,21 @@ import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import uk.gov.govuk.notifications.data.local.NotificationsDataStore
 
 @OptIn(ExperimentalPermissionsApi::class, ExperimentalCoroutinesApi::class)
 class NotificationsConsentViewModelTest {
     private val dispatcher = UnconfinedTestDispatcher()
     private val permissionStatus = mockk<PermissionStatus>()
     private val notificationsClient = mockk<NotificationsClient>()
+    private val notificationsDataStore = mockk<NotificationsDataStore>()
 
     private lateinit var viewModel: NotificationsConsentViewModel
 
     @Before
     fun setup() {
         Dispatchers.setMain(dispatcher)
-        viewModel = NotificationsConsentViewModel(notificationsClient)
+        viewModel = NotificationsConsentViewModel(notificationsClient, notificationsDataStore)
     }
 
     @After
@@ -55,8 +58,23 @@ class NotificationsConsentViewModelTest {
     }
 
     @Test
-    fun `Given the permission status is granted and consent is given, When init, then ui state should be finish`() {
+    fun `Given the permission status is granted and onboarding is not completed, When init, then ui state should be finish`() {
         every { permissionStatus.isGranted } returns true
+        every { notificationsClient.consentGiven() } returns true
+        coEvery { notificationsDataStore.isOnboardingCompleted() } returns false
+
+        runTest {
+            viewModel.updateUiState(permissionStatus)
+
+            val result = viewModel.uiState.first()
+            assertTrue(result is NotificationsUiState.Finish)
+        }
+    }
+
+    @Test
+    fun `Given the permission status is granted, onboarding is completed and consent is given, When init, then ui state should be finish`() {
+        every { permissionStatus.isGranted } returns true
+        coEvery { notificationsDataStore.isOnboardingCompleted() } returns true
         every { notificationsClient.consentGiven() } returns true
 
         runTest {
@@ -68,8 +86,9 @@ class NotificationsConsentViewModelTest {
     }
 
     @Test
-    fun `Given the permission status is granted and consent is not given, When init, then ui state should be default`() {
+    fun `Given the permission status is granted, onboarding is completed and consent is not given, When init, then ui state should be default`() {
         every { permissionStatus.isGranted } returns true
+        coEvery { notificationsDataStore.isOnboardingCompleted() } returns true
         every { notificationsClient.consentGiven() } returns false
 
         runTest {


### PR DESCRIPTION
# Turn OneSignal consent off when continue to device settings clicked

- Remove hardcoded FALSE from notifications debug flag so notifications is on in debug builds. 
- Remove OneSignal consent when continue to device settings button is pressed and rework logic around it.

## JIRA ticket(s)
  - [GOVUKAPP-1853](https://govukverify.atlassian.net/browse/GOVUKAPP-1853)

![Screenshot_1749040685](https://github.com/user-attachments/assets/9c4f4fef-45e7-4175-8d23-913df6de32fa)


[GOVUKAPP-1853]: https://govukverify.atlassian.net/browse/GOVUKAPP-1853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ