### PR TITLE
GOVUKAPP-1912 Info and relationships - What is your postcode?

### DIFF
--- a/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalLookupScreen.kt
+++ b/feature/local/src/main/kotlin/uk/govuk/app/local/ui/LocalLookupScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.traversalIndex
@@ -149,8 +150,13 @@ private fun LocalLookupScreen(
                     postcode = PostcodeSanitizer.sanitize(it)
                 },
                 label = {
+                    val contentDescPostcodeEntry =
+                        stringResource(R.string.local_content_desc_postcode_entry)
                     Text(
-                        text = stringResource(R.string.local_postcode_default_text)
+                        text = stringResource(R.string.local_postcode_default_text),
+                        Modifier.semantics {
+                            contentDescription = contentDescPostcodeEntry
+                        }
                     )
                 },
                 modifier = Modifier.fillMaxWidth()

--- a/feature/local/src/main/res/values/strings.xml
+++ b/feature/local/src/main/res/values/strings.xml
@@ -40,4 +40,5 @@
   <string name="local_confirmation_two_tier_bullet_title">Your local councils are:</string>
   <string name="local_confirmation_two_tier_description_2">You can now access your local council\'s websites from the bottom of the app home page.</string>
   <string name="local_confirmation_button">Done</string>
+  <string name="local_content_desc_postcode_entry">Postcode entry field</string>
 </resources>


### PR DESCRIPTION
# Info and relationships - What is your postcode?

Add content description to postcode entry textfield
Content description was intentionally applied to the TextField placeholder Text as it read 'Postcode' out twice when applied directly to the TextField and so sounded odd.

## JIRA ticket(s)
  - [GOVUKAPP-1912](https://govukverify.atlassian.net/browse/GOVUKAPP-1912)

## Video

https://github.com/user-attachments/assets/9d8ef65f-aee7-4f28-9875-2e0612cb204e




[GOVUKAPP-1912]: https://govukverify.atlassian.net/browse/GOVUKAPP-1912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ