### PR TITLE
GOVUKAPP-3400 Update launch mode

### DIFF
--- a/app/src/androidTest/kotlin/uk/gov/govuk/MainActivityTest.kt
+++ b/app/src/androidTest/kotlin/uk/gov/govuk/MainActivityTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.govuk
 
 import android.content.Intent
-import android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
 import androidx.test.core.app.ActivityScenario
@@ -38,19 +37,6 @@ class MainActivityTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
-    }
-
-    @Test
-    fun given_the_MainActivity_is_launched_When_onCreate_is_called_then_the_intent_flags_should_be_NEW_TASK_and_CLEAR_TASK() {
-        val scenario = ActivityScenario.launch<MainActivity>(intent)
-        scenario.onActivity { activity ->
-            runTest {
-                assertEquals(
-                    activity.intent.flags,
-                    FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
-                )
-            }
-        }
     }
 
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
             android:exported="true"
             android:theme="@style/Theme.GovUkMobileApp"
             android:windowSoftInputMode="adjustResize"
-            android:launchMode="singleInstance">
+            android:launchMode="singleTop">
             <intent-filter>
                 <data android:scheme="govuk" />
                 <data android:host="gov.uk" />

--- a/app/src/main/kotlin/uk/gov/govuk/MainActivity.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/MainActivity.kt
@@ -1,8 +1,6 @@
 package uk.gov.govuk
 
 import android.content.Intent
-import android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK
-import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -40,8 +38,6 @@ class MainActivity : FragmentActivity() {
             PlayIntegrityAppCheckProviderFactory.getInstance()
         )
 
-        setIntentFlags()
-
         emitIntent(savedInstanceState)
 
         setContent {
@@ -61,12 +57,6 @@ class MainActivity : FragmentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         _intentFlow.tryEmit(intent)
-    }
-
-    private fun setIntentFlags() {
-        // FLAG_ACTIVITY_CLEAR_TASK prevents activity recreation when app is started from a deep link.
-        // It must be used in conjunction with FLAG_ACTIVITY_NEW_TASK.
-        intent.flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
     }
 
     private fun emitIntent(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/uk/gov/govuk/MainActivity.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/MainActivity.kt
@@ -26,7 +26,7 @@ class MainActivity : FragmentActivity() {
     internal lateinit var appNavigation: AppNavigation
 
     private val _intentFlow: MutableSharedFlow<Intent> =
-        MutableSharedFlow(replay = 1)
+        MutableSharedFlow(replay = 2)
     internal val intentFlow = _intentFlow.asSharedFlow()
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/uk/gov/govuk/MainActivity.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/MainActivity.kt
@@ -12,6 +12,7 @@ import com.google.firebase.Firebase
 import com.google.firebase.appcheck.appCheck
 import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import uk.gov.govuk.design.ui.theme.GovUkTheme
@@ -26,7 +27,7 @@ class MainActivity : FragmentActivity() {
     internal lateinit var appNavigation: AppNavigation
 
     private val _intentFlow: MutableSharedFlow<Intent> =
-        MutableSharedFlow(replay = 2)
+        MutableSharedFlow(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
     internal val intentFlow = _intentFlow.asSharedFlow()
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/uk/gov/govuk/ui/BrowserLauncher.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/BrowserLauncher.kt
@@ -3,7 +3,6 @@ package uk.gov.govuk.ui
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
-import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
@@ -43,10 +42,9 @@ internal sealed class BrowserActivityLauncher(
             try {
                 Intent(Intent.ACTION_VIEW).run {
                     data = url.toUri()
-                    setFlags(FLAG_ACTIVITY_NEW_TASK)
                     launcher.launch(this)
                 }
-            } catch (e: ActivityNotFoundException) {
+            } catch (_: ActivityNotFoundException) {
                 onError()
             }
         }
@@ -59,10 +57,9 @@ internal sealed class BrowserActivityLauncher(
             try {
                 CustomTabsIntent.Builder().build().run {
                     intent.data = url.toUri()
-                    intent.setFlags(FLAG_ACTIVITY_NEW_TASK)
                     launcher.launch(this.intent)
                 }
-            } catch (e: ActivityNotFoundException) {
+            } catch (_: ActivityNotFoundException) {
                 onError()
             }
         }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/navigation/DeepLinkLauncher.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/navigation/DeepLinkLauncher.kt
@@ -1,7 +1,6 @@
 package uk.gov.govuk.notifications.navigation
 
 import android.content.Context
-import android.content.Intent
 import androidx.core.net.toUri
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -17,7 +16,6 @@ class DeepLinkLauncher @Inject constructor(
         }
         val intent = context.packageManager.getLaunchIntentForPackage(context.packageName) ?: return
         intent.data = uri.toUri()
-        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         context.startActivity(intent)
     }
 }

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/navigation/DeepLinkLauncherTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/navigation/DeepLinkLauncherTest.kt
@@ -37,7 +37,7 @@ class DeepLinkLauncherTest {
     }
 
     @Test
-    fun `Given a valid deep link, then the app is started with correct flags and data`() {
+    fun `Given a valid deep link, then the app is started with correct data`() {
         val url = "https://gov.uk/home"
         val uriMock = mockk<Uri>()
         every { Uri.parse(url) } returns uriMock
@@ -49,7 +49,6 @@ class DeepLinkLauncherTest {
 
         verify(exactly = 1) {
             mockIntent.data = uriMock
-            mockIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             context.startActivity(mockIntent)
         }
     }


### PR DESCRIPTION
# Update launch mode

- Update the app launch mode and remove intent flags which we added for Compose deep linking which we now no longer use to resolve Custom Chrome Tabs launching as a separate task when they should be launching within the context of the app (see before/after screen shots below).

- Drop the oldest intent to resolve deep link data not being read when the app is opened from a deep link whilst running in the background. OnNewIntent is called twice in this scenario, the first time with no intent data and the second time has intent data so dropping the oldest intent means new subscribers will get the latest intent (with data) when added. Thanks to @lamprosgk for this suggestion.

_I have tested this on emulator on Android 16 and physical Android 10 device but would appreciate others testing also if you have the time._

## JIRA ticket(s)
  - [GOVUKAPP-3400](https://govukverify.atlassian.net/browse/GOVUKAPP-3400)

## Screen shots

| Before | After |
|--------|-------|
| <img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/4566cb22-d83a-4470-be99-17d7ed2c9c49" /> | <img width="1344" height="2992" alt="image" src="https://github.com/user-attachments/assets/3e4e806b-906c-4143-a0a5-7101fd57efbc" /> |