### PR TITLE
GOVUKAPP-2137 : Add retryable error page

### DIFF
--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/data/ChatRepo.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/data/ChatRepo.kt
@@ -30,6 +30,10 @@ internal class ChatRepo @Inject constructor(
         }
     }
 
+    suspend fun clearConversation() {
+        dataStore.clearConversation()
+    }
+
     suspend fun askQuestion(question: String): ChatResult<AnsweredQuestion> {
         val conversationId = dataStore.conversationId()
         return if (conversationId != null) {

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/data/local/ChatDataStore.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/data/local/ChatDataStore.kt
@@ -27,4 +27,10 @@ internal class ChatDataStore @Inject constructor(
             preferences[stringPreferencesKey(CONVERSATION_ID_KEY)] = id
         }
     }
+
+    internal suspend fun clearConversation() {
+        dataStore.edit { preferences ->
+            preferences.remove(stringPreferencesKey(CONVERSATION_ID_KEY))
+        }
+    }
 }

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/ChatScreen.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/ChatScreen.kt
@@ -161,7 +161,7 @@ private fun ChatErrorPage(
     modifier: Modifier = Modifier,
     additionalText: String? = null,
     buttonText: String? = null,
-    onRetry: () -> Unit = {}
+    onRetry: (() -> Unit)? = null
 ) {
     CentreAlignedScreen(
         modifier = modifier,
@@ -200,7 +200,7 @@ private fun ChatErrorPage(
             }
         },
         footerContent = {
-            if (buttonText != null && onRetry != {}) {
+            if (buttonText != null && onRetry != null) {
                 MediumVerticalSpacer()
                 PrimaryButton(
                     text = buttonText,

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/ChatScreen.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/ChatScreen.kt
@@ -75,9 +75,11 @@ import uk.gov.govuk.chat.R
 import uk.gov.govuk.design.ui.component.BodyBoldLabel
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.CentreAlignedScreen
+import uk.gov.govuk.design.ui.component.ExtraLargeVerticalSpacer
 import uk.gov.govuk.design.ui.component.LargeHorizontalSpacer
 import uk.gov.govuk.design.ui.component.LargeTitleBoldLabel
 import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
+import uk.gov.govuk.design.ui.component.PrimaryButton
 import uk.gov.govuk.design.ui.component.SmallVerticalSpacer
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 import kotlin.math.abs
@@ -97,6 +99,9 @@ internal fun ChatRoute(
         onSubmit = { question ->
             viewModel.onSubmit(question)
         },
+        onRetry = {
+            viewModel.clearConversation()
+        },
         modifier = modifier
     )
 }
@@ -106,10 +111,16 @@ private fun ChatScreen(
     uiState: ChatUiState,
     onQuestionUpdated: (String) -> Unit,
     onSubmit: (String) -> Unit,
+    onRetry: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    if (uiState.isError) {
-        ChatErrorPage(modifier = modifier)
+    if (uiState.isRetryableError) {
+        ChatErrorPageWithRetry(
+            onRetry = onRetry,
+            modifier = modifier
+        )
+    } else if (uiState.isError) {
+        ChatErrorPageNoRetry(modifier)
     } else {
         ChatContent(
             uiState,
@@ -121,10 +132,37 @@ private fun ChatScreen(
 }
 
 @Composable
-private fun ChatErrorPage(
-    modifier: Modifier = Modifier,
+private fun ChatErrorPageWithRetry(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    // TODO: this probably should be a component like ErrorPage, but currently the need for links in text is only within Chat
+    ChatErrorPage(
+        subText = stringResource(id = R.string.error_retry_page_subtext),
+        modifier = modifier.padding(horizontal = GovUkTheme.spacing.medium),
+        additionalText = stringResource(id = R.string.error_retry_page_additional_text),
+        buttonText = stringResource(id = R.string.error_retry_button_text),
+        onRetry = onRetry
+    )
+}
+
+@Composable
+private fun ChatErrorPageNoRetry(
+    modifier: Modifier = Modifier
+) {
+    ChatErrorPage(
+        subText = stringResource(id = R.string.error_page_subtext),
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun ChatErrorPage(
+    subText: String,
+    modifier: Modifier = Modifier,
+    additionalText: String? = null,
+    buttonText: String? = null,
+    onRetry: () -> Unit = {}
+) {
     CentreAlignedScreen(
         modifier = modifier,
         screenContent = {
@@ -146,15 +184,34 @@ private fun ChatErrorPage(
             MediumVerticalSpacer()
 
             BodyRegularLabel(
-                text = stringResource(id = R.string.error_page_subtext),
+                text = subText,
                 textAlign = TextAlign.Center
             )
 
             MediumVerticalSpacer()
 
-            AdditionalText()
+            if (additionalText != null) {
+                BodyRegularLabel(
+                    text = additionalText,
+                    textAlign = TextAlign.Center
+                )
+            } else {
+                AdditionalText()
+            }
         },
-        footerContent = {}
+        footerContent = {
+            if (buttonText != null && onRetry != {}) {
+                MediumVerticalSpacer()
+                PrimaryButton(
+                    text = buttonText,
+                    onClick = onRetry,
+                    modifier = Modifier.padding(horizontal = GovUkTheme.spacing.medium),
+                    enabled = true,
+                    externalLink = false
+                )
+                ExtraLargeVerticalSpacer()
+            }
+        }
     )
 }
 
@@ -762,7 +819,8 @@ private fun LightModeChatScreenPreview() {
         ChatScreen(
             uiState = ChatUiState(isLoading = false),
             onQuestionUpdated = { _ -> },
-            onSubmit = { _ -> }
+            onSubmit = { _ -> },
+            onRetry = { }
         )
     }
 }
@@ -777,7 +835,8 @@ private fun DarkModeChatScreenPreview() {
         ChatScreen(
             uiState = ChatUiState(isLoading = false),
             onQuestionUpdated = { _ -> },
-            onSubmit = { _ -> }
+            onSubmit = { _ -> },
+            onRetry = { }
         )
     }
 }

--- a/feature/chat/src/main/res/values/strings.xml
+++ b/feature/chat/src/main/res/values/strings.xml
@@ -27,4 +27,7 @@
   <string name="error_page_additional_text_link_text">GOV.UK app homepage</string>
   <string name="error_page_additional_text_outro">if you need information now.</string>
   <string name="error_page_additional_text_url">https://www.gov.uk</string>
+  <string name="error_retry_page_subtext">Your previous conversation is no longer available.</string>
+  <string name="error_retry_page_additional_text">To continue using GOV.UK Chat, you need to start a new chat.</string>
+  <string name="error_retry_button_text">Start a new chat</string>
 </resources>

--- a/feature/chat/src/test/kotlin/uk/gov/govuk/chat/data/ChatRepoTest.kt
+++ b/feature/chat/src/test/kotlin/uk/gov/govuk/chat/data/ChatRepoTest.kt
@@ -115,4 +115,25 @@ class ChatRepoTest {
 
         assertTrue(result is NotFound)
     }
+
+    @Test
+    fun `Given a conversation id, when cleared the conversation id is removed`() = runTest {
+        coEvery { dataStore.conversationId() } returns "123"
+
+        chatRepo.getConversation()
+
+        coVerify {
+            chatApi.getConversation("123")
+        }
+
+        chatRepo.clearConversation()
+
+        coVerify {
+            dataStore.clearConversation()
+        }
+
+        coEvery { dataStore.conversationId() } returns null
+
+        assertNull(chatRepo.getConversation())
+    }
 }

--- a/feature/chat/src/test/kotlin/uk/gov/govuk/chat/data/local/ChatDataStoreTest.kt
+++ b/feature/chat/src/test/kotlin/uk/gov/govuk/chat/data/local/ChatDataStoreTest.kt
@@ -44,4 +44,14 @@ class ChatDataStoreTest {
         chatDataStore.saveConversationId("123")
         assertEquals("123", chatDataStore.conversationId())
     }
+
+    @Test
+    fun `Clears the conversation id`() = runTest {
+        chatDataStore.saveConversationId("123")
+        assertEquals("123", chatDataStore.conversationId())
+
+        chatDataStore.clearConversation()
+
+        assertNull(chatDataStore.conversationId())
+    }
 }


### PR DESCRIPTION
The retryable error page should only be shown on 404 (Not Found) errors, PII errors show a suitable message, all other errors should show the non-retryable error page (see screenshots below).

## JIRA ticket(s)
  - [GOVUKAPP-2137](https://govukverify.atlassian.net/browse/GOVUKAPP-2137)
  - [GOVUKAPP-2045](https://govukverify.atlassian.net/browse/GOVUKAPP-2045) - provides backend implementation for clearing the conversation, not the UI aspects of this ticket

## Figma
  - [Figma](https://www.figma.com/design/rKYEySuNc8aikJWYfEz1wR/2025-04-GOV.UK-Chat-and-AI?node-id=4593-43523&t=k8nL9IKwKYFaDwPw-0)

## Screen shots

| Retryable | Non-retryable |
|--------|-------|
| <img width="1080" height="2424" alt="light-404" src="https://github.com/user-attachments/assets/5bf43c2e-4713-4f88-a143-02342cd64db0" /> | <img width="1080" height="2424" alt="after-light" src="https://github.com/user-attachments/assets/d3e584a4-0167-4b95-ab98-5802f44258f9" /> |
| <img width="1080" height="2424" alt="dark-404" src="https://github.com/user-attachments/assets/c48abd0c-9e47-44e4-bd5c-4e059a59252b" /> | <img width="1080" height="2424" alt="after-dark" src="https://github.com/user-attachments/assets/47b7a9b6-bac4-4869-bd8d-7f1b0ccb6085" /> |




[GOVUKAPP-2137]: https://govukverify.atlassian.net/browse/GOVUKAPP-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GOVUKAPP-2045]: https://govukverify.atlassian.net/browse/GOVUKAPP-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ