### PR TITLE
GOVUKAPP-2304 Update biometrics settings screen

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/login/BiometricSettingsViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/BiometricSettingsViewModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.govuk.login
 
+import android.os.Build
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -60,4 +61,11 @@ internal class BiometricSettingsViewModel @Inject constructor(
             _uiState.value = authRepo.isUserSignedIn()
         }
     }
+
+    fun getDescriptionTwo(androidVersion: Int = Build.VERSION.SDK_INT): Int =
+        if (androidVersion > Build.VERSION_CODES.Q) {
+            R.string.biometric_settings_android_11_description_2
+        } else {
+            R.string.biometric_settings_android_10_description_2
+        }
 }

--- a/app/src/main/kotlin/uk/gov/govuk/login/ui/BiometricSettingsScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/ui/BiometricSettingsScreen.kt
@@ -1,6 +1,7 @@
 package uk.gov.govuk.login.ui
 
 import androidx.activity.compose.LocalActivity
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -44,6 +45,7 @@ internal fun BiometricSettingsRoute(
         onPageView = { viewModel.onPageView() },
         isUserSignedIn = uiState,
         onToggle = { text -> viewModel.onToggle(text, activity) },
+        descriptionTwo = viewModel.getDescriptionTwo(),
         modifier = modifier
     )
 }
@@ -54,6 +56,7 @@ private fun BiometricSettingsScreen(
     onPageView: () -> Unit,
     isUserSignedIn: Boolean,
     onToggle: (String) -> Unit,
+    @StringRes descriptionTwo: Int,
     modifier: Modifier = Modifier
 ) {
     LaunchedEffect(Unit) {
@@ -101,7 +104,7 @@ private fun BiometricSettingsScreen(
 
                 MediumVerticalSpacer()
 
-                BodyRegularLabel(stringResource(R.string.biometric_settings_description_2))
+                BodyRegularLabel(stringResource(descriptionTwo))
 
                 MediumVerticalSpacer()
 
@@ -123,7 +126,8 @@ private fun BiometricSettingsPreview() {
             onBack = { },
             onPageView = { },
             isUserSignedIn = true,
-            onToggle = { }
+            onToggle = { },
+            descriptionTwo = R.string.biometric_settings_android_11_description_2
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,8 +50,9 @@
     <string name="biometric_settings_title">Biometrics</string>
     <string name="biometric_settings_toggle">Unlock app with biometrics</string>
     <string name="biometric_settings_description_1">If you have biometrics turned on, you’ll be able to use your fingerprint, face or iris to unlock the app.</string>
-    <string name="biometric_settings_description_2">If you do not want to use biometrics, you can use your phone’s pin or pattern instead.</string>
-    <string name="biometric_settings_description_3">Anyone who can unlock your phone with their fingerprint, face or iris or with your phone’s pin or pattern might be able to access your app.</string>
+    <string name="biometric_settings_android_10_description_2">Anyone who can unlock your phone with their biometrics might be able to access your app.</string>
+    <string name="biometric_settings_android_11_description_2">Anyone who can unlock your phone with their biometrics or with your phone’s PIN, pattern or password might be able to access your app.</string>
+    <string name="biometric_settings_description_3">If you do not want to use biometrics, you can unlock the app with your GOV.UK One Login details.</string>
     <string name="biometric_settings_description_4">You can turn off biometrics at any time.</string>
 
 </resources>

--- a/app/src/test/kotlin/uk/gov/govuk/login/BiometricSettingsViewModelTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/BiometricSettingsViewModelTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.govuk.login
 
+import android.os.Build
 import androidx.fragment.app.FragmentActivity
 import io.mockk.coVerify
 import io.mockk.every
@@ -14,8 +15,10 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import uk.gov.govuk.R
 import uk.gov.govuk.analytics.AnalyticsClient
 import uk.gov.govuk.data.AppRepo
 import uk.gov.govuk.data.auth.AuthRepo
@@ -111,4 +114,19 @@ class BiometricSettingsViewModelTest {
         }
     }
 
+    @Test
+    fun `Given the app is running on an Android 10 device, when get description two is called, then return the correct resource`() {
+        val viewModel = BiometricSettingsViewModel(appRepo, authRepo, analyticsClient)
+        val descriptionTwo = viewModel.getDescriptionTwo(Build.VERSION_CODES.Q)
+
+        assertEquals(R.string.biometric_settings_android_10_description_2, descriptionTwo)
+    }
+
+    @Test
+    fun `Given the app is running on an Android 11 device, when get description two is called, then return the correct resource`() {
+        val viewModel = BiometricSettingsViewModel(appRepo, authRepo, analyticsClient)
+        val descriptionTwo = viewModel.getDescriptionTwo(Build.VERSION_CODES.R)
+
+        assertEquals(R.string.biometric_settings_android_11_description_2, descriptionTwo)
+    }
 }


### PR DESCRIPTION
# Update biometrics settings screen

Add 2 biometric settings descriptions (1 for Android <10 and 1 for Android 11>) and the logic to show them

## JIRA ticket(s)
  - [GOVUKAPP-2304](https://govukverify.atlassian.net/browse/GOVUKAPP-2304)

## Screen shots

| Android 10 Before | Android 10 After |
|--------|-------|
| <img width="1080" height="2280" alt="Screenshot_1755615597" src="https://github.com/user-attachments/assets/2af8e439-a655-4957-b869-474832226370" /> | <img width="1080" height="2280" alt="Screenshot_1755615132" src="https://github.com/user-attachments/assets/0bf1129d-0f1f-4085-acf3-2d6693aeeffd" /> |

| Android 11 Before | Android 11 After |
|--------|-------|
| <img width="1344" height="2992" alt="Screenshot_1755615570" src="https://github.com/user-attachments/assets/6393c7b0-aa60-47fb-bb43-4c0ee9d53da3" /> | <img width="1344" height="2992" alt="Screenshot_1755615207" src="https://github.com/user-attachments/assets/b05abcda-1759-4b67-ae46-e871bb5c0181" /> |



[GOVUKAPP-2304]: https://govukverify.atlassian.net/browse/GOVUKAPP-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ