### PR TITLE
GOVUKAPP-1947 Cached cognito request

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.appcheck.play)
+    implementation(libs.androidx.browser)
 
     ksp(libs.hilt.compiler)
 

--- a/data/src/main/kotlin/uk/gov/govuk/data/auth/AuthRepo.kt
+++ b/data/src/main/kotlin/uk/gov/govuk/data/auth/AuthRepo.kt
@@ -5,6 +5,8 @@ import android.content.SharedPreferences
 import android.util.Base64
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.ExperimentalEphemeralBrowsing
 import androidx.core.content.edit
 import androidx.fragment.app.FragmentActivity
 import net.openid.appauth.AuthorizationException
@@ -44,8 +46,12 @@ class AuthRepo @Inject constructor(
         private const val SUB_ID_KEY = "subId"
     }
 
+    @ExperimentalEphemeralBrowsing
     val authIntent: Intent by lazy {
-        authService.getAuthorizationRequestIntent(authRequest)
+        val intent = CustomTabsIntent.Builder()
+            .setEphemeralBrowsingEnabled(true)
+            .build()
+        authService.getAuthorizationRequestIntent(authRequest, intent)
     }
 
     private var tokens = Tokens()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ sonarqube = "5.0.0.4638"
 playServicesMeasurementApi = "22.4.0"
 playServicesOssLicenses = "17.1.0"
 googleAccompanist = "0.37.0"
-browser = "1.8.0"
+browser = "1.9.0-alpha01"
 
 openid = "0.11.1"
 


### PR DESCRIPTION
# Cached cognito request

- Update browser library and set ephemeral browsing enabled on browser that presents One Login
- Note: there are newer alpha browser versions than 1.9.0-alpha01 but they require a compile version of 36 and our is currently 35. We will be targeting 36 in the future.

## JIRA ticket(s)
  - [GOVUKAPP-1947](https://govukverify.atlassian.net/browse/GOVUKAPP-1947)

[GOVUKAPP-1947]: https://govukverify.atlassian.net/browse/GOVUKAPP-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ