### PR TITLE
GOVUKAPP-2181 Sign out crash

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/AppViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/AppViewModel.kt
@@ -100,7 +100,9 @@ internal class AppViewModel @Inject constructor(
         timeoutManager.onUserInteraction(interactionTime) {
             if (authRepo.isUserSessionActive()) {
                 authRepo.endUserSession()
-                appNavigation.onSignOut(navController)
+                viewModelScope.launch {
+                    appNavigation.onSignOut(navController)
+                }
             }
         }
     }


### PR DESCRIPTION
# Sign out crash

I believe devices that are affected by this crash are devices that are closing activities when apps are backgrounded to free up memory.

Steps to reproduce:
- In Developer options turn 'Don't keep Activities' to ON.
- Run the app and sign in.
- Background the app and wait until user interaction timeout (so sign out occurs).
- Observe crash in Firebase (I did not receive any indication on my device that the app had crashed).

Fix:
- Prevent navigation when the app view model has already been cleared.

## JIRA ticket(s)
  - [GOVUKAPP-2181](https://govukverify.atlassian.net/browse/GOVUKAPP-2181)

Stacktrace:
Fatal Exception: java.lang.IllegalStateException
State must be at least CREATED to move to DESTROYED, but was INITIALIZED in component NavBackStackEntrydestination=ComposeNavGraph(0x0) startDestination={ComposeNavGraph(0x23722855) route=login_graph_route startDestination={Destination(0xb5d6e846) route=login_route}}

[GOVUKAPP-2181]: https://govukverify.atlassian.net/browse/GOVUKAPP-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ