### PR TITLE
GOVUKAPP-2461 Dark mode blue to Alert Card

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
@@ -19,6 +19,7 @@ private val BlueLighter95 = Color(0xFFF4F8FB)
 private val BlueDarker25 = Color(0xFF16548A)
 private val BlueDarker50 = Color(0xFF0F385C)
 private val BlueDarker80 = Color(0xFF061625)
+private val BlueDarkMode = Color(0xFF263D54)
 private val TealAccent = Color(0xFF00FFE0)
 
 private val YellowPrimary = Color(0xFFFFDD00)
@@ -319,7 +320,7 @@ internal val DarkColorScheme = GovUkColourScheme(
         background = Black,
         primary = BlueAccent,
         splash = BluePrimary,
-        cardDefault = Grey800,
+        cardDefault = BlueDarkMode,
         cardBlue = BlueDarker50,
         cardHighlight = Grey850,
         cardSelected = GreenDarker50,


### PR DESCRIPTION
# Dark mode blue to Alert Card

Add 'blue-darkmode' colour to Alert Card background

<img width="600" height="150" alt="image" src="https://github.com/user-attachments/assets/053b974e-0c79-44e9-b37a-1fe7ae04c51d" />

## JIRA ticket(s)
  - [GOVUKAPP-2461](https://govukverify.atlassian.net/browse/GOVUKAPP-2461)

## Figma
  - [Figma board](https://www.figma.com/design/x5i4a5RT0xMhJAcjoIxefb/2025-06-GOV.UK-app-library-v2--UX-refresh?node-id=9045-5307&t=dnrzWfnQZnxk2nrj-0)

## Screen shots

| Before | After |
|--------|-------|
| <img width="300" height="668" alt="Screenshot_1756718873" src="https://github.com/user-attachments/assets/164f9f70-2aee-4f31-99bd-f3555a37d6d4" /> | <img width="300" height="668" alt="Screenshot_1756718371" src="https://github.com/user-attachments/assets/f0c58b39-5795-410a-abf6-2aa979d2dc2a" /> |



[GOVUKAPP-2461]: https://govukverify.atlassian.net/browse/GOVUKAPP-2461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ