### PR TITLE
GOVUKAPP-2577 App refresh background colours

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/login/ui/BiometricSettingsScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/login/ui/BiometricSettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.gov.govuk.R
+import uk.gov.govuk.design.ui.component.ScreenBackground
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.ChildPageHeader
 import uk.gov.govuk.design.ui.component.LargeTitleBoldLabel
@@ -59,6 +60,8 @@ private fun BiometricSettingsScreen(
     @StringRes descriptionTwo: Int,
     modifier: Modifier = Modifier
 ) {
+    ScreenBackground()
+
     LaunchedEffect(Unit) {
         onPageView()
     }

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Background.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/Background.kt
@@ -1,0 +1,17 @@
+package uk.gov.govuk.design.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import uk.gov.govuk.design.ui.theme.GovUkTheme
+
+@Composable
+fun ScreenBackground() {
+    Box(
+        modifier = Modifier
+            .background(GovUkTheme.colourScheme.surfaces.screenBackground)
+            .fillMaxSize()
+    )
+}

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
@@ -145,7 +145,8 @@ data class GovUkColourScheme(
         val chatButtonBackgroundEnabled: Color,
         val chatUserMessageBackground: Color,
         val chatBotMessageBackground: Color,
-        val chatIntroCardBackground: Color
+        val chatIntroCardBackground: Color,
+        val screenBackground: Color
     )
 
     data class Strokes(
@@ -252,7 +253,8 @@ internal val LightColorScheme = GovUkColourScheme(
         chatButtonBackgroundEnabled = BluePrimary,
         chatUserMessageBackground = WhiteAlpha50,
         chatBotMessageBackground = White,
-        chatIntroCardBackground = BlueLighter95
+        chatIntroCardBackground = BlueLighter95,
+        screenBackground = BlueLighter90
     ),
     strokes = Strokes(
         fixedContainer = BlackAlpha30,
@@ -358,7 +360,8 @@ internal val DarkColorScheme = GovUkColourScheme(
         chatButtonBackgroundEnabled = BlueAccent,
         chatUserMessageBackground = BlueDarker80Alpha50,
         chatBotMessageBackground = BlueDarker80,
-        chatIntroCardBackground = Blue99
+        chatIntroCardBackground = Blue99,
+        screenBackground = BlueDarker80
     ),
     strokes = Strokes(
         fixedContainer = WhiteAlpha30,
@@ -465,7 +468,8 @@ internal val LocalColourScheme = staticCompositionLocalOf {
             chatButtonBackgroundEnabled = Color.Unspecified,
             chatUserMessageBackground = Color.Unspecified,
             chatBotMessageBackground = Color.Unspecified,
-            chatIntroCardBackground = Color.Unspecified
+            chatIntroCardBackground = Color.Unspecified,
+            screenBackground = Color.Unspecified
         ),
         strokes = Strokes(
             fixedContainer = Color.Unspecified,

--- a/feature/home/src/main/kotlin/uk/gov/govuk/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/uk/gov/govuk/home/ui/HomeScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import uk.gov.govuk.design.ui.component.ScreenBackground
 import uk.gov.govuk.design.ui.component.LargeVerticalSpacer
 import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
 import uk.gov.govuk.design.ui.theme.GovUkTheme
@@ -50,6 +51,8 @@ private fun HomeScreen(
     modifier: Modifier = Modifier,
     headerWidget: (@Composable (Modifier) -> Unit)? = null,
 ) {
+    ScreenBackground()
+
     LaunchedEffect(Unit) {
         onPageView()
     }

--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/ui/SettingsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
+import uk.gov.govuk.design.ui.component.ScreenBackground
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.CaptionRegularLabel
 import uk.gov.govuk.design.ui.component.CardListItem
@@ -132,6 +133,8 @@ private fun SettingsScreen(
     actions: SettingsActions,
     modifier: Modifier = Modifier
 ) {
+    ScreenBackground()
+
     LaunchedEffect(Unit) {
         actions.onPageView()
     }

--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/AllStepByStepsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/AllStepByStepsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
+import uk.gov.govuk.design.ui.component.ScreenBackground
 import uk.gov.govuk.design.ui.component.ChildPageHeader
 import uk.gov.govuk.design.ui.component.ExternalLinkListItem
 import uk.gov.govuk.design.ui.component.LargeVerticalSpacer
@@ -56,6 +57,8 @@ private fun AllStepByStepsScreen(
     onExternalLink: (section: String, text: String, url: String, selectedItemIndex: Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    ScreenBackground()
+
     Column(modifier.fillMaxSize()) {
         val title = stringResource(R.string.stepByStepGuidesTitle)
 

--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/AllTopicsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/AllTopicsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
+import uk.gov.govuk.design.ui.component.ScreenBackground
 import uk.gov.govuk.design.ui.component.ChildPageHeader
 import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
 import uk.gov.govuk.design.ui.theme.GovUkTheme
@@ -49,6 +50,8 @@ private fun AllTopicsScreen(
     modifier: Modifier = Modifier
 ) {
     val title = stringResource(R.string.allTopicsTitle)
+
+    ScreenBackground()
 
     LaunchedEffect(Unit) {
         onPageView(title)

--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/EditTopicsScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/EditTopicsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
+import uk.gov.govuk.design.ui.component.ScreenBackground
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.ChildPageHeader
 import uk.gov.govuk.design.ui.component.ExtraLargeVerticalSpacer
@@ -53,6 +54,8 @@ private fun EditTopicsScreen(
     modifier: Modifier = Modifier
 ) {
     val title = stringResource(R.string.editTitle)
+
+    ScreenBackground()
 
     LaunchedEffect(Unit) {
         onPageView(title)

--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/TopicScreen.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/TopicScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.delay
+import uk.gov.govuk.design.ui.component.ScreenBackground
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.ChildPageHeader
 import uk.gov.govuk.design.ui.component.ExternalLinkListItem
@@ -58,6 +59,8 @@ internal fun TopicRoute(
     val viewModel: TopicViewModel = hiltViewModel()
     val uiState by viewModel.uiState.collectAsState()
     val focusRequester = remember { FocusRequester() }
+
+    ScreenBackground()
 
     Box(modifier.fillMaxSize()) {
         uiState?.let {

--- a/feature/visited/src/main/kotlin/uk/gov/govuk/visited/ui/EditVisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/gov/govuk/visited/ui/EditVisitedScreen.kt
@@ -1,5 +1,6 @@
 package uk.gov.govuk.visited.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -32,6 +33,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import uk.gov.govuk.design.ui.component.ScreenBackground
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.CardListItem
 import uk.gov.govuk.design.ui.component.ChildPageHeader
@@ -110,7 +112,6 @@ private fun EditVisitedScreen(
     val editingCompleteAltText = stringResource(R.string.visited_items_editing_complete_alt)
 
     Scaffold(
-        containerColor = GovUkTheme.colourScheme.surfaces.background,
         modifier = modifier
             .nestedScroll(scrollBehavior.nestedScrollConnection)
             .fillMaxWidth(),
@@ -133,6 +134,9 @@ private fun EditVisitedScreen(
             )
         }
     ) { innerPadding ->
+
+        ScreenBackground()
+
         LazyColumn(
             modifier = modifier
                 .padding(innerPadding)
@@ -261,7 +265,7 @@ private fun BottomNavBar(
     val deselectText = stringResource(R.string.visited_items_deselect_all_button)
     val removeText = stringResource(R.string.visited_items_remove_button)
 
-    Column(modifier = modifier) {
+    Column(modifier = modifier.background(GovUkTheme.colourScheme.surfaces.background)) {
         HorizontalDivider(
             thickness = 1.dp,
             color = GovUkTheme.colourScheme.strokes.fixedContainer

--- a/feature/visited/src/main/kotlin/uk/gov/govuk/visited/ui/VisitedScreen.kt
+++ b/feature/visited/src/main/kotlin/uk/gov/govuk/visited/ui/VisitedScreen.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.NavController
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import uk.gov.govuk.design.ui.component.ScreenBackground
 import uk.gov.govuk.design.ui.component.BodyBoldLabel
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.ChildPageHeader
@@ -77,6 +78,8 @@ private fun VisitedScreen(
     launchBrowser: (url: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    ScreenBackground()
+
     LaunchedEffect(Unit) {
         onPageView()
     }


### PR DESCRIPTION
# App refresh background colours

- Add new screen background colour to all main screens except for onboarding and search.

## JIRA ticket(s)
  - [GOVUKAPP-2577](https://govukverify.atlassian.net/browse/GOVUKAPP-2577)

## Figma
  - [Figma board](https://www.figma.com/design/PqVTAh9m4NGMWBdyXgltzl/2025-07-GOV.UK-app-updates-to-public-beta?node-id=2-12&t=tKOPTuzVuilTsWa9-0)

## Screen shots

| Before | After |
|--------|-------|
| <img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/33c74b99-9d86-4c52-9d8f-f60bc9627105" /> | <img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/749ec3a0-4671-4303-923e-1897c3eb080f" /> |



[GOVUKAPP-2577]: https://govukverify.atlassian.net/browse/GOVUKAPP-2577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ