### PR TITLE
GOVUKAPP-2604 App Unavailable UI Padding Bug

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/ui/DeviceOfflineScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/DeviceOfflineScreen.kt
@@ -2,8 +2,11 @@ package uk.gov.govuk.ui
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -21,7 +24,11 @@ internal fun DeviceOfflineScreen(
     onTryAgain: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier.fillMaxWidth()) {
+    Column(
+        modifier
+            .fillMaxWidth()
+            .windowInsetsPadding(WindowInsets.systemBars)
+    ) {
         Column(
             Modifier
                 .weight(1f)

--- a/app/src/main/kotlin/uk/gov/govuk/ui/ForcedUpdateScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/ForcedUpdateScreen.kt
@@ -2,8 +2,11 @@ package uk.gov.govuk.ui
 
 import android.content.Intent
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -23,7 +26,9 @@ internal fun ForcedUpdateScreen(
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier.fillMaxWidth()
+        modifier
+            .fillMaxWidth()
+            .windowInsetsPadding(WindowInsets.systemBars)
     ) {
         Column(
             Modifier

--- a/app/src/main/kotlin/uk/gov/govuk/ui/RecommendUpdateScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/RecommendUpdateScreen.kt
@@ -2,8 +2,11 @@ package uk.gov.govuk.ui
 
 import android.content.Intent
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -24,7 +27,9 @@ internal fun RecommendUpdateScreen(
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier.fillMaxWidth()
+        modifier
+            .fillMaxWidth()
+            .windowInsetsPadding(WindowInsets.systemBars)
     ) {
         Column(
             Modifier

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/error/AppUnavailableScreen.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/error/AppUnavailableScreen.kt
@@ -2,8 +2,11 @@ package uk.gov.govuk.design.ui.component.error
 
 import android.content.Intent
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -24,7 +27,9 @@ fun AppUnavailableScreen(
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier.fillMaxWidth()
+        modifier
+            .fillMaxWidth()
+            .windowInsetsPadding(WindowInsets.systemBars)
     ) {
         Column(
             Modifier


### PR DESCRIPTION
# App Unavailable UI Padding Bug

Add window insets padding to App Unavailable & related screens for system bars

## JIRA ticket(s)
  - [GOVUKAPP-2604](https://govukverify.atlassian.net/browse/GOVUKAPP-2604)

## Screen shots

| Before | After |
|--------|-------|
| <img width="1344" height="2992" alt="Screenshot_1759483130" src="https://github.com/user-attachments/assets/e436c213-6801-40dc-b5ac-089cccc1e896" /> | <img width="1344" height="2992" alt="Screenshot_1759482392" src="https://github.com/user-attachments/assets/4c2cd804-0992-449d-86f4-155c4fc404a7" /> |

| Before | After |
|--------|-------|
| <img width="1344" height="2992" alt="Screenshot_1759483161" src="https://github.com/user-attachments/assets/7511d0b2-4bdf-4c76-b4f9-d4702edc5f3a" /> | <img width="1344" height="2992" alt="Screenshot_1759482427" src="https://github.com/user-attachments/assets/594aca8b-74da-4682-ad0b-aeb1a2b7635f" /> |

| Before | After |
|--------|-------|
| <img width="1344" height="2992" alt="Screenshot_1759483179" src="https://github.com/user-attachments/assets/3918c961-5162-4d76-a107-abb762010912" /> | <img width="1344" height="2992" alt="Screenshot_1759482359" src="https://github.com/user-attachments/assets/20cfa5b4-1f69-4cb9-bacd-825e8537e6b3" /> |

| Before | After |
|--------|-------|
| <img width="1344" height="2992" alt="Screenshot_1759483375" src="https://github.com/user-attachments/assets/027d2021-2511-48bc-934c-8ca779d7afe2" /> | <img width="1344" height="2992" alt="Screenshot_1759482594" src="https://github.com/user-attachments/assets/2f9af080-a7de-44a4-bcb8-0c1c297a0951" /> |
