### PR TITLE
GOVUKAPP-2268 : Only show onboarding images in portrait

### DIFF
--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/OnboardingPage.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/OnboardingPage.kt
@@ -1,5 +1,6 @@
 package uk.gov.govuk.chat.ui
 
+import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -17,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.style.TextAlign
 import uk.gov.govuk.design.ui.component.ExtraLargeVerticalSpacer
 import uk.gov.govuk.design.ui.component.FixedContainerDivider
@@ -54,14 +56,18 @@ internal fun OnboardingPage(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
-                Image(
-                    painter = image,
-                    contentDescription = null,
-                    modifier = Modifier.height(IntrinsicSize.Min)
-                        .padding(all = GovUkTheme.spacing.medium)
-                )
+                val isLogoVisible = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
 
-                LargeHorizontalSpacer()
+                if (isLogoVisible) {
+                    Image(
+                        painter = image,
+                        contentDescription = null,
+                        modifier = Modifier.height(IntrinsicSize.Min)
+                            .padding(all = GovUkTheme.spacing.medium)
+                    )
+
+                    LargeHorizontalSpacer()
+                }
 
                 LargeTitleBoldLabel(
                     text = title,


### PR DESCRIPTION
Post amigo fix 

## JIRA ticket(s)
  - [GOVUKAPP-2268](https://govukverify.atlassian.net/browse/GOVUKAPP-2268)

## Screen shots

| Light | Dark |
|--------|-------|
| <img width="2424" height="1080" alt="Screenshot_20250811_105817" src="https://github.com/user-attachments/assets/d4bcf237-f64f-4883-a04a-2c5daa2ddf97" /> | <img width="2424" height="1080" alt="Screenshot_20250811_105852" src="https://github.com/user-attachments/assets/e714ec8e-338a-4127-b73a-d6134b771811" /> |
| <img width="2424" height="1080" alt="Screenshot_20250811_105832" src="https://github.com/user-attachments/assets/50f5d51e-0d46-4e16-9d34-79d72ae14d8b" /> | <img width="2424" height="1080" alt="Screenshot_20250811_105845" src="https://github.com/user-attachments/assets/3e021182-a977-4b6c-8224-cedc475a676e" /> |


