### PR TITLE
GOVUKAPP-1867: Biometrics on settings

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/data/AppRepo.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/data/AppRepo.kt
@@ -14,6 +14,8 @@ internal class AppRepo @Inject constructor(
 
     internal suspend fun skipBiometrics() = appDataStore.skipBiometrics()
 
+    internal suspend fun clearBiometricsSkipped() = appDataStore.clearBiometricsSkipped()
+
     internal suspend fun isTopicSelectionCompleted() = appDataStore.isTopicSelectionCompleted()
 
     internal suspend fun topicSelectionCompleted() = appDataStore.topicSelectionCompleted()

--- a/app/src/main/kotlin/uk/gov/govuk/data/local/AppDataStore.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/data/local/AppDataStore.kt
@@ -34,6 +34,12 @@ internal class AppDataStore @Inject constructor(
         }
     }
 
+    internal suspend fun clearBiometricsSkipped() {
+        dataStore.edit { prefs ->
+            prefs.remove(booleanPreferencesKey(SKIPPED_BIOMETRICS_KEY))
+        }
+    }
+
     internal suspend fun isTopicSelectionCompleted(): Boolean {
         return dataStore.data.firstOrNull()
             ?.get(booleanPreferencesKey(TOPIC_SELECTION_COMPLETED_KEY)) == true

--- a/app/src/main/kotlin/uk/gov/govuk/login/BiometricSettingsViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/BiometricSettingsViewModel.kt
@@ -1,0 +1,52 @@
+package uk.gov.govuk.login
+
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import uk.gov.govuk.R
+import uk.gov.govuk.analytics.AnalyticsClient
+import uk.gov.govuk.data.auth.AuthRepo
+import javax.inject.Inject
+
+@HiltViewModel
+internal class BiometricSettingsViewModel @Inject constructor(
+    private val authRepo: AuthRepo,
+    private val analyticsClient: AnalyticsClient
+) : ViewModel() {
+
+    companion object {
+        private const val SCREEN_CLASS = "BiometricSettingsScreen"
+        private const val SCREEN_NAME = "Biometric Settings"
+        private const val TITLE = "Biometric Settings"
+    }
+
+    private val _uiState: MutableStateFlow<Boolean> = MutableStateFlow(authRepo.isUserSignedIn())
+    val uiState = _uiState.asStateFlow()
+
+    fun onPageView() {
+        analyticsClient.screenView(
+            screenClass = SCREEN_CLASS,
+            screenName = SCREEN_NAME,
+            title = TITLE
+        )
+    }
+
+    fun onToggle(activity: FragmentActivity) {
+        viewModelScope.launch {
+            if (authRepo.isUserSignedIn()) {
+                authRepo.signOut()
+            } else {
+                authRepo.persistRefreshToken(
+                    activity = activity,
+                    title = activity.getString(R.string.login_biometric_prompt_title)
+                )
+            }
+
+            _uiState.value = authRepo.isUserSignedIn()
+        }
+    }
+}

--- a/app/src/main/kotlin/uk/gov/govuk/login/BiometricSettingsViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/BiometricSettingsViewModel.kt
@@ -40,7 +40,7 @@ internal class BiometricSettingsViewModel @Inject constructor(
     fun onToggle(text: String, activity: FragmentActivity) {
         viewModelScope.launch {
             val action = if (authRepo.isUserSignedIn()) {
-                authRepo.signOut()
+                authRepo.clearLocalAuth()
                 BIOMETRICS_SETTINGS_DISABLE
             } else {
                 appRepo.clearBiometricsSkipped()
@@ -59,7 +59,5 @@ internal class BiometricSettingsViewModel @Inject constructor(
 
             _uiState.value = authRepo.isUserSignedIn()
         }
-
-
     }
 }

--- a/app/src/main/kotlin/uk/gov/govuk/login/BiometricViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/BiometricViewModel.kt
@@ -24,8 +24,6 @@ internal class BiometricViewModel @Inject constructor(
         private const val SCREEN_CLASS = "BiometricScreen"
         private const val SCREEN_NAME = "Biometrics"
         private const val TITLE = "Biometrics"
-
-        private const val SECTION = "Biometrics"
     }
 
     private val _uiState: MutableStateFlow<Boolean> = MutableStateFlow(false)
@@ -42,7 +40,7 @@ internal class BiometricViewModel @Inject constructor(
     fun onContinue(activity: FragmentActivity, text: String) {
         analyticsClient.buttonClick(
             text = text,
-            section = SECTION
+            section = BIOMETRICS_SECTION
         )
 
         viewModelScope.launch {
@@ -56,7 +54,7 @@ internal class BiometricViewModel @Inject constructor(
     fun onSkip(text: String) {
         analyticsClient.buttonClick(
             text = text,
-            section = SECTION
+            section = BIOMETRICS_SECTION
         )
 
         viewModelScope.launch {

--- a/app/src/main/kotlin/uk/gov/govuk/login/ErrorViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/ErrorViewModel.kt
@@ -27,7 +27,7 @@ internal class ErrorViewModel @Inject constructor(
     fun onBack(text: String) {
         analyticsClient.buttonClick(
             text = text,
-            section = SECTION
+            section = LOGIN_SECTION
         )
     }
 }

--- a/app/src/main/kotlin/uk/gov/govuk/login/LoginAnalytics.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/LoginAnalytics.kt
@@ -2,3 +2,6 @@ package uk.gov.govuk.login
 
 internal const val LOGIN_SECTION = "Login"
 internal const val BIOMETRICS_SECTION = "Biometrics"
+
+internal const val BIOMETRICS_SETTINGS_ENABLE = "Enable"
+internal const val BIOMETRICS_SETTINGS_DISABLE = "Disable"

--- a/app/src/main/kotlin/uk/gov/govuk/login/LoginAnalytics.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/LoginAnalytics.kt
@@ -1,3 +1,4 @@
 package uk.gov.govuk.login
 
-internal const val SECTION = "Login"
+internal const val LOGIN_SECTION = "Login"
+internal const val BIOMETRICS_SECTION = "Biometrics"

--- a/app/src/main/kotlin/uk/gov/govuk/login/LoginSuccessViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/LoginSuccessViewModel.kt
@@ -28,7 +28,7 @@ internal class LoginSuccessViewModel @Inject constructor(
     fun onContinue(text: String) {
         analyticsClient.buttonClick(
             text = text,
-            section = SECTION
+            section = LOGIN_SECTION
         )
     }
 }

--- a/app/src/main/kotlin/uk/gov/govuk/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/LoginViewModel.kt
@@ -66,7 +66,7 @@ internal class LoginViewModel @Inject constructor(
     fun onContinue(text: String) {
         analyticsClient.buttonClick(
             text = text,
-            section = SECTION
+            section = LOGIN_SECTION
         )
     }
 

--- a/app/src/main/kotlin/uk/gov/govuk/login/navigation/LoginNavigation.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/navigation/LoginNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import uk.gov.govuk.login.ui.BiometricRoute
+import uk.gov.govuk.login.ui.BiometricSettingsRoute
 import uk.gov.govuk.login.ui.ErrorRoute
 import uk.gov.govuk.login.ui.LoginRoute
 import uk.gov.govuk.login.ui.LoginSuccessRoute
@@ -14,6 +15,7 @@ const val LOGIN_GRAPH_ROUTE = "login_graph_route"
 const val LOGIN_ROUTE = "login_route"
 private const val LOGIN_SUCCESS_ROUTE = "login_success_route"
 const val BIOMETRIC_ROUTE = "biometric_route"
+const val BIOMETRIC_SETTINGS_ROUTE = "biometric_settings_route"
 const val ERROR_ROUTE = "login_error_route"
 
 fun NavGraphBuilder.loginGraph(
@@ -51,6 +53,12 @@ fun NavGraphBuilder.loginGraph(
         composable(BIOMETRIC_ROUTE) {
             BiometricRoute(
                 onCompleted = { onBiometricSetupCompleted() },
+                modifier = modifier
+            )
+        }
+        composable(BIOMETRIC_SETTINGS_ROUTE) {
+            BiometricSettingsRoute(
+                onBack = { navController.popBackStack() },
                 modifier = modifier
             )
         }

--- a/app/src/main/kotlin/uk/gov/govuk/login/ui/BiometricSettingsScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/ui/BiometricSettingsScreen.kt
@@ -43,7 +43,7 @@ internal fun BiometricSettingsRoute(
         onBack = onBack,
         onPageView = { viewModel.onPageView() },
         isUserSignedIn = uiState,
-        onToggle = { viewModel.onToggle(activity) },
+        onToggle = { text -> viewModel.onToggle(text, activity) },
         modifier = modifier
     )
 }
@@ -53,7 +53,7 @@ private fun BiometricSettingsScreen(
     onBack: () -> Unit,
     onPageView: () -> Unit,
     isUserSignedIn: Boolean,
-    onToggle: () -> Unit,
+    onToggle: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LaunchedEffect(Unit) {
@@ -88,10 +88,11 @@ private fun BiometricSettingsScreen(
             LargeVerticalSpacer()
 
             Column(Modifier.padding(horizontal = GovUkTheme.spacing.medium)) {
+                val title = stringResource(R.string.biometric_settings_toggle)
                 ToggleListItem(
-                    title = stringResource(R.string.biometric_settings_toggle),
+                    title = title,
                     checked = isUserSignedIn,
-                    onCheckedChange = { onToggle() }
+                    onCheckedChange = { onToggle(title) }
                 )
 
                 MediumVerticalSpacer()

--- a/app/src/main/kotlin/uk/gov/govuk/login/ui/BiometricSettingsScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/ui/BiometricSettingsScreen.kt
@@ -1,0 +1,128 @@
+package uk.gov.govuk.login.ui
+
+import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.fragment.app.FragmentActivity
+import androidx.hilt.navigation.compose.hiltViewModel
+import uk.gov.govuk.R
+import uk.gov.govuk.design.ui.component.BodyRegularLabel
+import uk.gov.govuk.design.ui.component.ChildPageHeader
+import uk.gov.govuk.design.ui.component.LargeTitleBoldLabel
+import uk.gov.govuk.design.ui.component.LargeVerticalSpacer
+import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
+import uk.gov.govuk.design.ui.component.ToggleListItem
+import uk.gov.govuk.design.ui.theme.GovUkTheme
+import uk.gov.govuk.login.BiometricSettingsViewModel
+
+@Composable
+internal fun BiometricSettingsRoute(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val viewModel: BiometricSettingsViewModel = hiltViewModel()
+    val uiState by viewModel.uiState.collectAsState()
+
+    val activity = LocalActivity.current as FragmentActivity
+
+    BiometricSettingsScreen(
+        onBack = onBack,
+        onPageView = { viewModel.onPageView() },
+        isUserSignedIn = uiState,
+        onToggle = { viewModel.onToggle(activity) },
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun BiometricSettingsScreen(
+    onBack: () -> Unit,
+    onPageView: () -> Unit,
+    isUserSignedIn: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LaunchedEffect(Unit) {
+        onPageView()
+    }
+
+    Column(modifier.fillMaxWidth()) {
+        ChildPageHeader(
+            onBack = onBack
+        )
+
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = GovUkTheme.spacing.large)
+        ) {
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .background(GovUkTheme.colourScheme.surfaces.homeHeader)
+            ) {
+                LargeTitleBoldLabel(
+                    text = stringResource(R.string.biometric_settings_title),
+                    modifier = Modifier
+                        .padding(horizontal = GovUkTheme.spacing.medium)
+                        .semantics { heading() },
+                    color = GovUkTheme.colourScheme.textAndIcons.header
+                )
+            }
+
+            LargeVerticalSpacer()
+
+            Column(Modifier.padding(horizontal = GovUkTheme.spacing.medium)) {
+                ToggleListItem(
+                    title = stringResource(R.string.biometric_settings_toggle),
+                    checked = isUserSignedIn,
+                    onCheckedChange = { onToggle() }
+                )
+
+                MediumVerticalSpacer()
+
+                BodyRegularLabel(stringResource(R.string.biometric_settings_description_1))
+
+                MediumVerticalSpacer()
+
+                BodyRegularLabel(stringResource(R.string.biometric_settings_description_2))
+
+                MediumVerticalSpacer()
+
+                BodyRegularLabel(stringResource(R.string.biometric_settings_description_3))
+
+                MediumVerticalSpacer()
+
+                BodyRegularLabel(stringResource(R.string.biometric_settings_description_4))
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BiometricSettingsPreview() {
+    GovUkTheme {
+        BiometricSettingsScreen(
+            onBack = { },
+            onPageView = { },
+            isUserSignedIn = true,
+            onToggle = { }
+        )
+    }
+}

--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -63,6 +63,7 @@ import uk.gov.govuk.extension.asDeepLinks
 import uk.gov.govuk.extension.getUrlParam
 import uk.gov.govuk.home.navigation.HOME_GRAPH_START_DESTINATION
 import uk.gov.govuk.home.navigation.homeGraph
+import uk.gov.govuk.login.navigation.BIOMETRIC_SETTINGS_ROUTE
 import uk.gov.govuk.login.navigation.LOGIN_ROUTE
 import uk.gov.govuk.login.navigation.loginGraph
 import uk.gov.govuk.navigation.DeepLink
@@ -456,6 +457,7 @@ private fun GovUkNavHost(
         )
         settingsGraph(
             navigateTo = { route -> navController.navigate(route) },
+            onBiometricsClick = { navController.navigate(BIOMETRIC_SETTINGS_ROUTE) },
             appVersion = BuildConfig.VERSION_NAME_USER_FACING,
             deepLinks = { it.asDeepLinks(DeepLink.allowedAppUrls) },
             launchBrowser = { url -> browserLauncher.launchPartial(context = context, url = url) },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,4 +42,11 @@
 
     <string name="login_biometric_prompt_title">Confirm that it\'s you</string>
 
+    <string name="biometric_settings_title">Biometrics</string>
+    <string name="biometric_settings_toggle">Unlock app with biometrics</string>
+    <string name="biometric_settings_description_1">If you have biometrics turned on, you’ll be able to use your fingerprint, face or iris to unlock the app within 90 days of entering your GOV.UK One Login details.</string>
+    <string name="biometric_settings_description_2">If you do not want to use biometrics, you can use your phone’s pin or pattern instead.</string>
+    <string name="biometric_settings_description_3">Anyone who can unlock your phone with their fingerprint, face or iris or with your phone’s pin or pattern might be able to access your app.</string>
+    <string name="biometric_settings_description_4">You can turn off biometrics at any time.</string>
+
 </resources>

--- a/app/src/test/kotlin/uk/gov/govuk/data/AppRepoTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/data/AppRepoTest.kt
@@ -52,6 +52,17 @@ class AppRepoTest {
     }
 
     @Test
+    fun `Given skip biometrics is cleared, then update data store`() {
+        val repo = AppRepo(appDataStore)
+
+        runTest {
+            repo.clearBiometricsSkipped()
+
+            coVerify { appDataStore.clearBiometricsSkipped() }
+        }
+    }
+
+    @Test
     fun `Given the user has not previously completed topic selection, When is topic selection completed, then return false`() {
         val repo = AppRepo(appDataStore)
 

--- a/app/src/test/kotlin/uk/gov/govuk/data/local/AppDataStoreTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/data/local/AppDataStoreTest.kt
@@ -97,6 +97,22 @@ class AppDataStoreTest {
     }
 
     @Test
+    fun `Given skip biometrics is cleared, then update the prefs`() {
+        val appDatastore = AppDataStore(dataStore)
+
+        runTest {
+            appDatastore.skipBiometrics()
+
+            assertTrue(appDatastore.hasSkippedBiometrics())
+
+            appDatastore.clearBiometricsSkipped()
+
+            assertFalse(appDatastore.hasSkippedBiometrics())
+            assertFalse(dataStore.data.first().contains(booleanPreferencesKey(SKIPPED_BIOMETRICS_KEY)))
+        }
+    }
+
+    @Test
     fun `Given the data store is empty, When is topic selection completed, then return false`() {
         val appDatastore = AppDataStore(dataStore)
 

--- a/app/src/test/kotlin/uk/gov/govuk/login/BiometricSettingsViewModelTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/BiometricSettingsViewModelTest.kt
@@ -1,0 +1,114 @@
+package uk.gov.govuk.login
+
+import androidx.fragment.app.FragmentActivity
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import uk.gov.govuk.analytics.AnalyticsClient
+import uk.gov.govuk.data.AppRepo
+import uk.gov.govuk.data.auth.AuthRepo
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BiometricSettingsViewModelTest {
+
+    private val appRepo = mockk<AppRepo>(relaxed = true)
+    private val authRepo = mockk<AuthRepo>(relaxed = true)
+    private val analyticsClient = mockk<AnalyticsClient>(relaxed = true)
+    private val activity = mockk<FragmentActivity>(relaxed = true)
+    private val dispatcher = UnconfinedTestDispatcher()
+
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `Given a page view, then log analytics`() {
+        val viewModel = BiometricSettingsViewModel(appRepo, authRepo, analyticsClient)
+
+        viewModel.onPageView()
+
+        verify {
+            analyticsClient.screenView(
+                screenClass = "BiometricSettingsScreen",
+                screenName = "Biometric Settings",
+                title = "Biometric Settings"
+            )
+        }
+    }
+
+    @Test
+    fun `Given a user is signed in, when toggle, then clear local auth, log analytics and emit ui state`() {
+        every { authRepo.isUserSignedIn() } returns true andThen true andThen false
+
+        val viewModel = BiometricSettingsViewModel(appRepo, authRepo, analyticsClient)
+
+        runTest {
+            val uiStates = mutableListOf<Boolean>()
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.toList(uiStates)
+            }
+
+            viewModel.onToggle("text", activity)
+
+            verify {
+                analyticsClient.toggleFunction(
+                    "text",
+                    BIOMETRICS_SECTION,
+                    BIOMETRICS_SETTINGS_DISABLE
+                )
+            }
+            coVerify { authRepo.clearLocalAuth() }
+
+            assertFalse(uiStates.last())
+        }
+    }
+
+    @Test
+    fun `Given a user is not signed in, when toggle, then persist refresh token, log analytics and emit ui state`() {
+        every { authRepo.isUserSignedIn() } returns false andThen false andThen true
+
+        val viewModel = BiometricSettingsViewModel(appRepo, authRepo, analyticsClient)
+
+        runTest {
+            val uiStates = mutableListOf<Boolean>()
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.toList(uiStates)
+            }
+
+            viewModel.onToggle("text", activity)
+
+            verify {
+                analyticsClient.toggleFunction(
+                    "text",
+                    BIOMETRICS_SECTION,
+                    BIOMETRICS_SETTINGS_ENABLE
+                )
+            }
+            coVerify { authRepo.persistRefreshToken(any(), any()) }
+
+            assertTrue(uiStates.last())
+        }
+    }
+
+}

--- a/app/src/test/kotlin/uk/gov/govuk/login/BiometricViewModelTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/BiometricViewModelTest.kt
@@ -61,7 +61,7 @@ class BiometricViewModelTest {
         verify {
             analyticsClient.buttonClick(
                 text = "button text",
-                section = "Biometrics"
+                section = BIOMETRICS_SECTION
             )
         }
     }
@@ -73,7 +73,7 @@ class BiometricViewModelTest {
         coVerify {
             analyticsClient.buttonClick(
                 text = "button text",
-                section = "Biometrics"
+                section = BIOMETRICS_SECTION
             )
 
             appRepo.skipBiometrics()

--- a/app/src/test/kotlin/uk/gov/govuk/login/LoginSuccessViewModelTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/LoginSuccessViewModelTest.kt
@@ -50,7 +50,7 @@ class LoginSuccessViewModelTest {
         verify {
             analyticsClient.buttonClick(
                 text = "button text",
-                section = "Login"
+                section = LOGIN_SECTION
             )
         }
     }

--- a/app/src/test/kotlin/uk/gov/govuk/login/LoginViewModelTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/LoginViewModelTest.kt
@@ -106,7 +106,7 @@ class LoginViewModelTest {
         verify {
             analyticsClient.buttonClick(
                 text = "button text",
-                section = "Login"
+                section = LOGIN_SECTION
             )
         }
     }

--- a/data/src/main/kotlin/uk/gov/govuk/data/auth/AuthRepo.kt
+++ b/data/src/main/kotlin/uk/gov/govuk/data/auth/AuthRepo.kt
@@ -224,6 +224,10 @@ class AuthRepo @Inject constructor(
     }
 
     suspend fun signOut(): Boolean {
+        return clearLocalAuth()
+    }
+
+    suspend fun clearLocalAuth(): Boolean {
         try {
             secureStore.delete(REFRESH_TOKEN_KEY)
 

--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/SettingsViewModel.kt
@@ -29,6 +29,7 @@ internal data class SettingsUiState(
     val userEmail: String,
     val isLoginEnabled: Boolean,
     val isNotificationsEnabled: Boolean,
+    val isAuthenticationEnabled: Boolean,
     val isAnalyticsEnabled: Boolean
 )
 
@@ -53,6 +54,7 @@ internal class SettingsViewModel @Inject constructor(
             userEmail = authRepo.getUserEmail(),
             isLoginEnabled = flagRepo.isLoginEnabled(),
             isNotificationsEnabled = flagRepo.isNotificationsEnabled(),
+            isAuthenticationEnabled = flagRepo.isLoginEnabled() && authRepo.isAuthenticationEnabled(),
             isAnalyticsEnabled = analyticsClient.isAnalyticsEnabled()
         )
     }

--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/SettingsViewModel.kt
@@ -118,6 +118,13 @@ internal class SettingsViewModel @Inject constructor(
         )
     }
 
+    fun onBiometricsClick(text: String) {
+        analyticsClient.settingsItemClick(
+            text = text,
+            external = false
+        )
+    }
+
     fun onTermsAndConditionsView() {
         analyticsClient.settingsItemClick(
             text = TERMS_AND_CONDITIONS_EVENT,

--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/navigation/SettingsNavigation.kt
@@ -33,6 +33,7 @@ const val SIGN_OUT_ERROR_ROUTE = "sign_out_error_route"
 
 fun NavGraphBuilder.settingsGraph(
     navigateTo: (String) -> Unit,
+    onBiometricsClick: () -> Unit,
     appVersion: String,
     deepLinks: (path: String) -> List<NavDeepLink>,
     launchBrowser: (url: String) -> Unit,
@@ -58,6 +59,7 @@ fun NavGraphBuilder.settingsGraph(
                     onNotificationsClick = {
                         navigateTo(NOTIFICATIONS_PERMISSION_GRAPH_ROUTE)
                     },
+                    onBiometricsClick = onBiometricsClick,
                     onPrivacyPolicyClick = {
                         launchBrowser(PRIVACY_POLICY_URL)
                     },

--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/ui/SettingsScreen.kt
@@ -80,7 +80,10 @@ internal fun SettingsRoute(
                     viewModel.onNotificationsClick()
                     actions.onNotificationsClick()
                 },
-                onBiometricsClick = actions.onBiometricsClick,
+                onBiometricsClick = { text ->
+                    viewModel.onBiometricsClick(text)
+                    actions.onBiometricsClick()
+                },
                 onAnalyticsConsentChange = { enabled -> viewModel.onAnalyticsConsentChanged(enabled) },
                 onPrivacyPolicyClick = {
                     viewModel.onPrivacyPolicyView()
@@ -113,7 +116,7 @@ private class SettingsActions(
     val onAccountClick: () -> Unit,
     val onSignOutClick: () -> Unit,
     val onNotificationsClick: () -> Unit,
-    val onBiometricsClick: () -> Unit,
+    val onBiometricsClick: (String) -> Unit,
     val onAnalyticsConsentChange: (Boolean) -> Unit,
     val onPrivacyPolicyClick: () -> Unit,
     val onHelpClick: () -> Unit,
@@ -255,9 +258,10 @@ private fun NotificationsAndPrivacy(
         }
 
         if (uiState.isAuthenticationEnabled) {
+            val biometricTitle = stringResource(R.string.biometric_title)
             InternalLinkListItem(
-                title = stringResource(R.string.biometric_title),
-                onClick = actions.onBiometricsClick,
+                title = biometricTitle,
+                onClick = { actions.onBiometricsClick(biometricTitle) },
                 isFirst = !uiState.isNotificationsEnabled,
                 isLast = false
             )

--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/ui/SettingsScreen.kt
@@ -46,6 +46,7 @@ internal class SettingsRouteActions(
     val onAccountClick: () -> Unit,
     val onSignOutClick: () -> Unit,
     val onNotificationsClick: () -> Unit,
+    val onBiometricsClick: () -> Unit,
     val onPrivacyPolicyClick: () -> Unit,
     val onHelpClick: () -> Unit,
     val onAccessibilityStatementClick: () -> Unit,
@@ -79,6 +80,7 @@ internal fun SettingsRoute(
                     viewModel.onNotificationsClick()
                     actions.onNotificationsClick()
                 },
+                onBiometricsClick = actions.onBiometricsClick,
                 onAnalyticsConsentChange = { enabled -> viewModel.onAnalyticsConsentChanged(enabled) },
                 onPrivacyPolicyClick = {
                     viewModel.onPrivacyPolicyView()
@@ -111,6 +113,7 @@ private class SettingsActions(
     val onAccountClick: () -> Unit,
     val onSignOutClick: () -> Unit,
     val onNotificationsClick: () -> Unit,
+    val onBiometricsClick: () -> Unit,
     val onAnalyticsConsentChange: (Boolean) -> Unit,
     val onPrivacyPolicyClick: () -> Unit,
     val onHelpClick: () -> Unit,
@@ -153,11 +156,8 @@ private fun SettingsScreen(
             }
 
             NotificationsAndPrivacy(
-                isNotificationsEnabled = uiState.isNotificationsEnabled,
-                isAnalyticsEnabled = uiState.isAnalyticsEnabled,
-                onNotificationsClick = actions.onNotificationsClick,
-                onAnalyticsConsentChange = actions.onAnalyticsConsentChange,
-                onPrivacyPolicyClick = actions.onPrivacyPolicyClick
+                uiState = uiState,
+                actions = actions
             )
 
             MediumVerticalSpacer()
@@ -241,27 +241,33 @@ private fun ManageLogin(
 
 @Composable
 private fun NotificationsAndPrivacy(
-    isNotificationsEnabled: Boolean,
-    isAnalyticsEnabled: Boolean,
-    onNotificationsClick: () -> Unit,
-    onAnalyticsConsentChange: (Boolean) -> Unit,
-    onPrivacyPolicyClick: () -> Unit,
+    uiState: SettingsUiState,
+    actions: SettingsActions,
     modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier
     ) {
-        if (isNotificationsEnabled) {
+        if (uiState.isNotificationsEnabled) {
             Notifications(
-                onNotificationsClick = onNotificationsClick
+                onNotificationsClick = actions.onNotificationsClick
+            )
+        }
+
+        if (uiState.isAuthenticationEnabled) {
+            InternalLinkListItem(
+                title = stringResource(R.string.biometric_title),
+                onClick = actions.onBiometricsClick,
+                isFirst = !uiState.isNotificationsEnabled,
+                isLast = false
             )
         }
 
         ToggleListItem(
             title = stringResource(R.string.share_setting),
-            checked = isAnalyticsEnabled,
-            onCheckedChange = onAnalyticsConsentChange,
-            isFirst = !isNotificationsEnabled
+            checked = uiState.isAnalyticsEnabled,
+            onCheckedChange = actions.onAnalyticsConsentChange,
+            isFirst = !uiState.isAuthenticationEnabled && !uiState.isNotificationsEnabled
         )
 
         SmallVerticalSpacer()
@@ -282,7 +288,7 @@ private fun NotificationsAndPrivacy(
                     contentDescription = altText
                 }
                 .padding(horizontal = GovUkTheme.spacing.medium)
-                .clickable(onClick = onPrivacyPolicyClick),
+                .clickable(onClick = actions.onPrivacyPolicyClick),
             color = GovUkTheme.colourScheme.textAndIcons.link,
         )
     }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
   <string name="terms_and_conditions_title">Terms and conditions</string>
   <string name="privacy_policy_title">Privacy notice</string>
   <string name="notifications_title">Notifications</string>
+  <string name="biometric_title">Biometrics</string>
 
   <string name="feedback_prompt_widget_title">Give feedback to help improve this app</string>
 

--- a/feature/settings/src/test/kotlin/uk/gov/govuk/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/uk/gov/govuk/settings/SettingsViewModelTest.kt
@@ -51,6 +51,7 @@ class SettingsViewModelTest {
 
         every { authRepo.getUserEmail() } returns "user@email.com"
         coEvery { flagRepo.isLoginEnabled() } returns true
+        coEvery { authRepo.isAuthenticationEnabled() } returns true
         coEvery { analyticsClient.isAnalyticsEnabled() } returns true
         coEvery { flagRepo.isNotificationsEnabled() } returns true
 
@@ -117,6 +118,38 @@ class SettingsViewModelTest {
         runTest {
             val result = viewModel.uiState.first()
             assertFalse(result!!.isNotificationsEnabled)
+        }
+    }
+
+    @Test
+    fun `Given login and authentication are enabled, When init, then return authentication enabled`() {
+        runTest {
+            val result = viewModel.uiState.first()
+            assertTrue(result!!.isAuthenticationEnabled)
+        }
+    }
+
+    @Test
+    fun `Given login is enabled and authentication is disabled, When init, then return authentication disabled`() {
+        every { authRepo.isAuthenticationEnabled() } returns false
+
+        val viewModel = SettingsViewModel(authRepo, flagRepo, analyticsClient)
+
+        runTest {
+            val result = viewModel.uiState.first()
+            assertFalse(result!!.isAuthenticationEnabled)
+        }
+    }
+
+    @Test
+    fun `Given login is disabled and authentication is enabled, When init, then return authentication disabled`() {
+        every { flagRepo.isLoginEnabled() } returns false
+
+        val viewModel = SettingsViewModel(authRepo, flagRepo, analyticsClient)
+
+        runTest {
+            val result = viewModel.uiState.first()
+            assertFalse(result!!.isAuthenticationEnabled)
         }
     }
 
@@ -235,6 +268,18 @@ class SettingsViewModelTest {
             screenName = NOTIFICATIONS_PERMISSION_EVENT,
             title = NOTIFICATIONS_PERMISSION_EVENT
         )
+    }
+
+    @Test
+    fun `Given a biometrics click, then log analytics`() {
+        viewModel.onBiometricsClick("text")
+
+        verify {
+            analyticsClient.settingsItemClick(
+                text = "text",
+                external = false
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
# Title

Add biometrics settings item and screen to allow users to enable/disable biometrics.

## JIRA ticket(s)
  - [GOVUKAPP-1867](https://govukverify.atlassian.net/browse/GOVUKAPP-1867)

## Figma
  - [Figma board](https://www.figma.com/design/5u5cvVCgKY3Rng2ADNV30K/2024-07---GOV.UK-app---beta-designs?node-id=6627-9478&t=FPt6tSudqfkRcGnG-4)

## Screen shots
![Screenshot_20250616_091320](https://github.com/user-attachments/assets/fad58e7a-ec61-4d79-8de3-b4abfde7658b)
![Screenshot_20250616_091312](https://github.com/user-attachments/assets/60391586-42c0-46e9-a182-fb9aed7ea7c0)
![Screenshot_20250616_091257](https://github.com/user-attachments/assets/d93e07d7-f43a-4642-826a-1265493c8da9)

