### PR TITLE
GOVUKAPP-2302 Update biometrics opt in screen

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/login/BiometricViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/BiometricViewModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.govuk.login
 
+import android.os.Build
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -35,4 +36,11 @@ internal class BiometricViewModel @Inject constructor(
             appRepo.skipBiometrics()
         }
     }
+
+    fun getDescriptionOne(androidVersion: Int = Build.VERSION.SDK_INT): Int =
+        if (androidVersion > Build.VERSION_CODES.Q) {
+            R.string.login_biometrics_android_11_description_1
+        } else {
+            R.string.login_biometrics_android_10_description_1
+        }
 }

--- a/app/src/main/kotlin/uk/gov/govuk/login/ui/BiometricScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/ui/BiometricScreen.kt
@@ -1,6 +1,7 @@
 package uk.gov.govuk.login.ui
 
 import androidx.activity.compose.LocalActivity
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
@@ -47,6 +48,7 @@ internal fun BiometricRoute(
             viewModel.onSkip()
             onCompleted()
         },
+        descriptionOne = viewModel.getDescriptionOne(),
         modifier = modifier
     )
 
@@ -61,6 +63,7 @@ internal fun BiometricRoute(
 private fun BiometricScreen(
     onSetupBiometrics: () -> Unit,
     onSkip: () -> Unit,
+    @StringRes descriptionOne: Int,
     modifier: Modifier = Modifier
 ) {
     CentreAlignedScreen(
@@ -78,7 +81,7 @@ private fun BiometricScreen(
             MediumVerticalSpacer()
 
             BodyRegularLabel(
-                text = stringResource(R.string.login_biometrics_description_1),
+                text = stringResource(descriptionOne),
                 textAlign = TextAlign.Center
             )
 
@@ -152,7 +155,8 @@ private fun BiometricPreview() {
     GovUkTheme {
         BiometricScreen(
             onSetupBiometrics = { },
-            onSkip = { }
+            onSkip = { },
+            R.string.login_biometrics_android_11_description_1
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,8 +40,9 @@
     <string name="login_success_title">You have successfully signed in</string>
 
     <string name="login_biometrics_title">Unlock the app with biometrics</string>
-    <string name="login_biometrics_description_1">You can unlock the app with your face, fingerprint or iris.</string>
-    <string name="login_biometrics_description_2">If you do not want to use your biometrics, you can unlock the app with your phone’s pin or pattern, or with your email address and password.</string>
+    <string name="login_biometrics_android_10_description_1">Anyone who can unlock your phone with their biometrics might be able to access your app.</string>
+    <string name="login_biometrics_android_11_description_1">Anyone who can unlock your phone with their biometrics or with your phone’s PIN, pattern or password might be able to access your app.</string>
+    <string name="login_biometrics_description_2">If you do not want to use biometrics, you can unlock the app with your GOV.UK One Login details.</string>
     <string name="login_biometrics_button">Use biometrics</string>
     <string name="login_biometrics_skip_button">Skip</string>
 

--- a/app/src/test/kotlin/uk/gov/govuk/login/BiometricViewModelTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/BiometricViewModelTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.govuk.login
 
+import android.os.Build
 import androidx.fragment.app.FragmentActivity
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -14,6 +15,8 @@ import org.junit.Before
 import org.junit.Test
 import uk.gov.govuk.data.AppRepo
 import uk.gov.govuk.data.auth.AuthRepo
+import uk.gov.govuk.R
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -63,5 +66,19 @@ class BiometricViewModelTest {
         viewModel.onContinue(activity)
 
         assertFalse(viewModel.uiState.value)
+    }
+
+    @Test
+    fun `Given the app is running on an Android 10 device, when get description one is called, then return the correct resource`() {
+        val descriptionOne = viewModel.getDescriptionOne(Build.VERSION_CODES.Q)
+
+        assertEquals(R.string.login_biometrics_android_10_description_1, descriptionOne)
+    }
+
+    @Test
+    fun `Given the app is running on an Android 11 device, when get description one is called, then return the correct resource`() {
+        val descriptionOne = viewModel.getDescriptionOne(Build.VERSION_CODES.R)
+
+        assertEquals(R.string.login_biometrics_android_11_description_1, descriptionOne)
     }
 }


### PR DESCRIPTION
# Update biometrics opt in screen

Add 2 biometric login descriptions (1 for Android <10 and 1 for Android 11>) and the logic to show them

## JIRA ticket(s)
  - [GOVUKAPP-2302](https://govukverify.atlassian.net/browse/GOVUKAPP-2302)

## Screen shots

| Android 10 Before | Android 10 After |
|--------|-------|
| <img width="1080" height="2280" alt="Screenshot_1755615645" src="https://github.com/user-attachments/assets/e898daf8-dc37-4655-aa45-4f29954fa49e" /> | <img width="1080" height="2280" alt="Screenshot_1755612979" src="https://github.com/user-attachments/assets/efcd5c05-e0fe-4f69-9cff-d25675e59c73" /> |

| Android 11 Before | Android 11 After |
|--------|-------|
| <img width="1344" height="2992" alt="Screenshot_1755615563" src="https://github.com/user-attachments/assets/f6ea39c5-c6d2-43f7-a738-10ecddb96d18" /> | <img width="1344" height="2992" alt="Screenshot_1755612809" src="https://github.com/user-attachments/assets/7062e05d-6e1e-4bed-919e-9f9d76384610" /> |



[GOVUKAPP-2302]: https://govukverify.atlassian.net/browse/GOVUKAPP-2302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ