### PR TITLE
GOVUKAPP-2208 Handle expired refresh tokens

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/AppViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/AppViewModel.kt
@@ -18,6 +18,7 @@ import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.model.Result.DeviceOffline
 import uk.gov.govuk.data.model.Result.InvalidSignature
 import uk.gov.govuk.data.model.Result.Success
+import uk.gov.govuk.login.data.LoginRepo
 import uk.gov.govuk.navigation.AppNavigation
 import uk.gov.govuk.search.SearchFeature
 import uk.gov.govuk.topics.TopicsFeature
@@ -30,6 +31,7 @@ import javax.inject.Inject
 internal class AppViewModel @Inject constructor(
     private val timeoutManager: TimeoutManager,
     private val appRepo: AppRepo,
+    private val loginRepo: LoginRepo,
     private val configRepo: ConfigRepo,
     private val flagRepo: FlagRepo,
     private val authRepo: AuthRepo,
@@ -114,6 +116,7 @@ internal class AppViewModel @Inject constructor(
             if (authRepo.isDifferentUser()) {
                 authRepo.clear()
                 appRepo.clear()
+                loginRepo.clear()
                 topicsFeature.clear()
                 localFeature.clear()
                 searchFeature.clear()

--- a/app/src/main/kotlin/uk/gov/govuk/di/LoginModule.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/di/LoginModule.kt
@@ -1,0 +1,33 @@
+package uk.gov.govuk.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+internal class LoginModule {
+
+    @Singleton
+    @Provides
+    @Named("login_prefs")
+    fun providePreferencesDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler(
+                produceNewData = { emptyPreferences() }
+            ),
+            produceFile = { context.preferencesDataStoreFile("login_prefs") }
+        )
+    }
+}

--- a/app/src/main/kotlin/uk/gov/govuk/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/LoginViewModel.kt
@@ -11,13 +11,16 @@ import kotlinx.coroutines.launch
 import uk.gov.govuk.R
 import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.auth.ErrorEvent
+import uk.gov.govuk.login.data.LoginRepo
+import java.util.Date
 import javax.inject.Inject
 
 internal data class LoginEvent(val isBiometricLogin: Boolean)
 
 @HiltViewModel
 internal class LoginViewModel @Inject constructor(
-    private val authRepo: AuthRepo
+    private val authRepo: AuthRepo,
+    private val loginRepo: LoginRepo
 ) : ViewModel() {
 
     private val _loginCompleted = MutableSharedFlow<LoginEvent>()
@@ -33,15 +36,20 @@ internal class LoginViewModel @Inject constructor(
     fun init(activity: FragmentActivity) {
         if (authRepo.isUserSignedIn()) {
             viewModelScope.launch {
-                if (
-                    authRepo.refreshTokens(
-                        activity = activity,
-                        title = activity.getString(R.string.login_biometric_prompt_title)
-                    )
-                ) {
-                    _loginCompleted.emit(LoginEvent(isBiometricLogin = true))
+                if (shouldRefreshTokens()) {
+                    if (
+                        authRepo.refreshTokens(
+                            activity = activity,
+                            title = activity.getString(R.string.login_biometric_prompt_title)
+                        )
+                    ) {
+                        _loginCompleted.emit(LoginEvent(isBiometricLogin = true))
+                    } else {
+                        // Todo - handle failure!!!
+                    }
                 } else {
-                    // Todo - handle failure!!!
+                    authRepo.endUserSession()
+                    authRepo.clear()
                 }
             }
         }
@@ -51,9 +59,24 @@ internal class LoginViewModel @Inject constructor(
         viewModelScope.launch {
             val result = authRepo.handleAuthResponse(data)
             if (result) {
+                saveIdTokenDate()
                 _loginCompleted.emit(LoginEvent(isBiometricLogin = false))
             } else {
                 _errorEvent.emit(ErrorEvent.UnableToSignInError)
+            }
+        }
+    }
+
+    private suspend fun shouldRefreshTokens(): Boolean {
+        val idTokenIssueDate = loginRepo.getIdTokenIssueDate()
+        return idTokenIssueDate == null || idTokenIssueDate > Date().toInstant().epochSecond
+    }
+
+    private fun saveIdTokenDate() {
+        viewModelScope.launch {
+            authRepo.getIdTokenIssueDate()?.let { idTokenIssueDate ->
+                val datePlusSixDaysTwentyThreeHours = idTokenIssueDate + 601200L
+                loginRepo.setRefreshTokenExpiryDate(datePlusSixDaysTwentyThreeHours)
             }
         }
     }

--- a/app/src/main/kotlin/uk/gov/govuk/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/LoginViewModel.kt
@@ -59,7 +59,7 @@ internal class LoginViewModel @Inject constructor(
         viewModelScope.launch {
             val result = authRepo.handleAuthResponse(data)
             if (result) {
-                saveIdTokenDate()
+                saveRefreshTokenExpiryDate()
                 _loginCompleted.emit(LoginEvent(isBiometricLogin = false))
             } else {
                 _errorEvent.emit(ErrorEvent.UnableToSignInError)
@@ -68,11 +68,11 @@ internal class LoginViewModel @Inject constructor(
     }
 
     private suspend fun shouldRefreshTokens(): Boolean {
-        val idTokenIssueDate = loginRepo.getIdTokenIssueDate()
+        val idTokenIssueDate = loginRepo.getRefreshTokenExpiryDate()
         return idTokenIssueDate == null || idTokenIssueDate > Date().toInstant().epochSecond
     }
 
-    private fun saveIdTokenDate() {
+    private fun saveRefreshTokenExpiryDate() {
         viewModelScope.launch {
             authRepo.getIdTokenIssueDate()?.let { idTokenIssueDate ->
                 val datePlusSixDaysTwentyThreeHours = idTokenIssueDate + 601200L

--- a/app/src/main/kotlin/uk/gov/govuk/login/data/LoginRepo.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/data/LoginRepo.kt
@@ -1,0 +1,18 @@
+package uk.gov.govuk.login.data
+
+import uk.gov.govuk.login.data.local.LoginDataStore
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LoginRepo @Inject constructor(
+    private val loginDataStore: LoginDataStore
+) {
+    internal suspend fun getIdTokenIssueDate() = loginDataStore.getRefreshTokenExpiryDate()
+
+    internal suspend fun setRefreshTokenExpiryDate(expiryDate: Long) {
+        loginDataStore.setRefreshTokenExpiryDate(expiryDate)
+    }
+
+    internal suspend fun clear() = loginDataStore.clear()
+}

--- a/app/src/main/kotlin/uk/gov/govuk/login/data/LoginRepo.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/data/LoginRepo.kt
@@ -8,7 +8,7 @@ import javax.inject.Singleton
 class LoginRepo @Inject constructor(
     private val loginDataStore: LoginDataStore
 ) {
-    internal suspend fun getIdTokenIssueDate() = loginDataStore.getRefreshTokenExpiryDate()
+    internal suspend fun getRefreshTokenExpiryDate() = loginDataStore.getRefreshTokenExpiryDate()
 
     internal suspend fun setRefreshTokenExpiryDate(expiryDate: Long) {
         loginDataStore.setRefreshTokenExpiryDate(expiryDate)

--- a/app/src/main/kotlin/uk/gov/govuk/login/data/local/LoginDataStore.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/data/local/LoginDataStore.kt
@@ -1,0 +1,34 @@
+package uk.gov.govuk.login.data.local
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import kotlinx.coroutines.flow.firstOrNull
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class LoginDataStore @Inject constructor(
+    @Named("login_prefs") private val dataStore: DataStore<Preferences>
+) {
+    companion object {
+        internal const val REFRESH_TOKEN_EXPIRY_KEY = "refresh_token_expiry"
+    }
+
+    internal suspend fun getRefreshTokenExpiryDate(): Long? {
+        return dataStore.data.firstOrNull()
+            ?.get(longPreferencesKey(REFRESH_TOKEN_EXPIRY_KEY))
+    }
+
+    internal suspend fun setRefreshTokenExpiryDate(expiryDate: Long) {
+        dataStore.edit { prefs -> prefs[longPreferencesKey(REFRESH_TOKEN_EXPIRY_KEY)] = expiryDate }
+    }
+
+    internal suspend fun clear() {
+        dataStore.edit { prefs ->
+            prefs.clear()
+        }
+    }
+}

--- a/app/src/test/kotlin/uk/gov/govuk/AppViewModelTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/AppViewModelTest.kt
@@ -35,6 +35,7 @@ import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.model.Result.Error
 import uk.gov.govuk.data.model.Result.InvalidSignature
 import uk.gov.govuk.data.model.Result.Success
+import uk.gov.govuk.login.data.LoginRepo
 import uk.gov.govuk.navigation.AppNavigation
 import uk.gov.govuk.search.SearchFeature
 import uk.gov.govuk.topics.TopicsFeature
@@ -48,6 +49,7 @@ class AppViewModelTest {
     private val dispatcher = UnconfinedTestDispatcher()
     private val timeoutManager = mockk<TimeoutManager>(relaxed = true)
     private val appRepo = mockk<AppRepo>(relaxed = true)
+    private val loginRepo = mockk<LoginRepo>(relaxed = true)
     private val configRepo = mockk<ConfigRepo>(relaxed = true)
     private val flagRepo = mockk<FlagRepo>(relaxed = true)
     private val authRepo = mockk<AuthRepo>(relaxed = true)
@@ -72,7 +74,7 @@ class AppViewModelTest {
         every { appRepo.suppressedHomeWidgets } returns flowOf(emptySet())
         every { flagRepo.isAppAvailable() } returns true
 
-        viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
     }
 
@@ -85,7 +87,7 @@ class AppViewModelTest {
     fun `Given there is an error when retrieving the remote config, When init, then should display app unavailable`() {
         coEvery { configRepo.initConfig() } returns Error()
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -98,7 +100,7 @@ class AppViewModelTest {
     fun `Given the config signature is invalid, When init, then should display forced update`() {
         coEvery { configRepo.initConfig() } returns InvalidSignature()
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -111,7 +113,7 @@ class AppViewModelTest {
     fun `Given the app is unavailable, When init, then should display app unavailable`() {
         every { flagRepo.isAppAvailable() } returns false
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -132,7 +134,7 @@ class AppViewModelTest {
     fun `Given forced update, When init, then should display forced update`() {
         every { flagRepo.isForcedUpdate(any()) } returns true
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -145,7 +147,7 @@ class AppViewModelTest {
     fun `Given don't forced update, When init, then should not display forced update`() {
         every { flagRepo.isForcedUpdate(any()) } returns false
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -158,7 +160,7 @@ class AppViewModelTest {
     fun `Given recommend update, When init, then should display recommend update`() {
         every { flagRepo.isRecommendUpdate(any()) } returns true
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -171,7 +173,7 @@ class AppViewModelTest {
     fun `Given don't recommend update, When init, then should not display recommend update`() {
         every { flagRepo.isRecommendUpdate(any()) } returns false
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -184,7 +186,7 @@ class AppViewModelTest {
     fun `Given external browser enabled, When init, then should show external browser`() {
         every { flagRepo.isExternalBrowserEnabled() } returns true
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -197,7 +199,7 @@ class AppViewModelTest {
     fun `Given external browser enabled is false, When init, then should not show external browser`() {
         every { flagRepo.isExternalBrowserEnabled() } returns false
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -210,7 +212,7 @@ class AppViewModelTest {
     fun `Given the search feature is enabled, When init, then emit search enabled state`() {
         coEvery { flagRepo.isSearchEnabled() } returns true
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -224,7 +226,7 @@ class AppViewModelTest {
     fun `Given the search feature is disabled, When init, then emit search disabled state`() {
         coEvery { flagRepo.isSearchEnabled() } returns false
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -237,7 +239,7 @@ class AppViewModelTest {
     fun `Given the recent activity feature is enabled, When init, then emit recent activity enabled state`() {
         coEvery { flagRepo.isRecentActivityEnabled() } returns true
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -250,7 +252,7 @@ class AppViewModelTest {
     fun `Given the recent activity feature is disabled, When init, then emit recent activity disabled state`() {
         coEvery { flagRepo.isRecentActivityEnabled() } returns false
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -263,7 +265,7 @@ class AppViewModelTest {
     fun `Given the topics feature is enabled, When init, then emit topics enabled state`() {
         coEvery { flagRepo.isTopicsEnabled() } returns true
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -276,7 +278,7 @@ class AppViewModelTest {
     fun `Given the topics feature is disabled, When init, then emit topics disabled state`() {
         coEvery { flagRepo.isTopicsEnabled() } returns false
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature,
             localFeature, searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -384,7 +386,7 @@ class AppViewModelTest {
     fun `Given the local feature is disabled, When init, then emit local disabled state`() {
         coEvery { flagRepo.isLocalServicesEnabled() } returns false
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature, localFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature, localFeature,
             searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -398,7 +400,7 @@ class AppViewModelTest {
         coEvery { flagRepo.isLocalServicesEnabled() } returns true
         coEvery { flagRepo.isTopicsEnabled() } returns true
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature, localFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature, localFeature,
             searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -414,7 +416,7 @@ class AppViewModelTest {
         coEvery { flagRepo.isTopicsEnabled() } returns true
         every { localFeature.hasLocalAuthority() } returns flowOf(true)
 
-        val viewModel = AppViewModel(timeoutManager, appRepo, configRepo, flagRepo, authRepo, topicsFeature, localFeature,
+        val viewModel = AppViewModel(timeoutManager, appRepo, loginRepo, configRepo, flagRepo, authRepo, topicsFeature, localFeature,
             searchFeature, visited, chatFeature, analyticsClient, appNavigation)
 
         runTest {
@@ -434,6 +436,7 @@ class AppViewModelTest {
             coVerify(exactly = 0) {
                 authRepo.clear()
                 appRepo.clear()
+                loginRepo.clear()
                 topicsFeature.clear()
                 localFeature.clear()
                 searchFeature.clear()
@@ -458,6 +461,7 @@ class AppViewModelTest {
             coVerify {
                 authRepo.clear()
                 appRepo.clear()
+                loginRepo.clear()
                 topicsFeature.clear()
                 localFeature.clear()
                 searchFeature.clear()

--- a/app/src/test/kotlin/uk/gov/govuk/login/LoginViewModelTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/LoginViewModelTest.kt
@@ -136,7 +136,7 @@ class LoginViewModelTest {
     @Test
     fun `Given an auth response, when success and id token issue date is stored, then emit ui state`() {
         coEvery { authRepo.handleAuthResponse(any()) } returns true
-        every { authRepo.getIdTokenIssueDate() } returns 12345
+        every { authRepo.getIdTokenIssueDate() } returns 12345L
 
         runTest {
             val events = mutableListOf<LoginEvent>()
@@ -151,7 +151,7 @@ class LoginViewModelTest {
                 authRepo.getIdTokenIssueDate()
             }
             coVerify(exactly = 1) {
-                loginRepo.setRefreshTokenExpiryDate(12345 + 601200)
+                loginRepo.setRefreshTokenExpiryDate(12345L + 601200L)
             }
         }
     }

--- a/app/src/test/kotlin/uk/gov/govuk/login/LoginViewModelTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/LoginViewModelTest.kt
@@ -59,7 +59,7 @@ class LoginViewModelTest {
     fun `Given the user is signed in and the id token issue date is in the future, when init is successful, then emit ui state`() {
         every { authRepo.isUserSignedIn() } returns true
         coEvery { authRepo.refreshTokens(any(), any()) } returns true
-        coEvery { loginRepo.getIdTokenIssueDate() } returns Date().toInstant().epochSecond + 10000L
+        coEvery { loginRepo.getRefreshTokenExpiryDate() } returns Date().toInstant().epochSecond + 10000L
 
         runTest {
             val events = mutableListOf<LoginEvent>()
@@ -76,7 +76,7 @@ class LoginViewModelTest {
     fun `Given the user is signed in and the id token issue date is not in the future, then end user session and clear auth repo`() {
         every { authRepo.isUserSignedIn() } returns true
         coEvery { authRepo.refreshTokens(any(), any()) } returns true
-        coEvery { loginRepo.getIdTokenIssueDate() } returns Date().toInstant().epochSecond
+        coEvery { loginRepo.getRefreshTokenExpiryDate() } returns Date().toInstant().epochSecond
 
         runTest {
             val events = mutableListOf<LoginEvent>()

--- a/app/src/test/kotlin/uk/gov/govuk/login/data/LoginRepoTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/data/LoginRepoTest.kt
@@ -1,0 +1,61 @@
+package uk.gov.govuk.login.data
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import uk.gov.govuk.data.AppRepo
+import uk.gov.govuk.login.data.local.LoginDataStore
+
+class LoginRepoTest {
+    private val loginDataStore = mockk<LoginDataStore>(relaxed = true)
+
+    @Test
+    fun `Given the there is no refresh token expiry date stored, When get refresh token expiry date, then return null`() {
+        val repo = LoginRepo(loginDataStore)
+
+        coEvery { loginDataStore.getRefreshTokenExpiryDate() } returns null
+
+        runTest {
+
+            assertNull(repo.getIdTokenIssueDate())
+        }
+    }
+
+    @Test
+    fun `Given the there is a refresh token expiry date stored, When get refresh token expiry date, then return expiry date`() {
+        val repo = LoginRepo(loginDataStore)
+
+        coEvery { loginDataStore.getRefreshTokenExpiryDate() } returns 12345L
+
+        runTest {
+
+            assertEquals(12345L, repo.getIdTokenIssueDate())
+        }
+    }
+
+    @Test
+    fun `Given a refresh token expiry date is 12345, When set refresh token expiry date, then update data store`() {
+        val repo = LoginRepo(loginDataStore)
+
+        runTest {
+            repo.setRefreshTokenExpiryDate(12345L)
+
+            coVerify { loginDataStore.setRefreshTokenExpiryDate(12345L) }
+        }
+    }
+
+    @Test
+    fun `Given a different user has logged in, When clear, then clear data store`() {
+        val repo = LoginRepo(loginDataStore)
+
+        runTest {
+            repo.clear()
+
+            coVerify { loginDataStore.clear() }
+        }
+    }
+}

--- a/app/src/test/kotlin/uk/gov/govuk/login/data/LoginRepoTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/data/LoginRepoTest.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
-import uk.gov.govuk.data.AppRepo
 import uk.gov.govuk.login.data.local.LoginDataStore
 
 class LoginRepoTest {
@@ -21,7 +20,7 @@ class LoginRepoTest {
 
         runTest {
 
-            assertNull(repo.getIdTokenIssueDate())
+            assertNull(repo.getRefreshTokenExpiryDate())
         }
     }
 
@@ -33,7 +32,7 @@ class LoginRepoTest {
 
         runTest {
 
-            assertEquals(12345L, repo.getIdTokenIssueDate())
+            assertEquals(12345L, repo.getRefreshTokenExpiryDate())
         }
     }
 

--- a/app/src/test/kotlin/uk/gov/govuk/login/data/local/LoginDataStoreTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/data/local/LoginDataStoreTest.kt
@@ -1,0 +1,100 @@
+package uk.gov.govuk.login.data.local
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import uk.gov.govuk.data.local.AppDataStore
+import uk.gov.govuk.login.data.local.LoginDataStore.Companion.REFRESH_TOKEN_EXPIRY_KEY
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LoginDataStoreTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var tempDir: File
+    private lateinit var dataStore: DataStore<Preferences>
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+        tempDir = File(createTempDirectory().toString())
+        dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(tempDir, "test.preferences_pb") }
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun `Given the data store is empty, When get refresh token expiry date, then return null`() {
+        val loginDatastore = LoginDataStore(dataStore)
+
+        runTest {
+            assertNull(loginDatastore.getRefreshTokenExpiryDate())
+        }
+    }
+
+    @Test
+    fun `Given the refresh token expiry date is 12345 in the data store, When get refresh token expiry date, then return 12345`() {
+        val loginDatastore = LoginDataStore(dataStore)
+
+        runTest {
+            dataStore.edit { prefs ->
+                prefs[longPreferencesKey(REFRESH_TOKEN_EXPIRY_KEY)] = 12345L
+            }
+
+            assertEquals(12345L, loginDatastore.getRefreshTokenExpiryDate())
+        }
+    }
+
+    @Test
+    fun `Given the refresh token expiry date is 12345, When set refresh token expiry date, then update the prefs`() {
+        val loginDatastore = LoginDataStore(dataStore)
+
+        runTest {
+            loginDatastore.setRefreshTokenExpiryDate(12345L)
+
+            assertTrue(
+                dataStore.data.first()[longPreferencesKey(REFRESH_TOKEN_EXPIRY_KEY)] == 12345L
+            )
+        }
+    }
+
+    @Test
+    fun `Given the data store is cleared, when clear, then the data store is cleared`() {
+        val appDatastore = AppDataStore(dataStore)
+
+        runTest {
+            dataStore.edit { prefs ->
+                prefs[longPreferencesKey(REFRESH_TOKEN_EXPIRY_KEY)] = 12345L
+            }
+
+            assertTrue(dataStore.data.first().asMap().isNotEmpty())
+
+            appDatastore.clear()
+
+            assertTrue(dataStore.data.first().asMap().isEmpty())
+        }
+    }
+}

--- a/app/src/test/kotlin/uk/gov/govuk/login/data/local/LoginDataStoreTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/data/local/LoginDataStoreTest.kt
@@ -83,7 +83,7 @@ class LoginDataStoreTest {
 
     @Test
     fun `Given the data store is cleared, when clear, then the data store is cleared`() {
-        val appDatastore = AppDataStore(dataStore)
+        val loginDatastore = LoginDataStore(dataStore)
 
         runTest {
             dataStore.edit { prefs ->
@@ -92,7 +92,7 @@ class LoginDataStoreTest {
 
             assertTrue(dataStore.data.first().asMap().isNotEmpty())
 
-            appDatastore.clear()
+            loginDatastore.clear()
 
             assertTrue(dataStore.data.first().asMap().isEmpty())
         }

--- a/data/src/main/kotlin/uk/gov/govuk/data/auth/AuthRepo.kt
+++ b/data/src/main/kotlin/uk/gov/govuk/data/auth/AuthRepo.kt
@@ -230,8 +230,8 @@ class AuthRepo @Inject constructor(
         return getIdTokenProperty("email")
     }
 
-    fun getIdTokenIssueDate(): Int? {
-        return getIdTokenProperty("iat").toIntOrNull()
+    fun getIdTokenIssueDate(): Long? {
+        return getIdTokenProperty("iat").toLongOrNull()
     }
 
     private fun getIdTokenProperty(name: String): String {

--- a/data/src/main/kotlin/uk/gov/govuk/data/auth/AuthRepo.kt
+++ b/data/src/main/kotlin/uk/gov/govuk/data/auth/AuthRepo.kt
@@ -230,6 +230,10 @@ class AuthRepo @Inject constructor(
         return getIdTokenProperty("email")
     }
 
+    fun getIdTokenIssueDate(): Int? {
+        return getIdTokenProperty("iat").toIntOrNull()
+    }
+
     private fun getIdTokenProperty(name: String): String {
         val parts = tokens.idToken.split(".")
         return try {


### PR DESCRIPTION
# Handle expired refresh tokens

On successful auth response save the ID token issue date and time locally. 
On future app launches, check that the stored date and time is greater than 6 days 23 hours of the current date and time before prompting for biometric login else sign the user out.

## JIRA ticket(s)
  - [GOVUKAPP-2206](https://govukverify.atlassian.net/browse/GOVUKAPP-2206)


[GOVUKAPP-2206]: https://govukverify.atlassian.net/browse/GOVUKAPP-2206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ