### PR TITLE
Fix 'generating answer' : Add shimmering text and apply to loading state text

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
@@ -17,7 +17,6 @@ private val BlueLighter95 = Color(0xFFF4F8FB)
 private val BlueDarker25 = Color(0xFF16548A)
 private val BlueDarker50 = Color(0xFF0F385C)
 private val BlueDarker80 = Color(0xFF061625)
-
 private val TealAccent = Color(0xFF00FFE0)
 
 private val YellowPrimary = Color(0xFFFFDD00)
@@ -91,7 +90,10 @@ data class GovUkColourScheme(
         val chatButtonIconEnabled: Color,
         val chatUserMessageText: Color,
         val chatBotMessageText: Color,
-        val chatBotHeaderText: Color
+        val chatBotHeaderText: Color,
+        val chatLoadingTextDark: Color,
+        val chatLoadingTextLight: Color,
+        val chatLoadingIcon: Color
     )
 
     data class Surfaces(
@@ -195,7 +197,10 @@ internal val LightColorScheme = GovUkColourScheme(
         chatButtonIconEnabled = White,
         chatUserMessageText = Black,
         chatBotMessageText = Black,
-        chatBotHeaderText = Grey700
+        chatBotHeaderText = Grey700,
+        chatLoadingTextDark = Grey700,
+        chatLoadingTextLight = Grey300,
+        chatLoadingIcon = BluePrimary
     ),
     surfaces = Surfaces(
         background = White,
@@ -297,7 +302,10 @@ internal val DarkColorScheme = GovUkColourScheme(
         chatButtonIconEnabled = BlueDarker80,
         chatUserMessageText = White,
         chatBotMessageText = White,
-        chatBotHeaderText = BlueLighter25
+        chatBotHeaderText = BlueLighter25,
+        chatLoadingTextDark = BlueLighter25,
+        chatLoadingTextLight = BlueLighter80,
+        chatLoadingIcon = BluePrimary
     ),
     surfaces = Surfaces(
         background = Black,
@@ -400,7 +408,10 @@ internal val LocalColourScheme = staticCompositionLocalOf {
             chatButtonIconEnabled = Color.Unspecified,
             chatUserMessageText = Color.Unspecified,
             chatBotMessageText = Color.Unspecified,
-            chatBotHeaderText = Color.Unspecified
+            chatBotHeaderText = Color.Unspecified,
+            chatLoadingTextDark = Color.Unspecified,
+            chatLoadingTextLight = Color.Unspecified,
+            chatLoadingIcon = Color.Unspecified
         ),
         surfaces = Surfaces(
             background = Color.Unspecified,

--- a/feature/chat/src/main/res/drawable/baseline_circle_24.xml
+++ b/feature/chat/src/main/res/drawable/baseline_circle_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2z"/>
+    
+</vector>

--- a/feature/chat/src/main/res/values/strings.xml
+++ b/feature/chat/src/main/res/values/strings.xml
@@ -34,4 +34,5 @@
   <string name="error_retry_page_subtext">Your previous conversation is no longer available.</string>
   <string name="error_retry_page_additional_text">To continue using GOV.UK Chat, you need to start a new chat.</string>
   <string name="error_retry_button_text">Start a new chat</string>
+  <string name="loading_text">Generating your answer&#8230;</string>
 </resources>


### PR DESCRIPTION
## Figma

- [Figma](https://www.figma.com/design/rKYEySuNc8aikJWYfEz1wR/2025-04-GOV.UK-Chat-and-AI?node-id=4930-49082&t=x0DMsWRNtPyDcFHU-0)

## Screen shots

| Light | Dark |
|--------|-------|
| <img width="1080" height="2424" alt="light" src="https://github.com/user-attachments/assets/d11c16a6-2053-406e-9011-1b799d5b64a3" /> | <img width="1080" height="2424" alt="dark" src="https://github.com/user-attachments/assets/b0cb1a25-3e06-4734-840c-5504a9c14723" /> |

## Video

https://github.com/user-attachments/assets/3849ecfd-2cf2-49d2-8d6a-9c67b0d21e84

