### PR TITLE
GOVUKAPP-2586 Remote refresh token expiry seconds

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/LoginViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import uk.gov.govuk.R
+import uk.gov.govuk.config.data.ConfigRepo
 import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.auth.ErrorEvent
 import uk.gov.govuk.login.data.LoginRepo
@@ -22,7 +23,8 @@ internal data class LoginEvent(val isBiometricLogin: Boolean)
 @HiltViewModel
 internal class LoginViewModel @Inject constructor(
     private val authRepo: AuthRepo,
-    private val loginRepo: LoginRepo
+    private val loginRepo: LoginRepo,
+    private val configRepo: ConfigRepo
 ) : ViewModel() {
 
     private val _isLoading: MutableStateFlow<Boolean?> = MutableStateFlow(null)
@@ -83,8 +85,9 @@ internal class LoginViewModel @Inject constructor(
     private fun saveRefreshTokenExpiryDate() {
         viewModelScope.launch {
             authRepo.getIdTokenIssueDate()?.let { idTokenIssueDate ->
-                val datePlusSixDaysTwentyThreeHours = idTokenIssueDate + 601200L
-                loginRepo.setRefreshTokenExpiryDate(datePlusSixDaysTwentyThreeHours)
+                val datePlusRefreshTokenExpiry =
+                    idTokenIssueDate + configRepo.config.refreshTokenExpirySeconds
+                loginRepo.setRefreshTokenExpiryDate(datePlusRefreshTokenExpiry)
             }
         }
     }

--- a/app/src/test/kotlin/uk/gov/govuk/login/LoginViewModelTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/login/LoginViewModelTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import uk.gov.govuk.config.data.ConfigRepo
 import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.auth.AuthRepo.RefreshStatus.ERROR
 import uk.gov.govuk.data.auth.AuthRepo.RefreshStatus.LOADING
@@ -33,6 +34,7 @@ class LoginViewModelTest {
 
     private val authRepo = mockk<AuthRepo>(relaxed = true)
     private val loginRepo = mockk<LoginRepo>(relaxed = true)
+    private val configRepo = mockk<ConfigRepo>(relaxed = true)
     private val activity = mockk<FragmentActivity>(relaxed = true)
     private val dispatcher = UnconfinedTestDispatcher()
 
@@ -41,7 +43,7 @@ class LoginViewModelTest {
     @Before
     fun setup() {
         Dispatchers.setMain(dispatcher)
-        viewModel = LoginViewModel(authRepo, loginRepo)
+        viewModel = LoginViewModel(authRepo, loginRepo, configRepo)
     }
 
     @After
@@ -158,6 +160,7 @@ class LoginViewModelTest {
     fun `Given an auth response, when success and id token issue date is stored, then emit loading, login event and set token expiry`() {
         coEvery { authRepo.handleAuthResponse(any()) } returns true
         every { authRepo.getIdTokenIssueDate() } returns 12345L
+        every { configRepo.config.refreshTokenExpirySeconds } returns 601200L
 
         runTest {
             val isLoading = mutableListOf<Boolean?>()

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/model/Config.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/model/Config.kt
@@ -11,5 +11,6 @@ data class Config(
     @SerializedName("chatPollIntervalSeconds") val chatPollIntervalSeconds: Int?,
     @SerializedName("alertBanner") val alertBanner: AlertBanner?,
     @SerializedName("userFeedbackBanner") val userFeedbackBanner: UserFeedbackBanner?,
-    @SerializedName("chatUrls") val chatUrls: ChatUrls
+    @SerializedName("chatUrls") val chatUrls: ChatUrls,
+    @SerializedName("refreshTokenExpirySeconds") val refreshTokenExpirySeconds: Long
 )


### PR DESCRIPTION
# Remote refresh token expiry seconds

- Get the refresh token expiry seconds from app config instead of using the current hardcoded value.
- This is so we can update the refresh token expiry seconds remotely without an app update.

## JIRA ticket(s)
  - [GOVUKAPP-2586](https://govukverify.atlassian.net/browse/GOVUKAPP-2586)


[GOVUKAPP-2586]: https://govukverify.atlassian.net/browse/GOVUKAPP-2586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ