### PR TITLE
Fix - chat input field text size too small

### DIFF
--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/ChatScreen.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/ChatScreen.kt
@@ -319,7 +319,10 @@ private fun ChatContent(
 
                         TextField(
                             textStyle = TextStyle(
-                                color = GovUkTheme.colourScheme.textAndIcons.primary
+                                color = GovUkTheme.colourScheme.textAndIcons.primary,
+                                fontSize = GovUkTheme.typography.bodyRegular.fontSize,
+                                fontWeight = GovUkTheme.typography.bodyRegular.fontWeight,
+                                fontFamily = GovUkTheme.typography.bodyRegular.fontFamily
                             ),
                             modifier = Modifier
                                 .fillMaxWidth()


### PR DESCRIPTION
## Screen shots

| Before | After |
|--------|-------|
| | <img width="1080" height="2424" alt="font-size-check" src="https://github.com/user-attachments/assets/f5232cbb-936c-4b05-a274-35e229236797" /> |
