### PR TITLE
GOVUKAPP-2433: Chat window changes

### DIFF
--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/chat/ChatEntry.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/chat/ChatEntry.kt
@@ -1,8 +1,5 @@
 package uk.gov.govuk.chat.ui.chat
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.LinearOutSlowInEasing
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,18 +7,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import kotlinx.coroutines.delay
 import uk.gov.govuk.chat.R
 import uk.gov.govuk.chat.ui.model.ChatEntry
 import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
@@ -44,22 +33,7 @@ internal fun DisplayChatEntry(
 
         MediumVerticalSpacer()
         if (isLoading && chatEntry.answer.isEmpty()) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.baseline_circle_24),
-                    contentDescription = null,
-                    tint = GovUkTheme.colourScheme.textAndIcons.chatLoadingIcon,
-                    modifier = Modifier
-                        .padding(end = GovUkTheme.spacing.small),
-                )
-
-                LoadingText(
-                    text = stringResource(id = R.string.loading_text)
-                )
-            }
+            Loading()
         } else {
             Answer(
                 answer = chatEntry.answer,
@@ -73,44 +47,25 @@ internal fun DisplayChatEntry(
 }
 
 @Composable
-fun LoadingText(
-    text: String,
-    modifier: Modifier = Modifier,
-    baseColor: Color = GovUkTheme.colourScheme.textAndIcons.chatLoadingTextDark,
-    animationDuration: Int = 500,
-    pauseDuration: Long = 300L
+private fun Loading(
+    modifier: Modifier = Modifier
 ) {
-    val progress = remember { Animatable(0f) }
-    var faded by remember { mutableStateOf(false) }
-
-    LaunchedEffect(Unit) {
-        while (true) {
-            if (!faded) {
-                delay(pauseDuration)
-            }
-
-            progress.animateTo(
-                targetValue = 1f,
-                animationSpec = tween(durationMillis = animationDuration, easing = LinearOutSlowInEasing)
-            )
-
-            faded = !faded
-            progress.snapTo(0f)
-        }
-    }
-
-    val brush = Brush.horizontalGradient(
-        colorStops = arrayOf(
-            0f to baseColor.copy(alpha = if (faded) 1f else 0.3f),
-            progress.value to baseColor.copy(alpha = if (faded) 1f else 0.3f),
-            (progress.value + 0.01f).coerceAtMost(1f) to baseColor.copy(alpha = if (faded) 0.3f else 1f),
-            1f to baseColor.copy(alpha = if (faded) 0.3f else 1f),
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.baseline_circle_24),
+            contentDescription = null,
+            tint = GovUkTheme.colourScheme.textAndIcons.chatLoadingIcon,
+            modifier = Modifier
+                .padding(end = GovUkTheme.spacing.small),
         )
-    )
 
-    Text(
-        text = text,
-        modifier = modifier,
-        style = GovUkTheme.typography.bodyRegular.copy(brush = brush)
-    )
+        Text(
+            text = stringResource(R.string.loading_text),
+            color = GovUkTheme.colourScheme.textAndIcons.chatLoadingTextDark,
+            style = GovUkTheme.typography.bodyRegular
+        )
+    }
 }

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/chat/IntroMessages.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/chat/IntroMessages.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import uk.gov.govuk.chat.R
@@ -105,6 +106,7 @@ private fun MessageHeader(
         Text(
             text = stringResource(id = R.string.bot_message_availability_text),
             color = GovUkTheme.colourScheme.textAndIcons.chatBotHeaderText,
+            textAlign = TextAlign.Center,
             style = GovUkTheme.typography.bodyRegular
         )
     }

--- a/feature/chat/src/main/res/values/strings.xml
+++ b/feature/chat/src/main/res/values/strings.xml
@@ -27,14 +27,14 @@
   <string name="error_page_additional_text_link_text">GOV.UK app homepage</string>
   <string name="error_page_additional_text_outro">if you need information now.</string>
   <string name="error_page_additional_text_url">https://www.gov.uk</string>
-  <string name="bot_message_availability_text">Messages will be available for 90 days</string>
+  <string name="bot_message_availability_text">Messages will be available until the end of the GOV.UK Chat trial</string>
   <string name="bot_message_1">Hi 👋 I’m GOV.UK Chat.</string>
   <string name="bot_message_2">I’m an experimental AI tool.\n\nWhen you ask a question, I’ll find the most relevant information from GOV.UK and use it to create an answer.</string>
   <string name="bot_message_3">Ask a question to get started.</string>
   <string name="error_retry_page_subtext">Your previous conversation is no longer available.</string>
   <string name="error_retry_page_additional_text">To continue using GOV.UK Chat, you need to start a new chat.</string>
   <string name="error_retry_button_text">Start a new chat</string>
-  <string name="loading_text">Generating your answer&#8230;</string>
+  <string name="loading_text">Generating your answer</string>
   <string name="clear_dialog_title">Do you want to clear your chat history?</string>
   <string name="clear_dialog_positive_button">Yes, clear chat</string>
   <string name="clear_dialog_negative_button">No, not now</string>


### PR DESCRIPTION
# Title

- Remove ellipsis and animation from loading text
- Update header text
- Centre header text

## JIRA ticket(s)
  - [GOVUKAPP-2433](https://govukverify.atlassian.net/browse/GOVUKAPP-2433)

## Figma
  - [Figma board](https://www.figma.com/design/rKYEySuNc8aikJWYfEz1wR/2025-04-GOV.UK-Chat?node-id=8391-88164&t=0M9Lmlz9yKmV3p56-4)

## Screen shots

<img width="1080" height="2280" alt="Screenshot_20250903_105206" src="https://github.com/user-attachments/assets/0bd640f5-2226-4125-9e73-3b581d1dc456" />

<img width="1080" height="2280" alt="Screenshot_20250903_105240" src="https://github.com/user-attachments/assets/f7c26e0b-26d2-4372-9ba6-6dcb18f1f3e6" />

