### PR TITLE
GOVUKAPP-1950 : minor content fix on local success screen for a two-tier response

### DIFF
--- a/feature/local/src/main/res/values/strings.xml
+++ b/feature/local/src/main/res/values/strings.xml
@@ -38,7 +38,7 @@
   <string name="local_confirmation_two_tier_title">Services in your area are provided by 2 local councils</string>
   <string name="local_confirmation_two_tier_description_1">Different local councils are responsible for different services.</string>
   <string name="local_confirmation_two_tier_bullet_title">Your local councils are:</string>
-  <string name="local_confirmation_two_tier_description_2">You can now access your local council\'s websites from the bottom of the app home page.</string>
+  <string name="local_confirmation_two_tier_description_2">You can now access your local councils\' websites from the bottom of the app home page.</string>
   <string name="local_confirmation_button">Done</string>
   <string name="local_content_desc_postcode_entry">Postcode entry field</string>
 </resources>


### PR DESCRIPTION
Reason: "council's" is the singular possessive, meaning "belonging to one council," while "councils'" is the plural possessive, meaning "belonging to multiple councils."

## JIRA ticket(s)
  - [GOVUKAPP-1950](https://govukverify.atlassian.net/browse/GOVUKAPP-1950)

## Screen shots

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/14d8f819-88d5-41b5-a20d-eb97e3e56bb6) | ![after](https://github.com/user-attachments/assets/4b1e0bb8-2897-4299-b388-9c9193dbf760) |



[GOVUKAPP-1950]: https://govukverify.atlassian.net/browse/GOVUKAPP-1950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ