### PR TITLE
GOVUKAPP-3372 : Get Ts&Cs timestamp from the Content API

### DIFF
--- a/app/src/test/kotlin/uk/gov/govuk/terms/data/TermsRepoTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/terms/data/TermsRepoTest.kt
@@ -37,7 +37,8 @@ class TermsRepoTest {
     fun `Given there is no terms accepted date, when get terms acceptance state, then return new user`() = runTest {
         every { configRepo.termsAndConditions } returns TermsAndConditions(
             lastUpdated = "2024-01-01T00:00:00Z",
-            url = "https://terms.url"
+            url = "https://terms.url",
+            contentItemApiUrl = "https://content-item.url"
         )
         coEvery { termsDataStore.getTermsAcceptedDate() } returns null
 
@@ -51,7 +52,8 @@ class TermsRepoTest {
     fun `Given terms were updated after they were accepted, when get terms acceptance state, then return updated`() = runTest {
         every { configRepo.termsAndConditions } returns TermsAndConditions(
             lastUpdated = "2024-06-01T00:00:00Z",
-            url = "https://terms.url"
+            url = "https://terms.url",
+            contentItemApiUrl = "https://content-item.url"
         )
         coEvery { termsDataStore.getTermsAcceptedDate() } returns Instant.parse("2024-01-01T00:00:00Z").toEpochMilli()
 
@@ -65,7 +67,8 @@ class TermsRepoTest {
     fun `Given terms were accepted after they were last updated, when get terms acceptance state, then return accepted`() = runTest {
         every { configRepo.termsAndConditions } returns TermsAndConditions(
             lastUpdated = "2024-01-01T00:00:00Z",
-            url = "https://terms.url"
+            url = "https://terms.url",
+            contentItemApiUrl = "https://content-item.url"
         )
         coEvery { termsDataStore.getTermsAcceptedDate() } returns Instant.parse("2024-06-01T00:00:00Z").toEpochMilli()
 
@@ -76,7 +79,8 @@ class TermsRepoTest {
     fun `Given the terms last updated date is invalid, when get terms acceptance state, then return error`() = runTest {
         every { configRepo.termsAndConditions } returns TermsAndConditions(
             lastUpdated = "not-a-date",
-            url = "https://terms.url"
+            url = "https://terms.url",
+            contentItemApiUrl = "https://content-item.url"
         )
         coEvery { termsDataStore.getTermsAcceptedDate() } returns 123L
 

--- a/config/build.gradle.kts
+++ b/config/build.gradle.kts
@@ -21,7 +21,6 @@ android {
 
         buildConfigField("String", "CONFIG_BASE_URL", "\"https://app.integration.publishing.service.gov.uk/config/\"")
         buildConfigField("String", "CONFIG_PUBLIC_KEY", "\"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEI9ifhn/iLdu3PwCKMhzqICSNUTivwF78Z9ybmhyIDF1Nvv+BavPyvz1XICfgEQ8g6IvHapaALXHcTszv5tFFfg==\"")
-        buildConfigField("String", "TS_AND_CS_CONTENT_ITEM_URL", "\"https://www.gov.uk/api/\"")
     }
 
     buildTypes {

--- a/config/build.gradle.kts
+++ b/config/build.gradle.kts
@@ -21,6 +21,7 @@ android {
 
         buildConfigField("String", "CONFIG_BASE_URL", "\"https://app.integration.publishing.service.gov.uk/config/\"")
         buildConfigField("String", "CONFIG_PUBLIC_KEY", "\"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEI9ifhn/iLdu3PwCKMhzqICSNUTivwF78Z9ybmhyIDF1Nvv+BavPyvz1XICfgEQ8g6IvHapaALXHcTszv5tFFfg==\"")
+        buildConfigField("String", "TS_AND_CS_CONTENT_ITEM_URL", "\"https://www.gov.uk/api/\"")
     }
 
     buildTypes {

--- a/config/consumer-rules.pro
+++ b/config/consumer-rules.pro
@@ -18,3 +18,5 @@
 -keep class uk.gov.govuk.config.data.remote.model.Link
 -keep class uk.gov.govuk.config.data.remote.model.ChatUrls
 -keep class uk.gov.govuk.config.data.remote.model.ChatBanner
+-keep class uk.gov.govuk.config.data.remote.model.TermsAndConditions
+-keep class uk.gov.govuk.config.data.remote.model.TermsAndConditionsTimestamp

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/ContentApi.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/ContentApi.kt
@@ -7,5 +7,5 @@ import retrofit2.http.Url
 fun interface ContentApi {
     // This requires a placeholder URL in providesContentApi
     @GET
-    suspend fun getContent(@Url url: String): Response<String>
+    suspend fun getContent(@Url url: String?): Response<String>
 }

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/ContentApi.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/ContentApi.kt
@@ -1,0 +1,9 @@
+package uk.gov.govuk.config.data.remote
+
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface ContentApi {
+    @GET("content/guidance/govuk-app-terms-and-conditions")
+    suspend fun getContent(): Response<String>
+}

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/ContentApi.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/ContentApi.kt
@@ -3,7 +3,7 @@ package uk.gov.govuk.config.data.remote
 import retrofit2.Response
 import retrofit2.http.GET
 
-interface ContentApi {
+fun interface ContentApi {
     @GET("content/guidance/govuk-app-terms-and-conditions")
     suspend fun getContent(): Response<String>
 }

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/ContentApi.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/ContentApi.kt
@@ -2,8 +2,10 @@ package uk.gov.govuk.config.data.remote
 
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Url
 
 fun interface ContentApi {
-    @GET("content/guidance/govuk-app-terms-and-conditions")
-    suspend fun getContent(): Response<String>
+    // This requires a placeholder URL in providesContentApi
+    @GET
+    suspend fun getContent(@Url url: String): Response<String>
 }

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/model/TermsAndConditions.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/model/TermsAndConditions.kt
@@ -4,5 +4,6 @@ import com.google.gson.annotations.SerializedName
 
 data class TermsAndConditions(
     @SerializedName("url") val url: String,
-    @SerializedName("lastUpdated") val lastUpdated: String? = null,
+    @SerializedName("contentItemApiUrl") val contentItemApiUrl: String,
+    @SerializedName("lastUpdated") val lastUpdated: String? = null
 )

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/model/TermsAndConditions.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/model/TermsAndConditions.kt
@@ -4,6 +4,6 @@ import com.google.gson.annotations.SerializedName
 import java.util.Date
 
 data class TermsAndConditions(
-    @SerializedName("lastUpdated") val lastUpdated: String,
-    @SerializedName("url") val url: String
+    @SerializedName("url") val url: String,
+    @SerializedName("lastUpdated") val lastUpdated: String? = null,
 )

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/model/TermsAndConditions.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/model/TermsAndConditions.kt
@@ -1,7 +1,6 @@
 package uk.gov.govuk.config.data.remote.model
 
 import com.google.gson.annotations.SerializedName
-import java.util.Date
 
 data class TermsAndConditions(
     @SerializedName("url") val url: String,

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/model/TermsAndConditionsTimestamp.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/model/TermsAndConditionsTimestamp.kt
@@ -1,0 +1,7 @@
+package uk.gov.govuk.config.data.remote.model
+
+import com.google.gson.annotations.SerializedName
+
+data class TermsAndConditionsTimestamp(
+    @SerializedName("public_updated_at") val publicUpdatedAt: String
+)

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSource.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSource.kt
@@ -37,8 +37,7 @@ class GovUkConfigDataSource @Inject constructor(
                     val configResponse = gson.fromJson(it, ConfigResponse::class.java)
                     val config = configResponse.config
 
-                    // TODO: Get the content item URL from the remote config
-                    val contentItemUrl = "https://www.gov.uk/api/content/guidance/govuk-app-terms-and-conditions"
+                    val contentItemUrl = config.termsAndConditions?.contentItemApiUrl
                     val content = contentApi.getContent(contentItemUrl)
 
                     if (content.isSuccessful) {

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSource.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSource.kt
@@ -1,10 +1,14 @@
 package uk.gov.govuk.config.data.remote.source
 
 import com.google.gson.Gson
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import uk.gov.govuk.config.SignatureValidator
 import uk.gov.govuk.config.data.remote.ConfigApi
+import uk.gov.govuk.config.data.remote.ContentApi
 import uk.gov.govuk.config.data.remote.model.Config
 import uk.gov.govuk.config.data.remote.model.ConfigResponse
+import uk.gov.govuk.config.data.remote.model.TermsAndConditionsTimestamp
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.data.model.Result.Success
 import uk.gov.govuk.data.model.Result.DeviceOffline
@@ -17,22 +21,42 @@ import javax.inject.Singleton
 @Singleton
 class GovUkConfigDataSource @Inject constructor(
     private val configApi: ConfigApi,
+    private val contentApi: ContentApi,
     private val gson: Gson,
     private val signatureValidator: SignatureValidator
 ) {
-    suspend fun fetchConfig(): Result<Config> {
-        return try {
-            val response = configApi.getConfig()
+    suspend fun fetchConfig(): Result<Config> = coroutineScope {
+        return@coroutineScope try {
+            val configDeferred = async { configApi.getConfig() }
+            val termsDeferred = async { contentApi.getContent() }
+
+            val response = configDeferred.await()
+            val content = termsDeferred.await()
+
             if (response.isSuccessful) {
                 response.body()?.let {
                     val signature = response.headers()["x-amz-meta-govuk-sig"] ?: ""
                     val valid = signatureValidator.isValidSignature(signature, it)
                     if (!valid) {
-                        return InvalidSignature()
+                        return@coroutineScope InvalidSignature()
                     }
 
                     val configResponse = gson.fromJson(it, ConfigResponse::class.java)
-                    Success(configResponse.config)
+                    val config = configResponse.config
+
+                    if (content.isSuccessful) {
+                        val contentItemTimestamp: String = content.body().run {
+                            gson.fromJson(this, TermsAndConditionsTimestamp::class.java).publicUpdatedAt
+                        }
+
+                        config.termsAndConditions = config.termsAndConditions?.copy(
+                            lastUpdated = contentItemTimestamp
+                        )
+
+                        Success(config)
+                    } else {
+                        Error() // Can't get the content item
+                    }
                 } ?: Error()
             } else {
                 Error()

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSource.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSource.kt
@@ -25,8 +25,8 @@ class GovUkConfigDataSource @Inject constructor(
     private val gson: Gson,
     private val signatureValidator: SignatureValidator
 ) {
-    suspend fun fetchConfig(): Result<Config> = coroutineScope {
-        return@coroutineScope try {
+    suspend fun fetchConfig(): Result<Config> = try {
+        coroutineScope {
             val configDeferred = async { configApi.getConfig() }
             val termsDeferred = async { contentApi.getContent() }
 
@@ -61,10 +61,10 @@ class GovUkConfigDataSource @Inject constructor(
             } else {
                 Error()
             }
-        } catch (_: UnknownHostException) {
-            DeviceOffline()
-        } catch (_: Exception) {
-            Error()
         }
+    } catch (_: UnknownHostException) {
+        DeviceOffline()
+    } catch (_: Exception) {
+        Error()
     }
 }

--- a/config/src/main/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSource.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSource.kt
@@ -1,8 +1,6 @@
 package uk.gov.govuk.config.data.remote.source
 
 import com.google.gson.Gson
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import uk.gov.govuk.config.SignatureValidator
 import uk.gov.govuk.config.data.remote.ConfigApi
 import uk.gov.govuk.config.data.remote.ContentApi
@@ -10,10 +8,10 @@ import uk.gov.govuk.config.data.remote.model.Config
 import uk.gov.govuk.config.data.remote.model.ConfigResponse
 import uk.gov.govuk.config.data.remote.model.TermsAndConditionsTimestamp
 import uk.gov.govuk.data.model.Result
-import uk.gov.govuk.data.model.Result.Success
 import uk.gov.govuk.data.model.Result.DeviceOffline
-import uk.gov.govuk.data.model.Result.InvalidSignature
 import uk.gov.govuk.data.model.Result.Error
+import uk.gov.govuk.data.model.Result.InvalidSignature
+import uk.gov.govuk.data.model.Result.Success
 import java.net.UnknownHostException
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -25,28 +23,30 @@ class GovUkConfigDataSource @Inject constructor(
     private val gson: Gson,
     private val signatureValidator: SignatureValidator
 ) {
-    suspend fun fetchConfig(): Result<Config> = try {
-        coroutineScope {
-            val configDeferred = async { configApi.getConfig() }
-            val termsDeferred = async { contentApi.getContent() }
-
-            val response = configDeferred.await()
-            val content = termsDeferred.await()
-
+    suspend fun fetchConfig(): Result<Config> {
+        return try {
+            val response = configApi.getConfig()
             if (response.isSuccessful) {
                 response.body()?.let {
                     val signature = response.headers()["x-amz-meta-govuk-sig"] ?: ""
                     val valid = signatureValidator.isValidSignature(signature, it)
                     if (!valid) {
-                        return@coroutineScope InvalidSignature()
+                        return InvalidSignature()
                     }
 
                     val configResponse = gson.fromJson(it, ConfigResponse::class.java)
                     val config = configResponse.config
 
+                    // TODO: Get the content item URL from the remote config
+                    val contentItemUrl = "https://www.gov.uk/api/content/guidance/govuk-app-terms-and-conditions"
+                    val content = contentApi.getContent(contentItemUrl)
+
                     if (content.isSuccessful) {
                         val contentItemTimestamp: String = content.body().run {
-                            gson.fromJson(this, TermsAndConditionsTimestamp::class.java).publicUpdatedAt
+                            gson.fromJson(
+                                this,
+                                TermsAndConditionsTimestamp::class.java
+                            ).publicUpdatedAt
                         }
 
                         config.termsAndConditions = config.termsAndConditions?.copy(
@@ -55,16 +55,16 @@ class GovUkConfigDataSource @Inject constructor(
 
                         Success(config)
                     } else {
-                        Error() // Can't get the content item
+                        Error()
                     }
-                } ?: Error()
+               } ?: Error()
             } else {
                 Error()
             }
+        } catch (_: UnknownHostException) {
+            DeviceOffline()
+        } catch (_: Exception) {
+            Error()
         }
-    } catch (_: UnknownHostException) {
-        DeviceOffline()
-    } catch (_: Exception) {
-        Error()
     }
 }

--- a/config/src/main/kotlin/uk/gov/govuk/config/di/ConfigModule.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/di/ConfigModule.kt
@@ -47,7 +47,7 @@ class ConfigModule {
     @Singleton
     fun providesContentApi(gson: Gson): ContentApi {
         return Retrofit.Builder()
-            .baseUrl(BuildConfig.TS_AND_CS_CONTENT_ITEM_URL)
+            .baseUrl("https://www.gov.uk/") // placeholder URL required by Retrofit
             .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(GsonConverterFactory.create(gson))
             .build()

--- a/config/src/main/kotlin/uk/gov/govuk/config/di/ConfigModule.kt
+++ b/config/src/main/kotlin/uk/gov/govuk/config/di/ConfigModule.kt
@@ -18,6 +18,7 @@ import uk.gov.govuk.config.data.ConfigRepoImpl
 import uk.gov.govuk.config.data.flags.DebugFlags
 import uk.gov.govuk.config.data.flags.FlagRepo
 import uk.gov.govuk.config.data.remote.ConfigApi
+import uk.gov.govuk.config.data.remote.ContentApi
 import uk.gov.govuk.config.data.serialisation.EmergencyBannerTypeAdapter
 import javax.inject.Singleton
 
@@ -40,6 +41,17 @@ class ConfigModule {
             .addConverterFactory(GsonConverterFactory.create(gson))
             .build()
             .create(ConfigApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun providesContentApi(gson: Gson): ContentApi {
+        return Retrofit.Builder()
+            .baseUrl(BuildConfig.TS_AND_CS_CONTENT_ITEM_URL)
+            .addConverterFactory(ScalarsConverterFactory.create())
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .build()
+            .create(ContentApi::class.java)
     }
 
     @Provides

--- a/config/src/test/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSourceTest.kt
+++ b/config/src/test/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSourceTest.kt
@@ -37,7 +37,11 @@ class GovUkConfigDataSourceTest {
     @Test
     fun `Given a successful config response with a body, then return success`() = runTest {
         val remoteTimestamp = "2026-01-01T00:00:00Z"
-        val termsAndConditions = TermsAndConditions(lastUpdated = "old-timestamp", url = "url")
+        val termsAndConditions = TermsAndConditions(
+            lastUpdated = "old-timestamp",
+            url = "url",
+            contentItemApiUrl = "contentItemUrl"
+        )
         val config = Config(
             available = true,
             minimumVersion = "1.0.0",
@@ -125,7 +129,11 @@ class GovUkConfigDataSourceTest {
     @Test
     fun `Given a successful config and terms response, when fetched, then the terms timestamp is updated`() = runTest {
         val remoteTimestamp = "2026-01-01T00:00:00Z"
-        val termsAndConditions = TermsAndConditions(lastUpdated = "old-timestamp", url = "url")
+        val termsAndConditions = TermsAndConditions(
+            lastUpdated = "old-timestamp",
+            url = "url",
+            contentItemApiUrl = "contentItemUrl"
+        )
         val config = Config(
             available = true,
             minimumVersion = "1.0.0",
@@ -154,8 +162,11 @@ class GovUkConfigDataSourceTest {
 
     @Test
     fun `Given a successful config but a failed terms response, when fetched, then return failure`() = runTest {
-        val originalTimestamp = "old-timestamp"
-        val termsAndConditions = TermsAndConditions(lastUpdated = originalTimestamp, url = "url")
+        val termsAndConditions = TermsAndConditions(
+            lastUpdated = "old-timestamp",
+            url = "url",
+            contentItemApiUrl = "contentItemUrl"
+        )
         val config = Config(
             available = true,
             minimumVersion = "1.0.0",
@@ -182,7 +193,10 @@ class GovUkConfigDataSourceTest {
     @Test
     fun `Given a config with no terms and conditions timestamp, when fetched, then the terms timestamp is added`() = runTest {
         val remoteTimestamp = "2026-01-01T00:00:00Z"
-        val termsAndConditions = TermsAndConditions(url = "url")
+        val termsAndConditions = TermsAndConditions(
+            url = "url",
+            contentItemApiUrl = "contentItemUrl"
+        )
         val config = Config(
             available = true,
             minimumVersion = "1.0.0",
@@ -207,5 +221,37 @@ class GovUkConfigDataSourceTest {
         val result = dataSource.fetchConfig() as Result.Success
 
         assertEquals(remoteTimestamp, result.value.termsAndConditions?.lastUpdated)
+    }
+
+    @Test
+    fun `Given a config with no terms and conditions content item url, when fetched, then return failure`() = runTest {
+        val remoteTimestamp = "2026-01-01T00:00:00Z"
+        val termsAndConditions = TermsAndConditions(
+            lastUpdated = "old-timestamp",
+            url = "url",
+            contentItemApiUrl = ""
+        )
+        val config = Config(
+            available = true,
+            minimumVersion = "1.0.0",
+            recommendedVersion = "1.1.0",
+            releaseFlags = mockk(relaxed = true),
+            version = "1.0.0",
+            chatPollIntervalSeconds = 3.0,
+            userFeedbackBanner = null,
+            chatUrls = mockk(relaxed = true),
+            refreshTokenExpirySeconds = 3600,
+            emergencyBanners = null,
+            chatBanner = null,
+            termsAndConditions = termsAndConditions
+        )
+
+        coEvery { configApi.getConfig() } returns Response.success("{}")
+        coEvery { contentApi.getContent(url = null) } returns Response.success("{}")
+        coEvery { signatureValidator.isValidSignature(any(), any()) } returns true
+        coEvery { gson.fromJson(any<String>(), ConfigResponse::class.java) } returns ConfigResponse(config, "sig")
+        coEvery { gson.fromJson(any<String>(), TermsAndConditionsTimestamp::class.java) } returns TermsAndConditionsTimestamp(remoteTimestamp)
+
+        assertTrue(dataSource.fetchConfig() is Result.Error)
     }
 }

--- a/config/src/test/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSourceTest.kt
+++ b/config/src/test/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSourceTest.kt
@@ -54,7 +54,7 @@ class GovUkConfigDataSourceTest {
         )
 
         coEvery { configApi.getConfig() } returns Response.success(configResponse.toString())
-        coEvery { contentApi.getContent() } returns Response.success(contentResponse.toString())
+        coEvery { contentApi.getContent(url = any()) } returns Response.success(contentResponse.toString())
         coEvery { signatureValidator.isValidSignature(any(), any()) } returns true
         coEvery { gson.fromJson(any<String>(), ConfigResponse::class.java) } returns ConfigResponse(config, "sig")
         coEvery { gson.fromJson(any<String>(), TermsAndConditionsTimestamp::class.java) } returns TermsAndConditionsTimestamp(remoteTimestamp)
@@ -142,7 +142,7 @@ class GovUkConfigDataSourceTest {
         )
 
         coEvery { configApi.getConfig() } returns Response.success("{}")
-        coEvery { contentApi.getContent() } returns Response.success("{}")
+        coEvery { contentApi.getContent(any()) } returns Response.success("{}")
         coEvery { signatureValidator.isValidSignature(any(), any()) } returns true
         coEvery { gson.fromJson(any<String>(), ConfigResponse::class.java) } returns ConfigResponse(config, "sig")
         coEvery { gson.fromJson(any<String>(), TermsAndConditionsTimestamp::class.java) } returns TermsAndConditionsTimestamp(remoteTimestamp)
@@ -172,7 +172,7 @@ class GovUkConfigDataSourceTest {
         )
 
         coEvery { configApi.getConfig() } returns Response.success("{}")
-        coEvery { contentApi.getContent() } returns Response.error(404, mockk(relaxed = true))
+        coEvery { contentApi.getContent(url = any()) } returns Response.error(404, mockk(relaxed = true))
         coEvery { signatureValidator.isValidSignature(any(), any()) } returns true
         coEvery { gson.fromJson(any<String>(), ConfigResponse::class.java) } returns ConfigResponse(config, "sig")
 
@@ -199,7 +199,7 @@ class GovUkConfigDataSourceTest {
         )
 
         coEvery { configApi.getConfig() } returns Response.success("{}")
-        coEvery { contentApi.getContent() } returns Response.success("{}")
+        coEvery { contentApi.getContent(url = any()) } returns Response.success("{}")
         coEvery { signatureValidator.isValidSignature(any(), any()) } returns true
         coEvery { gson.fromJson(any<String>(), ConfigResponse::class.java) } returns ConfigResponse(config, "sig")
         coEvery { gson.fromJson(any<String>(), TermsAndConditionsTimestamp::class.java) } returns TermsAndConditionsTimestamp(remoteTimestamp)

--- a/config/src/test/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSourceTest.kt
+++ b/config/src/test/kotlin/uk/gov/govuk/config/data/remote/source/GovUkConfigDataSourceTest.kt
@@ -12,14 +12,18 @@ import org.junit.Test
 import retrofit2.Response
 import uk.gov.govuk.config.SignatureValidator
 import uk.gov.govuk.config.data.remote.ConfigApi
+import uk.gov.govuk.config.data.remote.ContentApi
 import uk.gov.govuk.config.data.remote.model.Config
 import uk.gov.govuk.config.data.remote.model.ConfigResponse
+import uk.gov.govuk.config.data.remote.model.TermsAndConditions
+import uk.gov.govuk.config.data.remote.model.TermsAndConditionsTimestamp
 import uk.gov.govuk.data.model.Result
 import java.net.UnknownHostException
 
 class GovUkConfigDataSourceTest {
 
     private val configApi = mockk<ConfigApi>(relaxed = true)
+    private val contentApi = mockk<ContentApi>(relaxed = true)
     private val gson = mockk<Gson>(relaxed = true)
     private val signatureValidator = mockk<SignatureValidator>(relaxed = true)
 
@@ -27,13 +31,33 @@ class GovUkConfigDataSourceTest {
     private val config = mockk<Config>(relaxed = true)
     private val configResponse = mockk<ConfigResponse>(relaxed = true)
     private val response = mockk<Response<String>>(relaxed = true)
-    private val dataSource = GovUkConfigDataSource(configApi, gson, signatureValidator)
+    private val contentResponse = mockk<Response<String>>(relaxed = true)
+    private val dataSource = GovUkConfigDataSource(configApi, contentApi, gson, signatureValidator)
 
     @Test
     fun `Given a successful config response with a body, then return success`() = runTest {
+        val remoteTimestamp = "2026-01-01T00:00:00Z"
+        val termsAndConditions = TermsAndConditions(lastUpdated = "old-timestamp", url = "url")
+        val config = Config(
+            available = true,
+            minimumVersion = "1.0.0",
+            recommendedVersion = "1.1.0",
+            releaseFlags = mockk(relaxed = true),
+            version = "1.0.0",
+            chatPollIntervalSeconds = 3.0,
+            userFeedbackBanner = null,
+            chatUrls = mockk(relaxed = true),
+            refreshTokenExpirySeconds = 3600,
+            emergencyBanners = null,
+            chatBanner = null,
+            termsAndConditions = termsAndConditions
+        )
+
         coEvery { configApi.getConfig() } returns Response.success(configResponse.toString())
+        coEvery { contentApi.getContent() } returns Response.success(contentResponse.toString())
         coEvery { signatureValidator.isValidSignature(any(), any()) } returns true
-        coEvery { gson.fromJson(any<String>(), ConfigResponse::class.java) } returns ConfigResponse(config, "signature")
+        coEvery { gson.fromJson(any<String>(), ConfigResponse::class.java) } returns ConfigResponse(config, "sig")
+        coEvery { gson.fromJson(any<String>(), TermsAndConditionsTimestamp::class.java) } returns TermsAndConditionsTimestamp(remoteTimestamp)
 
         val result = dataSource.fetchConfig()
         assertTrue(result is Result.Success)
@@ -96,5 +120,92 @@ class GovUkConfigDataSourceTest {
         dataSource.fetchConfig()
 
         coVerify { signatureValidator.isValidSignature("", any()) }
+    }
+
+    @Test
+    fun `Given a successful config and terms response, when fetched, then the terms timestamp is updated`() = runTest {
+        val remoteTimestamp = "2026-01-01T00:00:00Z"
+        val termsAndConditions = TermsAndConditions(lastUpdated = "old-timestamp", url = "url")
+        val config = Config(
+            available = true,
+            minimumVersion = "1.0.0",
+            recommendedVersion = "1.1.0",
+            releaseFlags = mockk(relaxed = true),
+            version = "1.0.0",
+            chatPollIntervalSeconds = 3.0,
+            userFeedbackBanner = null,
+            chatUrls = mockk(relaxed = true),
+            refreshTokenExpirySeconds = 3600,
+            emergencyBanners = null,
+            chatBanner = null,
+            termsAndConditions = termsAndConditions
+        )
+
+        coEvery { configApi.getConfig() } returns Response.success("{}")
+        coEvery { contentApi.getContent() } returns Response.success("{}")
+        coEvery { signatureValidator.isValidSignature(any(), any()) } returns true
+        coEvery { gson.fromJson(any<String>(), ConfigResponse::class.java) } returns ConfigResponse(config, "sig")
+        coEvery { gson.fromJson(any<String>(), TermsAndConditionsTimestamp::class.java) } returns TermsAndConditionsTimestamp(remoteTimestamp)
+
+        val result = dataSource.fetchConfig() as Result.Success
+
+        assertEquals(remoteTimestamp, result.value.termsAndConditions?.lastUpdated)
+    }
+
+    @Test
+    fun `Given a successful config but a failed terms response, when fetched, then return failure`() = runTest {
+        val originalTimestamp = "old-timestamp"
+        val termsAndConditions = TermsAndConditions(lastUpdated = originalTimestamp, url = "url")
+        val config = Config(
+            available = true,
+            minimumVersion = "1.0.0",
+            recommendedVersion = "1.1.0",
+            releaseFlags = mockk(relaxed = true),
+            version = "1.0.0",
+            chatPollIntervalSeconds = 3.0,
+            userFeedbackBanner = null,
+            chatUrls = mockk(relaxed = true),
+            refreshTokenExpirySeconds = 3600,
+            emergencyBanners = null,
+            chatBanner = null,
+            termsAndConditions = termsAndConditions
+        )
+
+        coEvery { configApi.getConfig() } returns Response.success("{}")
+        coEvery { contentApi.getContent() } returns Response.error(404, mockk(relaxed = true))
+        coEvery { signatureValidator.isValidSignature(any(), any()) } returns true
+        coEvery { gson.fromJson(any<String>(), ConfigResponse::class.java) } returns ConfigResponse(config, "sig")
+
+        assertTrue(dataSource.fetchConfig() is Result.Error)
+    }
+
+    @Test
+    fun `Given a config with no terms and conditions timestamp, when fetched, then the terms timestamp is added`() = runTest {
+        val remoteTimestamp = "2026-01-01T00:00:00Z"
+        val termsAndConditions = TermsAndConditions(url = "url")
+        val config = Config(
+            available = true,
+            minimumVersion = "1.0.0",
+            recommendedVersion = "1.1.0",
+            releaseFlags = mockk(relaxed = true),
+            version = "1.0.0",
+            chatPollIntervalSeconds = 3.0,
+            userFeedbackBanner = null,
+            chatUrls = mockk(relaxed = true),
+            refreshTokenExpirySeconds = 3600,
+            emergencyBanners = null,
+            chatBanner = null,
+            termsAndConditions = termsAndConditions
+        )
+
+        coEvery { configApi.getConfig() } returns Response.success("{}")
+        coEvery { contentApi.getContent() } returns Response.success("{}")
+        coEvery { signatureValidator.isValidSignature(any(), any()) } returns true
+        coEvery { gson.fromJson(any<String>(), ConfigResponse::class.java) } returns ConfigResponse(config, "sig")
+        coEvery { gson.fromJson(any<String>(), TermsAndConditionsTimestamp::class.java) } returns TermsAndConditionsTimestamp(remoteTimestamp)
+
+        val result = dataSource.fetchConfig() as Result.Success
+
+        assertEquals(remoteTimestamp, result.value.termsAndConditions?.lastUpdated)
     }
 }


### PR DESCRIPTION
## Note
Error handling is as recommended in [this document](https://docs.google.com/document/d/1uA-3ACA8jzW57B9_Z5Kuh0a_pDVZD1KIiZl4AD4POLU/edit?pli=1&tab=t.0)

## JIRA ticket(s)
  - [GOVUKAPP-3372](https://govukverify.atlassian.net/browse/GOVUKAPP-3372)

## Docs
  - [Use Content API timestamp for T&Cs](https://docs.google.com/document/d/1uA-3ACA8jzW57B9_Z5Kuh0a_pDVZD1KIiZl4AD4POLU/edit?tab=t.0)
  - [Ts&Cs Content API](https://www.gov.uk/api/content/guidance/govuk-app-terms-and-conditions)
