### PR TITLE
GOVUKAPP-2149 Enable biometrics for devices running Android 9 or 10

### DIFF
--- a/data/src/main/kotlin/uk/gov/govuk/data/auth/AuthRepo.kt
+++ b/data/src/main/kotlin/uk/gov/govuk/data/auth/AuthRepo.kt
@@ -2,6 +2,7 @@ package uk.gov.govuk.data.auth
 
 import android.content.Intent
 import android.content.SharedPreferences
+import android.os.Build
 import android.util.Base64
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators
@@ -199,11 +200,14 @@ class AuthRepo @Inject constructor(
         )
     }
 
-    fun isAuthenticationEnabled(): Boolean {
-        val result  = biometricManager.canAuthenticate(
+    fun isAuthenticationEnabled(androidVersion: Int = Build.VERSION.SDK_INT): Boolean {
+        val authenticators = if (androidVersion > Build.VERSION_CODES.Q) {
+            // DEVICE_CREDENTIAL only supported after Android 29
             Authenticators.BIOMETRIC_STRONG or Authenticators.DEVICE_CREDENTIAL
-        )
-        return result == BiometricManager.BIOMETRIC_SUCCESS
+        } else {
+            Authenticators.BIOMETRIC_STRONG
+        }
+        return biometricManager.canAuthenticate(authenticators) == BiometricManager.BIOMETRIC_SUCCESS
     }
 
     fun isUserSessionActive(): Boolean {

--- a/data/src/test/kotlin/uk/gov/govuk/data/auth/AuthRepoTest.kt
+++ b/data/src/test/kotlin/uk/gov/govuk/data/auth/AuthRepoTest.kt
@@ -2,6 +2,7 @@ package uk.gov.govuk.data.auth
 
 import android.content.Intent
 import android.content.SharedPreferences
+import android.os.Build
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators
 import androidx.biometric.BiometricManager.BIOMETRIC_SUCCESS
@@ -318,25 +319,39 @@ class AuthRepoTest {
     }
 
     @Test
-    fun `Given biometric success, when is authentication enabled, return true`() {
+    fun `Given the Android version is 30 and biometric success, when is authentication enabled, return true`() {
         every {
             biometricManager.canAuthenticate(
                 Authenticators.BIOMETRIC_STRONG or Authenticators.DEVICE_CREDENTIAL
             )
         } returns  BIOMETRIC_SUCCESS
+        val androidVersion = Build.VERSION_CODES.R
 
-        assertTrue(authRepo.isAuthenticationEnabled())
+        assertTrue(authRepo.isAuthenticationEnabled(androidVersion))
     }
 
     @Test
-    fun `Given non biometric success, when is authentication enabled, return false`() {
+    fun `Given the Android version is 29 and biometric success, when is authentication enabled, return true`() {
+        every {
+            biometricManager.canAuthenticate(
+                Authenticators.BIOMETRIC_STRONG
+            )
+        } returns  BIOMETRIC_SUCCESS
+        val androidVersion = Build.VERSION_CODES.Q
+
+        assertTrue(authRepo.isAuthenticationEnabled(androidVersion))
+    }
+
+    @Test
+    fun `Given the Android version is 30 and non biometric success, when is authentication enabled, return false`() {
         every {
             biometricManager.canAuthenticate(
                 Authenticators.BIOMETRIC_STRONG or Authenticators.DEVICE_CREDENTIAL
             )
         } returns BiometricManager.BIOMETRIC_STATUS_UNKNOWN
+        val androidVersion = Build.VERSION_CODES.R
 
-        assertFalse(authRepo.isAuthenticationEnabled())
+        assertFalse(authRepo.isAuthenticationEnabled(androidVersion))
 
         every {
             biometricManager.canAuthenticate(
@@ -344,7 +359,7 @@ class AuthRepoTest {
             )
         } returns BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED
 
-        assertFalse(authRepo.isAuthenticationEnabled())
+        assertFalse(authRepo.isAuthenticationEnabled(androidVersion))
 
         every {
             biometricManager.canAuthenticate(
@@ -352,7 +367,7 @@ class AuthRepoTest {
             )
         } returns BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE
 
-        assertFalse(authRepo.isAuthenticationEnabled())
+        assertFalse(authRepo.isAuthenticationEnabled(androidVersion))
 
         every {
             biometricManager.canAuthenticate(
@@ -360,7 +375,7 @@ class AuthRepoTest {
             )
         } returns BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED
 
-        assertFalse(authRepo.isAuthenticationEnabled())
+        assertFalse(authRepo.isAuthenticationEnabled(androidVersion))
 
         every {
             biometricManager.canAuthenticate(
@@ -368,7 +383,7 @@ class AuthRepoTest {
             )
         } returns BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
 
-        assertFalse(authRepo.isAuthenticationEnabled())
+        assertFalse(authRepo.isAuthenticationEnabled(androidVersion))
 
         every {
             biometricManager.canAuthenticate(
@@ -376,7 +391,59 @@ class AuthRepoTest {
             )
         } returns BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED
 
-        assertFalse(authRepo.isAuthenticationEnabled())
+        assertFalse(authRepo.isAuthenticationEnabled(androidVersion))
+    }
+
+    @Test
+    fun `Given the Android version is 29 and non biometric success, when is authentication enabled, return false`() {
+        every {
+            biometricManager.canAuthenticate(
+                Authenticators.BIOMETRIC_STRONG
+            )
+        } returns BiometricManager.BIOMETRIC_STATUS_UNKNOWN
+        val androidVersion = Build.VERSION_CODES.Q
+
+        assertFalse(authRepo.isAuthenticationEnabled(androidVersion))
+
+        every {
+            biometricManager.canAuthenticate(
+                Authenticators.BIOMETRIC_STRONG
+            )
+        } returns BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED
+
+        assertFalse(authRepo.isAuthenticationEnabled(androidVersion))
+
+        every {
+            biometricManager.canAuthenticate(
+                Authenticators.BIOMETRIC_STRONG
+            )
+        } returns BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE
+
+        assertFalse(authRepo.isAuthenticationEnabled(androidVersion))
+
+        every {
+            biometricManager.canAuthenticate(
+                Authenticators.BIOMETRIC_STRONG
+            )
+        } returns BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED
+
+        assertFalse(authRepo.isAuthenticationEnabled(androidVersion))
+
+        every {
+            biometricManager.canAuthenticate(
+                Authenticators.BIOMETRIC_STRONG
+            )
+        } returns BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
+
+        assertFalse(authRepo.isAuthenticationEnabled(androidVersion))
+
+        every {
+            biometricManager.canAuthenticate(
+                Authenticators.BIOMETRIC_STRONG
+            )
+        } returns BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED
+
+        assertFalse(authRepo.isAuthenticationEnabled(androidVersion))
     }
 
     @Test


### PR DESCRIPTION
# Enable biometrics for devices running Android 9 or 10

- Set supported authenticators for different Android versions to enable biometrics on BIOMETRICS_STRONG devices running pre Android 11 (SDK 30)

## JIRA ticket(s)
  - [GOVUKAPP-2149](https://govukverify.atlassian.net/browse/GOVUKAPP-2149)

[GOVUKAPP-2149]: https://govukverify.atlassian.net/browse/GOVUKAPP-2149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ