### PR TITLE
GOVUKAPP-2504 Non tappable card

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Card.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Card.kt
@@ -2,6 +2,7 @@ package uk.gov.govuk.design.ui.component
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -22,6 +24,7 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -330,6 +333,19 @@ fun UserFeedbackCard(
     }
 }
 
+@Composable
+fun NonTappableCard(body: String) {
+    BodyRegularLabel(
+        text = body,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape = RoundedCornerShape(12.dp))
+            .background(GovUkTheme.colourScheme.surfaces.cardNonTappable)
+            .padding(16.dp),
+        color = GovUkTheme.colourScheme.textAndIcons.secondary
+    )
+}
+
 @Preview
 @Composable
 private fun HomeNavigationCardPreview() {
@@ -429,5 +445,13 @@ private fun SearchResultWithoutDescriptionPreview() {
 private fun UserFeedbackCardPreview() {
     GovUkTheme {
         UserFeedbackCard("Card body", "A link description", {})
+    }
+}
+
+@Preview
+@Composable
+private fun NonTappableCardPreview() {
+    GovUkTheme {
+        NonTappableCard("Card body")
     }
 }

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
@@ -18,6 +18,7 @@ private val BlueLighter90 = Color(0xFFE8F1F8)
 private val BlueLighter95 = Color(0xFFF4F8FB)
 private val BlueDarker25 = Color(0xFF16548A)
 private val BlueDarker50 = Color(0xFF0F385C)
+private val BlueDarker65 = Color(0xFF0A2740)
 private val BlueDarker80 = Color(0xFF061625)
 private val BlueDarker80Alpha50 = Color(0x80061625)
 private val BlueDarkMode = Color(0xFF263D54)
@@ -108,6 +109,7 @@ data class GovUkColourScheme(
         val cardDefault: Color,
         val cardBlue: Color,
         val cardHighlight: Color,
+        val cardNonTappable: Color,
         val cardSelected: Color,
         val listBlue: Color,
         val listHeadingBlue: Color,
@@ -215,6 +217,7 @@ internal val LightColorScheme = GovUkColourScheme(
         cardDefault = White,
         cardBlue = BlueLighter95,
         cardHighlight = Grey400,
+        cardNonTappable = BlueLighter80,
         cardSelected = GreenLighter95,
         listBlue = BlueLighter95,
         listHeadingBlue = BlueLighter95,
@@ -321,6 +324,7 @@ internal val DarkColorScheme = GovUkColourScheme(
         cardDefault = BlueDarkMode,
         cardBlue = BlueDarker50,
         cardHighlight = Grey850,
+        cardNonTappable = BlueDarker65,
         cardSelected = GreenDarker50,
         listBlue = BlueDarker80,
         listHeadingBlue = BlueDarker50,
@@ -428,6 +432,7 @@ internal val LocalColourScheme = staticCompositionLocalOf {
             cardDefault = Color.Unspecified,
             cardBlue = Color.Unspecified,
             cardHighlight = Color.Unspecified,
+            cardNonTappable = Color.Unspecified,
             cardSelected = Color.Unspecified,
             listBlue = Color.Unspecified,
             listHeadingBlue = Color.Unspecified,


### PR DESCRIPTION
# Non tappable card

- Add new non tappable card
*Card is currently not used anywhere in the app

## JIRA ticket(s)
  - [GOVUKAPP-2504](https://govukverify.atlassian.net/browse/GOVUKAPP-2504)

## Figma
  - [Figma board](https://www.figma.com/design/x5i4a5RT0xMhJAcjoIxefb/2025-06-GOV.UK-app-library-v2--UX-refresh?node-id=6532-6646&t=PgWWJCWJtE6mN0ua-0)

## Screen shots

<img width="411" height="187" alt="image" src="https://github.com/user-attachments/assets/85062a91-34d2-4ba8-a550-d4f3bb3d3180" />


[GOVUKAPP-2504]: https://govukverify.atlassian.net/browse/GOVUKAPP-2504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ