### PR TITLE
GOVUKAPP-2605 : Change polling frequency to support decimal

### DIFF
--- a/config/src/main/kotlin/uk/gov/govuk/config/data/ConfigRepo.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/ConfigRepo.kt
@@ -21,7 +21,7 @@ class ConfigRepo @Inject constructor(
 ) {
 
     companion object {
-        private const val CHAT_POLL_INTERVAL_FALLBACK = 3
+        private const val CHAT_POLL_INTERVAL_FALLBACK = 3.0
     }
 
     private lateinit var _config: Config
@@ -60,6 +60,6 @@ class ConfigRepo @Inject constructor(
         }
     }
 
-    val chatPollIntervalSeconds: Int
-        get() = config.chatPollIntervalSeconds?.takeIf { it > 0 } ?: CHAT_POLL_INTERVAL_FALLBACK
+    val chatPollIntervalSeconds: Double
+        get() = (config.chatPollIntervalSeconds?.takeIf { it > 0.0 } ?: CHAT_POLL_INTERVAL_FALLBACK)
 }

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/model/Config.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/model/Config.kt
@@ -8,7 +8,7 @@ data class Config(
     @SerializedName("recommendedVersion") val recommendedVersion: String,
     @SerializedName("releaseFlags") val releaseFlags: ReleaseFlags,
     @SerializedName("version") val version: String,
-    @SerializedName("chatPollIntervalSeconds") val chatPollIntervalSeconds: Int?,
+    @SerializedName("chatPollIntervalSeconds") val chatPollIntervalSeconds: Double?,
     @SerializedName("alertBanner") val alertBanner: AlertBanner?,
     @SerializedName("userFeedbackBanner") val userFeedbackBanner: UserFeedbackBanner?,
     @SerializedName("chatUrls") val chatUrls: ChatUrls,

--- a/config/src/test/kotlin/uk/gov/govuk/config/data/ConfigRepoTest.kt
+++ b/config/src/test/kotlin/uk/gov/govuk/config/data/ConfigRepoTest.kt
@@ -135,13 +135,13 @@ class ConfigRepoTest {
         coEvery { configApi.getConfig() } returns Response.success(configResponse.toString())
         coEvery { signatureValidator.isValidSignature(any(), any()) } returns true
         coEvery { gson.fromJson(any<String>(), ConfigResponse::class.java) } returns ConfigResponse(config, "signature")
-        every { config.chatPollIntervalSeconds } returns 2
+        every { config.chatPollIntervalSeconds } returns 0.5
 
         val repo = ConfigRepo(configApi, gson, signatureValidator)
 
         runTest {
             repo.initConfig()
-            assertEquals(2, repo.chatPollIntervalSeconds)
+            assertEquals(0.5, repo.chatPollIntervalSeconds, 0.0)
         }
     }
 
@@ -156,7 +156,7 @@ class ConfigRepoTest {
 
         runTest {
             repo.initConfig()
-            assertEquals(3, repo.chatPollIntervalSeconds)
+            assertEquals(3.0, repo.chatPollIntervalSeconds, 0.0)
         }
     }
 
@@ -165,13 +165,13 @@ class ConfigRepoTest {
         coEvery { configApi.getConfig() } returns Response.success(configResponse.toString())
         coEvery { signatureValidator.isValidSignature(any(), any()) } returns true
         coEvery { gson.fromJson(any<String>(), ConfigResponse::class.java) } returns ConfigResponse(config, "signature")
-        every { config.chatPollIntervalSeconds } returns 0
+        every { config.chatPollIntervalSeconds } returns 0.0
 
         val repo = ConfigRepo(configApi, gson, signatureValidator)
 
         runTest {
             repo.initConfig()
-            assertEquals(3, repo.chatPollIntervalSeconds)
+            assertEquals(3.0, repo.chatPollIntervalSeconds, 0.0)
         }
     }
 }

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/data/ChatRepo.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/data/ChatRepo.kt
@@ -78,7 +78,7 @@ internal class ChatRepo @Inject constructor(
     suspend fun getAnswer(
         conversationId: String,
         questionId: String,
-        wait: Int? = null,
+        wait: Double? = null,
     ): ChatResult<Answer> {
         val pollInterval = wait ?: configRepo.chatPollIntervalSeconds
 

--- a/feature/chat/src/test/kotlin/uk/gov/govuk/chat/data/ChatRepoTest.kt
+++ b/feature/chat/src/test/kotlin/uk/gov/govuk/chat/data/ChatRepoTest.kt
@@ -106,7 +106,7 @@ class ChatRepoTest {
 
         val expected = Success(answer)
 
-        assertEquals(expected, chatRepo.getAnswer("123", "abc", wait = 1))
+        assertEquals(expected, chatRepo.getAnswer("123", "abc", wait = 1.0))
     }
 
     @Test
@@ -115,7 +115,7 @@ class ChatRepoTest {
         every { answerResponse.isSuccessful } returns true andThen false
         every { answerResponse.code() } returns 202 andThen 404
 
-        val result = chatRepo.getAnswer("123", "abc", wait = 1)
+        val result = chatRepo.getAnswer("123", "abc", wait = 1.0)
 
         assertTrue(result is NotFound)
     }


### PR DESCRIPTION
Change data type of `chatPollIntervalSeconds` from `Int` to `Double` in order to support sub-second intervals.

## JIRA ticket(s)
  - [GOVUKAPP-2605](https://govukverify.atlassian.net/browse/GOVUKAPP-2605)


[GOVUKAPP-2605]: https://govukverify.atlassian.net/browse/GOVUKAPP-2605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ