### PR TITLE
GOVUKAPP-2486 : Post amigo fixups

### DIFF
--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ChatInput.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ChatInput.kt
@@ -77,6 +77,10 @@ internal fun ChatInput(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(start = GovUkTheme.spacing.medium)
+                .height(32.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Start
         ) {
             if (isFocused) {
                 CharacterCountMessage(
@@ -265,8 +269,7 @@ private fun CharacterCountMessage(
     modifier: Modifier = Modifier
 ) {
     val charactersRemaining = abs(charactersRemaining)
-    var color = GovUkTheme.colourScheme.textAndIcons.secondary
-    var style = GovUkTheme.typography.subheadlineRegular
+    var color = GovUkTheme.colourScheme.textAndIcons.primary
     var text = ""
 
     when {
@@ -284,14 +287,16 @@ private fun CharacterCountMessage(
                 charactersRemaining
             )
             color = GovUkTheme.colourScheme.textAndIcons.textFieldError
-            style = GovUkTheme.typography.subheadlineBold
         }
     }
 
     Text(
         text = text,
         color = color,
-        style = style,
+        fontSize = GovUkTheme.typography.bodyRegular.fontSize,
+        fontWeight = GovUkTheme.typography.bodyRegular.fontWeight,
+        fontFamily = GovUkTheme.typography.bodyRegular.fontFamily,
+        lineHeight = GovUkTheme.typography.bodyRegular.lineHeight,
         modifier = modifier.padding(horizontal = GovUkTheme.spacing.medium)
     )
 }


### PR DESCRIPTION
## Fixes:

- Use regular font size, weight, family and line height for character count text
- Use `primary` font colour - unless over limit - for character count text
- Don't use bold font weight when over limit - for character count text
- Use height of 32px for character count container
- Left align start of character count text inline with input text and answer text

## JIRA ticket(s)
  - [GOVUKAPP-2486](https://govukverify.atlassian.net/browse/GOVUKAPP-2486)

## Screen shots

| Within limit | Show count alignment | Over limit |
| --- | --- | --- |
| <img width="1080" height="2424" alt="Screenshot_20250926_113101" src="https://github.com/user-attachments/assets/8ac95d77-644a-49c5-90c7-8a7da4628c67" /> | <img width="1080" height="2424" alt="Screenshot_20250926_113119" src="https://github.com/user-attachments/assets/da5607e4-c6f2-4406-8a03-021c759aa52d" /> | <img width="1080" height="2424" alt="Screenshot_20250926_113136" src="https://github.com/user-attachments/assets/969cc5fd-c0a2-4fd3-91ba-742af753fa97" /> |


[GOVUKAPP-2486]: https://govukverify.atlassian.net/browse/GOVUKAPP-2486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ