### PR TITLE
GOVUKAPP-2528 : Markdown rendering investigation

### DIFF
--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/Answer.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/Answer.kt
@@ -39,6 +39,8 @@ internal fun Answer(
                     end = GovUkTheme.spacing.medium
                 )
             )
+
+            MediumVerticalSpacer()
         }
 
         Markdown(

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ChatEntry.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ChatEntry.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.delay
 import uk.gov.govuk.chat.R
 import uk.gov.govuk.chat.ui.model.ChatEntry
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
-import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
+import uk.gov.govuk.design.ui.component.LargeVerticalSpacer
 import uk.gov.govuk.design.ui.component.SmallHorizontalSpacer
 
 @Composable
@@ -41,9 +41,9 @@ internal fun ChatEntry(
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
-        MediumVerticalSpacer()
+        LargeVerticalSpacer()
         Question(question = chatEntry.question)
-        MediumVerticalSpacer()
+        LargeVerticalSpacer()
         AnimatedChatEntry(
             chatEntry = chatEntry,
             onMarkdownLinkClicked = onMarkdownLinkClicked,

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ChatInput.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ChatInput.kt
@@ -89,7 +89,11 @@ internal fun ChatInput(
 
         Row(
             modifier = Modifier
-                .padding(horizontal = GovUkTheme.spacing.medium),
+                .padding(
+                    start = GovUkTheme.spacing.medium,
+                    end = GovUkTheme.spacing.medium,
+                    bottom = GovUkTheme.spacing.medium
+                ),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ChatInput.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ChatInput.kt
@@ -100,11 +100,7 @@ internal fun ChatInput(
             Box(
                 modifier = Modifier
                     .fillMaxWidth(
-                        if (isFocused && uiState.question.isNotEmpty()) {
-                            1f
-                        } else {
-                            0.88f
-                        }
+                        if (focusedWithInput(isFocused, uiState)) 1f else 0.88f
                     )
                     .animateContentSize(
                         animationSpec = tween(durationMillis = 100)
@@ -144,7 +140,7 @@ internal fun ChatInput(
                     colors = inputTextFieldDefaults(),
                     trailingIcon = {
                         AnimateIcon(
-                            isFocused && uiState.question.isNotEmpty(),
+                            focusedWithInput(isFocused, uiState),
                             {
                                 SubmitIconButton(
                                     onClick = {
@@ -160,7 +156,7 @@ internal fun ChatInput(
             }
 
             AnimateIcon(
-                (uiState.question.isEmpty() || !isFocused && uiState.question.isNotEmpty()),
+                (uiState.question.isEmpty() || !focusedWithInput(isFocused, uiState)),
                 {
                     ActionMenu(
                         hasConversation = hasConversation,
@@ -179,6 +175,13 @@ internal fun ChatInput(
             )
         }
     }
+}
+
+private fun focusedWithInput(
+    isFocused: Boolean,
+    uiState: ChatUiState.Default
+) : Boolean {
+    return isFocused && uiState.question.isNotEmpty()
 }
 
 @Composable

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/Markdown.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/Markdown.kt
@@ -18,14 +18,19 @@ internal fun Markdown(
     markdownLinkType: String,
     modifier: Modifier = Modifier
 ) {
+    // Convert h1-h6 headers to bold
+    val headerRegex = "(#+ *)(.*)(\n)".toRegex()
+    val headerReplacement = "$3\\*\\*$2\\*\\*$3$3" // \n**header text**\n\n
+
     MarkdownText(
-        markdown = text,
+        markdown = headerRegex.replace(text, headerReplacement),
         linkColor = GovUkTheme.colourScheme.textAndIcons.link,
         style = TextStyle(
             color = GovUkTheme.colourScheme.textAndIcons.primary,
             fontSize = GovUkTheme.typography.bodyRegular.fontSize,
             fontFamily = GovUkTheme.typography.bodyRegular.fontFamily,
-            fontWeight = GovUkTheme.typography.bodyRegular.fontWeight
+            fontWeight = GovUkTheme.typography.bodyRegular.fontWeight,
+            lineHeight = GovUkTheme.typography.bodyRegular.lineHeight
         ),
         enableSoftBreakAddsNewLine = false,
         enableUnderlineForLink = false,

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/Sources.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/Sources.kt
@@ -27,6 +27,7 @@ import uk.gov.govuk.chat.domain.Analytics
 import uk.gov.govuk.design.ui.component.BodyBoldLabel
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
+import uk.gov.govuk.design.ui.component.SmallVerticalSpacer
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 
 @Composable
@@ -54,7 +55,10 @@ internal fun Sources(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(GovUkTheme.spacing.medium),
+                .padding(
+                    horizontal = GovUkTheme.spacing.medium,
+                    vertical = GovUkTheme.spacing.small
+                ),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Icon(
@@ -79,7 +83,10 @@ internal fun Sources(
                     }
                 }
                 .fillMaxWidth()
-                .padding(GovUkTheme.spacing.medium),
+                .padding(
+                    horizontal = GovUkTheme.spacing.medium,
+                    vertical = GovUkTheme.spacing.small
+                ),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             BodyRegularLabel(
@@ -103,7 +110,7 @@ internal fun Sources(
                     val linkAddendumText = stringResource(id = R.string.sources_open_in_text)
                     val linkText = "${sources[index]} $linkAddendumText"
 
-                    MediumVerticalSpacer()
+                    SmallVerticalSpacer()
 
                     Markdown(
                         text = sources[index],
@@ -113,7 +120,7 @@ internal fun Sources(
                     )
 
                     if (index < sources.size - 1) {
-                        MediumVerticalSpacer()
+                        SmallVerticalSpacer()
                         ChatDivider(
                             modifier = Modifier.padding(horizontal = GovUkTheme.spacing.medium)
                         )


### PR DESCRIPTION
## Addresses the following

- Answer formatting: Remove bullet point (unordered) and number list (ordered) indentation
- Answer formatting: Spacing between the accuracy warning and the separator line inconsistent across OS versions
- Headlines: Revise headlines hierarchy - font size on headings in LLM generated answers
- Answer formatting: Answer needs spacing between title and answer
- List items: Line height for list items is broken
- Responses: Response typography / formatting
- Responses: Response title
- Detail of the expected outcome (some are duplicates of above items):
    - There should be additional spacing padding between each bulleted item. (likely 10px)
    - Any large headings should be the same size as regular text but bold
    - Reduce indent on bullet points
    - Reduce indent on numbered list
    - Could we align spacing with the app homepage. So use 8px between chat messages and 16px between chat messages and user messages

Also, padding issue at bottom of input box.

## Markdown library currently in use
  - [compose-markdown](https://github.com/jeziellago/compose-markdown)

## JIRA ticket(s)
  - [GOVUKAPP-2528](https://govukverify.atlassian.net/browse/GOVUKAPP-2528)

## Doc
  - [Typography and spacing adjustments for GOV.UK Chat in app](https://docs.google.com/document/d/1pDdF6DyIoBtJZ4_ZL1rNgDukwSKUk-ajmKzg6aHxndo/edit?tab=t.0)

## List indentation

### Video show document showing valid and invalid lists as displayed by the [compose-markdown](https://github.com/jeziellago/compose-markdown).

[Screen_recording_20250925_114306.webm](https://github.com/user-attachments/assets/ed1e0789-3432-4d2f-9b1a-92d03bcec52e)

From this we can see that `compose-markdown` has issues displaying the following **valid** lists:
- `Mixed Markers`
- `Custom Start Numbers`
- `Zero/Leading Zeros`
- `Empty List items`

All other lists options are correctly display, with no indentation issues being found.

So, we can say that given [correctly formatted lists](https://spec.commonmark.org/0.31.2/#list-items) they are (mostly) displayed correctly (with the above exceptions). Where, the library has been given incorrectly formatted lists - those too are displayed correctly.

Which means any incorrectly formatted lists should - ideally - be fixed at source. If not possible due to volume for example, all possible breakages should be identified and documented so that manual fixes can be added if required.

## Videos - Markdown headers

| Before | After |
|--------|-------|
| [Screen_recording_20250924_153443.webm](https://github.com/user-attachments/assets/367f72ad-4a8c-4bb8-9c25-48bc9227ecde) | [Screen_recording_20250924_153257.webm](https://github.com/user-attachments/assets/451d18ae-b59d-45e5-8d55-ee2fbe25d080) |

[Regex validation](https://regex101.com/r/ieIwt6/1)

## Screenshots - Padding issues

| Before | After |
|--------|-------|
| <img width="1080" height="2424" alt="Screenshot_20250925_110055" src="https://github.com/user-attachments/assets/8e76c5fb-a375-4620-8681-ba1b35185510" /> | <img width="1080" height="2424" alt="Screenshot_20250925_105824" src="https://github.com/user-attachments/assets/ac44e80c-9fb0-4a54-b7d4-f780803b7932" /> |
| <img width="1079" height="515" alt="Screenshot_20250925_132426" src="https://github.com/user-attachments/assets/2b4ec423-2bd2-49d2-8205-4e930545db16" /> | <img width="1078" height="611" alt="Screenshot_20250925_131656" src="https://github.com/user-attachments/assets/c062806e-4de1-4dba-93c6-b51efe9dcbde" /> |
| <img width="1077" height="904" alt="Screenshot_20250925_132322" src="https://github.com/user-attachments/assets/b98642a9-9fa8-4794-a430-a3242c553edb" /> | <img width="1075" height="750" alt="Screenshot_20250925_131726" src="https://github.com/user-attachments/assets/9f65d345-a44b-41ee-b218-5cf5aeb11aa0" /> |



[GOVUKAPP-2528]: https://govukverify.atlassian.net/browse/GOVUKAPP-2528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ