### PR TITLE
GOVUKAPP-2301: Dark mode header

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Header.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Header.kt
@@ -157,7 +157,7 @@ fun ChildPageHeader(
         actionAltText = actionAltText,
         backgroundColour = GovUkTheme.colourScheme.surfaces.homeHeader,
         actionColour = GovUkTheme.colourScheme.textAndIcons.linkHeader,
-        titleColour = GovUkTheme.colourScheme.textAndIcons.linkHeader
+        titleColour = GovUkTheme.colourScheme.textAndIcons.header
     )
 }
 

--- a/feature/visited/src/main/kotlin/uk/gov/govuk/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/gov/govuk/visited/ui/EditVisitedScreen.kt
@@ -37,6 +37,7 @@ import uk.gov.govuk.design.ui.component.CardListItem
 import uk.gov.govuk.design.ui.component.ChildPageHeader
 import uk.gov.govuk.design.ui.component.LargeVerticalSpacer
 import uk.gov.govuk.design.ui.component.ListHeadingLabel
+import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
 import uk.gov.govuk.design.ui.component.SmallVerticalSpacer
 import uk.gov.govuk.design.ui.component.SubheadlineRegularLabel
 import uk.gov.govuk.design.ui.theme.GovUkTheme
@@ -140,7 +141,7 @@ private fun EditVisitedScreen(
                 .fillMaxWidth()
         ) {
             item {
-                SmallVerticalSpacer()
+                MediumVerticalSpacer()
             }
 
             item {


### PR DESCRIPTION
Update child page header to use white text for dark mode. Correct spacing on visited edit screen.

# Title

Description

## JIRA ticket(s)
  - [GOVUKAPP-2301](https://govukverify.atlassian.net/browse/GOVUKAPP-2301)

## Figma
  - [Figma board](https://www.figma.com/design/siD3CH5hRhIAmVTQ10xkjb/2024-07-GOV.UK-app-library-v1--Private-Beta?node-id=1299-2922&t=gqKGHugCi3soWfyv-0)

## Screen shots

<img width="1080" height="2280" alt="Screenshot_20250925_152742" src="https://github.com/user-attachments/assets/116bd4b8-dd26-4cd1-b520-59385384c916" />




[GOVUKAPP-2301]: https://govukverify.atlassian.net/browse/GOVUKAPP-2301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ