### PR TITLE
GOVUKAPP-2067 Navigation crash

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -198,21 +198,21 @@ private fun BottomNavScaffold(
                 shouldShowExternalBrowser = shouldShowExternalBrowser,
                 paddingValues = paddingValues
             )
+
+            /* Uncomment when deep links are live
+            HandleReceivedIntents(
+                intentFlow = intentFlow,
+                navController = { navController },
+                shouldShowExternalBrowser = shouldShowExternalBrowser,
+            ) { hasDeepLink, url ->
+                viewModel.onDeepLinkReceived(hasDeepLink, url)
+            }
+            */
+
+            if (shouldDisplayNotificationsOnboarding) {
+                HandleNotificationsPermissionStatus(navController = { navController })
+            }
         }
-    }
-
-    /* Uncomment when deep links are live
-    HandleReceivedIntents(
-        intentFlow = intentFlow,
-        navController = { navController },
-        shouldShowExternalBrowser = shouldShowExternalBrowser,
-    ) { hasDeepLink, url ->
-        viewModel.onDeepLinkReceived(hasDeepLink, url)
-    }
-    */
-
-    if (shouldDisplayNotificationsOnboarding) {
-        HandleNotificationsPermissionStatus(navController = { navController })
     }
 }
 
@@ -228,12 +228,19 @@ private fun HandleReceivedIntents(
     LaunchedEffect(intentFlow) {
         intentFlow.collectLatest { intent ->
             intent.data?.let { uri ->
-                if (navController().graph.hasDeepLink(uri)) {
+                val controller = navController()
+                try {
+                    controller.graph
+                } catch (e: IllegalStateException) {
+                    // Nav graph has not been set
+                    return@collectLatest
+                }
+                if (controller.graph.hasDeepLink(uri)) {
                     onDeepLinkReceived(true, uri.toString())
                     val request = NavDeepLinkRequest.Builder
                         .fromUri(uri)
                         .build()
-                    navController().navigate(
+                    controller.navigate(
                         request,
                         navOptions = NavOptions.Builder().setLaunchSingleTop(true).build()
                     )
@@ -273,12 +280,19 @@ private fun HandleNotificationsPermissionStatus(
     LaunchedEffect(lifecycleState) {
         when (lifecycleState) {
             Lifecycle.State.RESUMED -> {
-                val route = when (navController().currentDestination?.route) {
+                val controller = navController()
+                try {
+                    controller.graph
+                } catch (e: IllegalStateException) {
+                    // Nav graph has not been set
+                    return@LaunchedEffect
+                }
+                val route = when (controller.currentDestination?.route) {
                     NOTIFICATIONS_ONBOARDING_ROUTE -> NOTIFICATIONS_ONBOARDING_ROUTE
                     NOTIFICATIONS_PERMISSION_ROUTE -> return@LaunchedEffect
                     else -> NOTIFICATIONS_CONSENT_GRAPH_ROUTE
                 }
-                navController().navigate(route) {
+                controller.navigate(route) {
                     launchSingleTop = true
                 }
             }


### PR DESCRIPTION
# Navigation crash

- I have been unable to reproduce this crash and it didn't appear during initial dev testing of notifications.
- Currently we read properties and call functions on navcontroller in OnResume. 
- Code has been refactored in this change so the current instance of navcontroller is always read as we are reading it during lifecycle events when new objects could be instantiated.
- Add a try-catch to check that the navcontroller has a nav graph set.
- Move functions which call the navcontroller into the scope where the navhost is instantiated - _I suspect this is the actual reason for the crash that the navcontrollers properties and functions are read and called before navhost has been instantiated_.
- Also made the same change for currently commented out code that handles received intents.

https://console.firebase.google.com/project/govuk-app-production/crashlytics/app/android:uk.gov.govuk/issues/b50f41d93d6600859577a82a8d161d0d?time=last-seven-days&types=crash&sessionEventKey=68639DE400BB000172CA841D020367B8_2100475027185220839

## JIRA ticket(s)
  - [GOVUKAPP-2067](https://govukverify.atlassian.net/browse/GOVUKAPP-2067)

[GOVUKAPP-2067]: https://govukverify.atlassian.net/browse/GOVUKAPP-2067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ