### PR TITLE
GOVUKAPP-2508 Switch accessibility improvement

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -28,7 +29,8 @@ import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
@@ -217,7 +219,12 @@ fun ToggleListItem(
         Row(
             modifier = Modifier
                 .padding(horizontal = GovUkTheme.spacing.medium)
-                .padding(vertical = GovUkTheme.spacing.small),
+                .padding(vertical = GovUkTheme.spacing.small)
+                .toggleable(
+                    value = checked,
+                    onValueChange = onCheckedChange,
+                    role = Role.Switch
+                ),
             verticalAlignment = Alignment.CenterVertically
         ) {
             BodyRegularLabel(
@@ -231,9 +238,7 @@ fun ToggleListItem(
                 checked = checked,
                 onCheckedChange = onCheckedChange,
                 testDescription = title,
-                modifier = Modifier.semantics {
-                    contentDescription = title
-                }
+                Modifier.clearAndSetSemantics {  }
             )
         }
     }


### PR DESCRIPTION
# Switch accessibility improvement

Make row containing text and switch 'toggleable' so elements are read as one.
*For some reason 'toggleable' naturally announces the toggle state (e.g "On") before it announces the label.

## JIRA ticket(s)
  - [GOVUKAPP-2508](https://govukverify.atlassian.net/browse/GOVUKAPP-2508)


https://github.com/user-attachments/assets/6d0a5904-9181-4e68-a31d-ac949d5887c4



[GOVUKAPP-2508]: https://govukverify.atlassian.net/browse/GOVUKAPP-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ