### PR TITLE
GOVUKAPP-3393 Enums for topic ref

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -86,6 +86,7 @@ import uk.gov.govuk.terms.navigation.termsGraph
 import uk.gov.govuk.topics.navigation.DVLA_LINK_RESULT
 import uk.gov.govuk.topics.navigation.topicSelectionGraph
 import uk.gov.govuk.topics.navigation.topicsGraph
+import uk.gov.govuk.topics.ui.model.isDrivingTopic
 import uk.gov.govuk.visited.navigation.visitedGraph
 import uk.gov.govuk.widgets.model.HomeWidget
 import uk.gov.govuk.widgets.ui.contains
@@ -464,7 +465,7 @@ private fun GovUkNavHost(
                 }
             },
             topicHeader = { topicRef, linkResult ->
-                val isDrivingTopic = topicRef == "driving-transport"
+                val isDrivingTopic = topicRef.isDrivingTopic()
                 val isFeatureEnabled = viewModel.isDvlaLinkEnabled()
 
                 if (isDrivingTopic && isFeatureEnabled) {

--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/extension/StringExtension.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/extension/StringExtension.kt
@@ -1,7 +1,7 @@
 package uk.gov.govuk.topics.extension
 
 import android.content.Context
-import uk.gov.govuk.topics.R
+import uk.gov.govuk.topics.ui.model.TopicRef
 import java.util.Locale
 
 /**
@@ -9,19 +9,12 @@ import java.util.Locale
  * If the reference cannot be mapped then the reference is formatted and returned.
  */
 fun String.toTopicName(context: Context): String {
-    return when (this) {
-        "benefits" -> context.getString(R.string.benefits)
-        "business" -> context.getString(R.string.business)
-        "care" -> context.getString(R.string.care)
-        "driving-transport" -> context.getString(R.string.driving_and_transport)
-        "employment" -> context.getString(R.string.employment)
-        "health-disability" -> context.getString(R.string.health_and_disability)
-        "money-tax" -> context.getString(R.string.money_and_tax)
-        "parenting-guardianship" -> context.getString(R.string.parenting_and_guardianship)
-        "retirement" -> context.getString(R.string.retirement)
-        "studying-training" -> context.getString(R.string.studying_and_training)
-        "travel-abroad" -> context.getString(R.string.travel_abroad)
-        else -> this.replace("-", " ")
+    val topicRef = TopicRef.fromString(this)
+
+    return if (topicRef != null) {
+        context.getString(topicRef.titleResId)
+    } else {
+        this.replace("-", " ")
             .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }
     }
 }

--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/extension/TopicItem.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/extension/TopicItem.kt
@@ -3,22 +3,11 @@ package uk.gov.govuk.topics.extension
 import uk.gov.govuk.topics.R
 import uk.gov.govuk.topics.domain.model.TopicItem
 import uk.gov.govuk.topics.ui.model.TopicItemUi
+import uk.gov.govuk.topics.ui.model.TopicRef
 
 internal fun TopicItem.toTopicItemUi(): TopicItemUi {
-    val icon = when (ref) {
-        "benefits" -> R.drawable.ic_topic_benefits
-        "business" -> R.drawable.ic_topic_business
-        "care" -> R.drawable.ic_topic_care
-        "driving-transport" -> R.drawable.ic_topic_transport
-        "employment" -> R.drawable.ic_topic_employment
-        "health-disability" -> R.drawable.ic_topic_health
-        "money-tax" -> R.drawable.ic_topic_money
-        "parenting-guardianship" -> R.drawable.ic_topic_parenting
-        "retirement" -> R.drawable.ic_topic_retirement
-        "studying-training" -> R.drawable.ic_topic_studying
-        "travel-abroad" -> R.drawable.ic_topic_travel
-        else -> R.drawable.ic_topic_default
-    }
+    val topicRef = TopicRef.fromString(ref)
+    val icon = topicRef?.iconResId ?: R.drawable.ic_topic_default
 
     return TopicItemUi(
         ref = ref,

--- a/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/model/TopicRef.kt
+++ b/feature/topics/src/main/kotlin/uk/gov/govuk/topics/ui/model/TopicRef.kt
@@ -1,0 +1,32 @@
+package uk.gov.govuk.topics.ui.model
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import uk.gov.govuk.topics.R
+
+internal enum class TopicRef(
+    val ref: String,
+    @StringRes val titleResId: Int,
+    @DrawableRes val iconResId: Int
+) {
+    BENEFITS("benefits", R.string.benefits, R.drawable.ic_topic_benefits),
+    BUSINESS("business", R.string.business, R.drawable.ic_topic_business),
+    CARE("care", R.string.care, R.drawable.ic_topic_care),
+    DRIVING_AND_TRANSPORT("driving-transport", R.string.driving_and_transport, R.drawable.ic_topic_transport),
+    EMPLOYMENT("employment", R.string.employment, R.drawable.ic_topic_employment),
+    HEALTH_DISABILITY("health-disability", R.string.health_and_disability, R.drawable.ic_topic_health),
+    MONEY_TAX("money-tax", R.string.money_and_tax, R.drawable.ic_topic_money),
+    PARENTING_GUARDIANSHIP("parenting-guardianship", R.string.parenting_and_guardianship, R.drawable.ic_topic_parenting),
+    RETIREMENT("retirement", R.string.retirement, R.drawable.ic_topic_retirement),
+    STUDYING_TRAINING("studying-training", R.string.studying_and_training, R.drawable.ic_topic_studying),
+    TRAVEL_ABROAD("travel-abroad", R.string.travel_abroad, R.drawable.ic_topic_travel);
+
+    companion object {
+        fun fromString(ref: String?): TopicRef? {
+            return entries.find { it.ref == ref }
+        }
+    }
+}
+
+/** Public helper for app module to check if topic is driving */
+fun String?.isDrivingTopic(): Boolean = this == TopicRef.DRIVING_AND_TRANSPORT.ref


### PR DESCRIPTION
# Title

Added enum to create a single source of truth for topic refs now that they are used elsewhere (e.g. app module to check for driving topic).

## JIRA ticket(s)
  - [GOVUKAPP-3393](https://govukverify.atlassian.net/browse/GOVUKAPP-3393)

## Figma
  - [Figma board]()

## Screen shots

| Before | After |
|--------|-------|
|        |       |

