### PR TITLE
GOVUKAPP-2153 : Chat API gateway change

### DIFF
--- a/data/src/main/kotlin/uk/gov/govuk/data/auth/AuthRepo.kt
+++ b/data/src/main/kotlin/uk/gov/govuk/data/auth/AuthRepo.kt
@@ -214,6 +214,10 @@ class AuthRepo @Inject constructor(
         return tokens.accessToken.isNotBlank()
     }
 
+    fun getAccessToken(): String {
+        return tokens.accessToken
+    }
+
     fun isUserSignedIn(): Boolean {
         return secureStore.exists(REFRESH_TOKEN_KEY)
     }

--- a/data/src/test/kotlin/uk/gov/govuk/data/auth/AuthRepoTest.kt
+++ b/data/src/test/kotlin/uk/gov/govuk/data/auth/AuthRepoTest.kt
@@ -836,4 +836,24 @@ class AuthRepoTest {
             assertFalse(authRepo.isUserSessionActive())
         }
     }
+
+    @Test
+    fun `Given a request for the access token, return the access token`() {
+        every { AuthorizationResponse.fromIntent(any()) } returns authResponse
+        every { authService.performTokenRequest(any(), any(), any()) } answers {
+            val callback = thirdArg<TokenResponseCallback>()
+            callback.onTokenRequestCompleted(tokenResponse, null)
+        }
+        every { tokenResponseMapper.map(any()) } returns
+            TokenResponseMapper.Tokens(
+                accessToken = "accessToken",
+                idToken = "idToken",
+                refreshToken = "refreshToken"
+            )
+
+        runTest {
+            authRepo.handleAuthResponse(intent)
+            assertEquals("accessToken", authRepo.getAccessToken())
+        }
+    }
 }

--- a/feature/chat/build.gradle.kts
+++ b/feature/chat/build.gradle.kts
@@ -22,23 +22,13 @@ android {
 
         consumerProguardFiles("consumer-rules.pro")
 
-        buildConfigField("String", "CHAT_BASE_URL", "\"https://chat.integration.publishing.service.gov.uk/api/v0/\"")
+        buildConfigField("String", "CHAT_BASE_URL", "\"https://t4l83ued82.execute-api.eu-west-2.amazonaws.com/staging/\"")
         buildConfigField("String", "ABOUT_APP_URL", "\"https://www.gov.uk\"")
-
-        if (file("${rootProject.projectDir.path}/github.properties").exists()) {
-            val propsFile = File("${rootProject.projectDir.path}/github.properties")
-            val props = Properties().also { it.load(FileInputStream(propsFile)) }
-            val chatToken = props["chatToken"] as String?
-            buildConfigField("String", "CHAT_TOKEN", "\"$chatToken\"")
-        } else {
-            buildConfigField("String", "CHAT_TOKEN", "\"${System.getenv("CHAT_TOKEN")}\"")
-        }
     }
 
     buildTypes {
         release {
-            buildConfigField("String", "CHAT_BASE_URL", "\"https://chat.integration.publishing.service.gov.uk/api/v0/\"")
-            buildConfigField("String", "CHAT_TOKEN", "\"\"")
+            buildConfigField("String", "CHAT_BASE_URL", "\"https://t4l83ued82.execute-api.eu-west-2.amazonaws.com/staging/\"")
         }
     }
 

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/data/remote/ChatApi.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/data/remote/ChatApi.kt
@@ -3,49 +3,33 @@ package uk.gov.govuk.chat.data.remote
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
-import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
-import uk.gov.govuk.chat.BuildConfig
 import uk.gov.govuk.chat.data.remote.model.Answer
 import uk.gov.govuk.chat.data.remote.model.AnsweredQuestion
 import uk.gov.govuk.chat.data.remote.model.Conversation
 import uk.gov.govuk.chat.data.remote.model.ConversationQuestionRequest
 
 interface ChatApi {
-    @Headers(
-        "content-type: application/json",
-        "authorization: Bearer ${BuildConfig.CHAT_TOKEN}"
-    )
+    // Headers are added via interceptor in ChatModule.kt
+
     @POST("conversation")
     suspend fun startConversation(
         @Body requestBody: ConversationQuestionRequest
     ): Response<AnsweredQuestion>
 
-    @Headers(
-        "content-type: application/json",
-        "authorization: Bearer ${BuildConfig.CHAT_TOKEN}"
-    )
     @GET("conversation/{conversationId}")
     suspend fun getConversation(
         @Path("conversationId") conversationId: String
     ): Response<Conversation>
 
-    @Headers(
-        "content-type: application/json",
-        "authorization: Bearer ${BuildConfig.CHAT_TOKEN}"
-    )
     @PUT("conversation/{conversationId}")
     suspend fun updateConversation(
         @Path("conversationId") conversationId: String,
         @Body requestBody: ConversationQuestionRequest
     ): Response<AnsweredQuestion>
 
-    @Headers(
-        "content-type: application/json",
-        "authorization: Bearer ${BuildConfig.CHAT_TOKEN}"
-    )
     @GET("conversation/{conversationId}/questions/{questionId}/answer")
     suspend fun getAnswer(
         @Path("conversationId") conversationId: String,

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/di/ChatModule.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/di/ChatModule.kt
@@ -12,6 +12,9 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import uk.gov.govuk.chat.BuildConfig
@@ -19,8 +22,32 @@ import uk.gov.govuk.chat.ChatFeature
 import uk.gov.govuk.chat.DefaultChatFeature
 import uk.gov.govuk.chat.data.ChatRepo
 import uk.gov.govuk.chat.data.remote.ChatApi
+import uk.gov.govuk.data.auth.AuthRepo
+import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
+
+internal class HeaderInterceptor @Inject constructor(): Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val currentRequest = chain.request().newBuilder()
+        currentRequest.addHeader("Content-Type", "application/json")
+
+        val newRequest = currentRequest.build()
+        return chain.proceed(newRequest)
+    }
+}
+
+internal class AuthorizationInterceptor @Inject constructor(
+    private val authRepo: AuthRepo
+): Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val currentRequest = chain.request().newBuilder()
+        currentRequest.addHeader("Authorization", "Bearer ${authRepo.getAccessToken()}")
+
+        val newRequest = currentRequest.build()
+        return chain.proceed(newRequest)
+    }
+}
 
 @InstallIn(SingletonComponent::class)
 @Module
@@ -34,10 +61,16 @@ internal class ChatModule {
 
     @Provides
     @Singleton
-    fun providesChatApi(): ChatApi {
+    fun providesChatApi(authRepo: AuthRepo): ChatApi {
+        val client = OkHttpClient.Builder()
+            .addInterceptor(HeaderInterceptor())
+            .addInterceptor(AuthorizationInterceptor(authRepo))
+            .build()
+
         return Retrofit.Builder()
             .baseUrl(BuildConfig.CHAT_BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
+            .client(client)
             .build()
             .create(ChatApi::class.java)
     }


### PR DESCRIPTION
Does the following:

- Removes CHAT_TOKEN and uses the access token instead
- Adds headers via Retrofit interceptor so that current value is always read in
- Updates CHAT_BASE_URL to point at API Gateway

⚠️ API calls are simply passed through to the Chat API from the API Gateway, so no API call code changes are required

## JIRA ticket(s)
  - [GOVUKAPP-2153](https://govukverify.atlassian.net/browse/GOVUKAPP-2153)

[GOVUKAPP-2153]: https://govukverify.atlassian.net/browse/GOVUKAPP-2153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ