### PR TITLE
GOVUKAPP-1870 RealmProvider.open crash

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.9.2"
 biometric = "1.1.0"
-kotlin = "2.0.0"
+kotlin = "2.0.21"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
@@ -14,8 +14,8 @@ navigationCompose = "2.8.9"
 composeBom = "2025.04.00"
 androidxHilt = "1.2.0"
 adaptiveAndroid = "1.1.0"
-hilt = "2.51.1"
-ksp = "2.0.0-1.0.22"
+hilt = "2.56.2"
+ksp = "2.0.21-1.0.28"
 datastorePreferences = "1.1.4"
 googlePlayServices = "4.4.2"
 crashlytics = "3.0.3"
@@ -26,7 +26,7 @@ retrofit = "2.11.0"
 
 firebaseBom = "33.12.0"
 
-realm = "2.0.0"
+realm = "3.0.0"
 
 mockk = "1.13.11"
 coroutineTest = "1.8.1"


### PR DESCRIPTION
# RealmProvider.open crash

Unable to reproduce crash so made the following change to see if it resolves issue:

- Update Realm version from 2.0.0 to 3.0.0
- Update Kotlin, Hilt & KSP to compatible versions with Realm 3.0.0

## JIRA ticket(s)
  - [GOVUKAPP-1870](https://govukverify.atlassian.net/browse/GOVUKAPP-1870)

[GOVUKAPP-1870]: https://govukverify.atlassian.net/browse/GOVUKAPP-1870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ