### PR TITLE
GOVUKAPP-3453 DVLA linking connection error

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -66,6 +66,7 @@ import uk.gov.govuk.chat.navigation.chatGraph
 import uk.gov.govuk.design.ui.component.InfoAlert
 import uk.gov.govuk.design.ui.component.LoadingScreen
 import uk.gov.govuk.design.ui.component.error.AppUnavailableScreen
+import uk.gov.govuk.design.ui.component.error.DeviceOfflineScreen
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 import uk.gov.govuk.dvla.navigation.DVLA_GRAPH_ROUTE
 import uk.gov.govuk.dvla.navigation.dvlaGraph

--- a/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/GovUkApp.kt
@@ -63,8 +63,11 @@ import uk.gov.govuk.R
 import uk.gov.govuk.analytics.navigation.analyticsGraph
 import uk.gov.govuk.chat.navigation.CHAT_GRAPH_ROUTE
 import uk.gov.govuk.chat.navigation.chatGraph
+import uk.gov.govuk.design.ui.component.FullScreenHeader
+import uk.gov.govuk.design.ui.component.FullScreenWrapper
 import uk.gov.govuk.design.ui.component.InfoAlert
 import uk.gov.govuk.design.ui.component.LoadingScreen
+import uk.gov.govuk.design.ui.component.StatusBar
 import uk.gov.govuk.design.ui.component.error.AppUnavailableScreen
 import uk.gov.govuk.design.ui.component.error.DeviceOfflineScreen
 import uk.gov.govuk.design.ui.theme.GovUkTheme
@@ -122,9 +125,11 @@ internal fun GovUkApp(intentFlow: Flow<Intent>, appNavigation: AppNavigation) {
             when (it) {
                 is AppUiState.Loading -> LoadingScreen()
                 is AppUiState.AppUnavailable -> AppUnavailableScreen()
-                is AppUiState.DeviceOffline -> DeviceOfflineScreen(
-                    onTryAgain = { viewModel.onTryAgain() }
-                )
+                is AppUiState.DeviceOffline -> FullScreenWrapper {
+                    DeviceOfflineScreen(
+                        onTryAgain = { viewModel.onTryAgain() }
+                    )
+                }
 
                 is AppUiState.ForcedUpdate -> ForcedUpdateScreen()
                 is AppUiState.Default -> {
@@ -655,26 +660,4 @@ private fun GovUkNavHost(
     }
 }
 
-@Composable
-private fun StatusBar(
-    hideBackground: Boolean,
-    useDarkIcons: Boolean,
-    modifier: Modifier = Modifier
-) {
-    val localView = LocalView.current
-    val window = (localView.context as Activity).window
 
-    if (!hideBackground) {
-        Box(
-            modifier
-                .fillMaxWidth()
-                .windowInsetsTopHeight(WindowInsets.statusBars)
-                .background(GovUkTheme.colourScheme.surfaces.homeHeader)
-        )
-    }
-
-    WindowCompat.getInsetsController(window, localView).apply {
-        isAppearanceLightStatusBars = useDarkIcons
-        isAppearanceLightNavigationBars = !hideBackground && !isSystemInDarkTheme()
-    }
-}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,6 @@
 <resources>
     <string name="app_name">GOV.UK</string>
 
-    <string name="device_offline_title">You are not connected to the internet</string>
-    <string name="device_offline_description_1">You need to have an internet connection to use the GOV.UK app.</string>
-    <string name="device_offline_description_2">Reconnect to the internet and try again.</string>
-    <string name="device_offline_button_title">Try again</string>
-
     <string name="forced_update_button_title_update">Update</string>
     <string name="forced_update_description">You’re using an old version of the app. Update your app to continue.</string>
     <string name="forced_update_title">You need to update your app</string>

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/StatusBar.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/StatusBar.kt
@@ -1,0 +1,55 @@
+package uk.gov.govuk.design.ui.component
+
+import android.app.Activity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsTopHeight
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+import uk.gov.govuk.design.ui.theme.GovUkTheme
+
+@Composable
+fun StatusBar(
+    hideBackground: Boolean,
+    useDarkIcons: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val localView = LocalView.current
+    val window = (localView.context as Activity).window
+
+    if (!hideBackground) {
+        Box(
+            modifier
+                .fillMaxWidth()
+                .windowInsetsTopHeight(WindowInsets.statusBars)
+                .background(GovUkTheme.colourScheme.surfaces.homeHeader)
+        )
+    }
+
+    WindowCompat.getInsetsController(window, localView).apply {
+        isAppearanceLightStatusBars = useDarkIcons
+        isAppearanceLightNavigationBars = !hideBackground && !isSystemInDarkTheme()
+    }
+}
+
+@Composable
+fun FullScreenWrapper(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Column(modifier = modifier.fillMaxSize()) {
+        StatusBar(
+            hideBackground = true,
+            useDarkIcons = !isSystemInDarkTheme()
+        )
+        content()
+    }
+}

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/error/DeviceOfflineScreen.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/error/DeviceOfflineScreen.kt
@@ -1,4 +1,4 @@
-package uk.gov.govuk.ui
+package uk.gov.govuk.design.ui.component.error
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -7,22 +7,24 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
-import uk.gov.govuk.R
+import uk.gov.govuk.design.R
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.FixedPrimaryButton
 import uk.gov.govuk.design.ui.component.LargeTitleBoldLabel
 import uk.gov.govuk.design.ui.component.MediumVerticalSpacer
 import uk.gov.govuk.design.ui.component.SmallVerticalSpacer
 import uk.gov.govuk.design.ui.theme.GovUkTheme
+import uk.gov.govuk.design.ui.theme.ThemePreviews
 
 @Composable
-internal fun DeviceOfflineScreen(
+fun DeviceOfflineScreen(
     onTryAgain: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -60,12 +62,14 @@ internal fun DeviceOfflineScreen(
     }
 }
 
-@Preview (showBackground = true)
+@ThemePreviews
 @Composable
 private fun DeviceOfflinePreview() {
     GovUkTheme {
-        DeviceOfflineScreen(
-            onTryAgain = { }
-        )
+        Surface {
+            DeviceOfflineScreen(
+                onTryAgain = { }
+            )
+        }
     }
 }

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/error/OfflineMessage.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/error/OfflineMessage.kt
@@ -24,7 +24,7 @@ fun OfflineMessage(
     )
 }
 
-@Preview
+@Preview (showBackground = true)
 @Composable
 private fun OfflineMessagePreview() {
     GovUkTheme {

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -16,6 +16,11 @@
     <string name="app_unavailable_description">You cannot use the GOV.UK app at the moment. Try again later.</string>
     <string name="app_unavailable_title">Sorry, the app is unavailable</string>
 
+    <string name="device_offline_title">You are not connected to the internet</string>
+    <string name="device_offline_description_1">You need to have an internet connection to use the GOV.UK app.</string>
+    <string name="device_offline_description_2">Reconnect to the internet and try again.</string>
+    <string name="device_offline_button_title">Try again</string>
+
     <string name="no_internet_title">You are not connected to the internet</string>
     <string name="no_internet_description">You need to have an internet connection to use the GOV.UK app.\n\nReconnect to the internet and try again.</string>
     <string name="try_again">Try again</string>

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -42,7 +43,10 @@ internal class DvlaViewModel @Inject constructor(
         data object Default : UiState
         data object Loading : UiState
         data object Success : UiState
-        data object Error : UiState
+        sealed interface Error : UiState {
+            data object Offline : Error
+            data object Other : Error
+        }
     }
 
     private val _linkingEvent = MutableSharedFlow<LinkingEvent>()
@@ -120,21 +124,25 @@ internal class DvlaViewModel @Inject constructor(
         }
     }
 
-    private suspend fun linkDvlaAccount(token: String) {
-        if (dvlaRepo.linkAccount(token) is Result.Success) {
-            _uiState.value = UiState.Success
-        } else {
-            _uiState.value = UiState.Error
+    private suspend fun linkDvlaAccount(token: String, withDelay: Boolean = true) {
+        // TODO remove
+        if (withDelay) delay(5000)
+
+
+        when (dvlaRepo.linkAccount(token)) {
+            is Result.Success -> _uiState.value = UiState.Success
+            is Result.DeviceOffline -> _uiState.value = UiState.Error.Offline
+            else -> _uiState.value = UiState.Error.Other
         }
     }
 
     private fun unlinkDvlaAccount() {
         viewModelScope.launch {
             _uiState.value = UiState.Loading
-            if (dvlaRepo.unlinkAccount() is Result.Success) {
-                _linkingEvent.emit(LinkingEvent.UnlinkComplete)
-            } else {
-                _uiState.value = UiState.Error
+            when (dvlaRepo.unlinkAccount()) {
+                is Result.Success -> _linkingEvent.emit(LinkingEvent.UnlinkComplete)
+                is Result.DeviceOffline -> _uiState.value = UiState.Error.Offline
+                else -> _uiState.value = UiState.Error.Other
             }
         }
     }

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
@@ -19,7 +19,7 @@ import javax.inject.Named
 
 @HiltViewModel
 internal class DvlaViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle,
+    private val savedStateHandle: SavedStateHandle,
     private val dvlaRepo: DvlaRepo,
     private val analyticsClient: AnalyticsClient,
     @param:Named("dvla_auth_url") private val dvlaAuthUrl: String
@@ -59,6 +59,14 @@ internal class DvlaViewModel @Inject constructor(
     val authUrlToLaunch = _authUrlToLaunch.asStateFlow()
 
     init {
+        processLinkingState()
+    }
+
+    fun onRetryClicked() {
+        processLinkingState()
+    }
+
+    private fun processLinkingState() {
         val token: String? = savedStateHandle[ARG_DVLA_TOKEN]
 
         when {
@@ -124,9 +132,9 @@ internal class DvlaViewModel @Inject constructor(
         }
     }
 
-    private suspend fun linkDvlaAccount(token: String, withDelay: Boolean = true) {
+    private suspend fun linkDvlaAccount(token: String) {
         // TODO remove
-        if (withDelay) delay(5000)
+        delay(3000)
 
 
         when (dvlaRepo.linkAccount(token)) {

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
@@ -133,10 +133,6 @@ internal class DvlaViewModel @Inject constructor(
     }
 
     private suspend fun linkDvlaAccount(token: String) {
-        // TODO remove
-        delay(3000)
-
-
         when (dvlaRepo.linkAccount(token)) {
             is Result.Success -> _uiState.value = UiState.Success
             is Result.DeviceOffline -> _uiState.value = UiState.Error.Offline

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
@@ -45,6 +45,7 @@ internal class DvlaViewModel @Inject constructor(
         data object Success : UiState
         sealed interface Error : UiState {
             data object Offline : Error
+            // TODO 'offline' and 'other' for now, there is another ticket for errors
             data object Other : Error
         }
     }

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/DvlaLinkingRoute.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/DvlaLinkingRoute.kt
@@ -3,10 +3,14 @@ package uk.gov.govuk.dvla.ui
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -21,6 +25,7 @@ import androidx.lifecycle.compose.LifecycleResumeEffect
 import uk.gov.govuk.design.ui.component.AccountConnectionSuccessScreen
 import uk.gov.govuk.design.ui.component.BookendConnectingScreen
 import uk.gov.govuk.design.ui.component.InfoAlert
+import uk.gov.govuk.design.ui.component.error.DeviceOfflineScreen
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 import uk.gov.govuk.dvla.DvlaViewModel
 import uk.gov.govuk.dvla.R
@@ -79,16 +84,28 @@ internal fun DvlaLinkingRoute(
                     viewModel.onLinkSuccessPageView(screenTitle)
                 },
                 onContinue = { buttonText ->
-                    viewModel.onSuccessContinueClicked(buttonText) },
+                    viewModel.onSuccessContinueClicked(buttonText)
+                },
                 modifier = modifier
             )
         }
+
         is DvlaViewModel.UiState.Loading -> {
             DvlaLinkLoadingScreen(
                 modifier = modifier
             )
         }
-        is DvlaViewModel.UiState.Error -> {
+
+        is DvlaViewModel.UiState.Error.Offline -> {
+            DvlaOfflineScreen(
+                // TODO handle retry
+                onTryAgain = { onClose() },
+                modifier = modifier
+            )
+
+        }
+
+        is DvlaViewModel.UiState.Error.Other -> {
             InfoAlert(
                 title = R.string.error_dialog_title,
                 message = R.string.error_dialog_message,
@@ -141,6 +158,27 @@ private fun DvlaLinkSuccessScreen(
             buttonText = buttonText,
             onContinue = { onContinue(buttonText) },
             modifier = Modifier
+        )
+    }
+}
+
+@Composable
+private fun DvlaOfflineScreen(
+    onTryAgain: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxSize()) {
+        // Status bars are transparent in DVLA route (GovUkApp TRANSPARENT_STATUS_BAR_ROUTES),
+        // apply background blue manually
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .windowInsetsTopHeight(WindowInsets.statusBars)
+                .background(GovUkTheme.colourScheme.surfaces.homeHeader)
+        )
+
+        DeviceOfflineScreen(
+            onTryAgain = onTryAgain
         )
     }
 }

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/DvlaLinkingRoute.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/DvlaLinkingRoute.kt
@@ -20,6 +20,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import uk.gov.govuk.design.ui.component.AccountConnectionSuccessScreen
 import uk.gov.govuk.design.ui.component.BookendConnectingScreen
+import uk.gov.govuk.design.ui.component.FullScreenWrapper
 import uk.gov.govuk.design.ui.component.InfoAlert
 import uk.gov.govuk.design.ui.component.error.DeviceOfflineScreen
 import uk.gov.govuk.design.ui.theme.GovUkTheme
@@ -93,7 +94,7 @@ internal fun DvlaLinkingRoute(
         }
 
         is DvlaViewModel.UiState.Error.Offline -> {
-            DeviceOfflineScreen(
+            DvlaOfflineScreen(
                 onTryAgain = { viewModel.onRetryClicked() },
                 modifier = modifier
             )
@@ -153,6 +154,18 @@ private fun DvlaLinkSuccessScreen(
             buttonText = buttonText,
             onContinue = { onContinue(buttonText) },
             modifier = Modifier
+        )
+    }
+}
+
+@Composable
+private fun DvlaOfflineScreen(
+    onTryAgain: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    FullScreenWrapper(modifier = modifier) {
+        DeviceOfflineScreen(
+            onTryAgain = onTryAgain
         )
     }
 }

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/DvlaLinkingRoute.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/DvlaLinkingRoute.kt
@@ -3,14 +3,10 @@ package uk.gov.govuk.dvla.ui
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -97,9 +93,8 @@ internal fun DvlaLinkingRoute(
         }
 
         is DvlaViewModel.UiState.Error.Offline -> {
-            DvlaOfflineScreen(
-                // TODO handle retry
-                onTryAgain = { onClose() },
+            DeviceOfflineScreen(
+                onTryAgain = { viewModel.onRetryClicked() },
                 modifier = modifier
             )
 
@@ -162,23 +157,3 @@ private fun DvlaLinkSuccessScreen(
     }
 }
 
-@Composable
-private fun DvlaOfflineScreen(
-    onTryAgain: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Column(modifier = modifier.fillMaxSize()) {
-        // Status bars are transparent in DVLA route (GovUkApp TRANSPARENT_STATUS_BAR_ROUTES),
-        // apply background blue manually
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .windowInsetsTopHeight(WindowInsets.statusBars)
-                .background(GovUkTheme.colourScheme.surfaces.homeHeader)
-        )
-
-        DeviceOfflineScreen(
-            onTryAgain = onTryAgain
-        )
-    }
-}

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
@@ -81,7 +81,19 @@ class DvlaViewModelTest {
 
         advanceUntilIdle()
 
-        assertEquals(DvlaViewModel.UiState.Error, viewModel.uiState.value)
+        assertEquals(DvlaViewModel.UiState.Error.Other, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `Given account is not linked and linking api returns DeviceOffline, when initialised, then state should be Error Offline`() = runTest(dispatcher) {
+        every { repo.isLinked } returns MutableStateFlow(false)
+        coEvery { repo.linkAccount(any()) } returns Result.DeviceOffline()
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        advanceUntilIdle()
+
+        assertEquals(DvlaViewModel.UiState.Error.Offline, viewModel.uiState.value)
     }
 
     @Test
@@ -143,7 +155,19 @@ class DvlaViewModelTest {
 
         advanceUntilIdle()
 
-        assertEquals(DvlaViewModel.UiState.Error, viewModel.uiState.value)
+        assertEquals(DvlaViewModel.UiState.Error.Other, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `Given account is already linked and unlink api returns DeviceOffline, when initialised, then state should be Error Offline`() = runTest(dispatcher) {
+        every { repo.isLinked } returns MutableStateFlow(true)
+        coEvery { repo.unlinkAccount() } returns Result.DeviceOffline()
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        advanceUntilIdle()
+
+        assertEquals(DvlaViewModel.UiState.Error.Offline, viewModel.uiState.value)
     }
 
     @Test
@@ -230,6 +254,23 @@ class DvlaViewModelTest {
         }
 
         assertEquals(DvlaViewModel.LinkingEvent.LinkComplete, events.first())
+    }
+
+    @Test
+    fun `Given a token exists, when onRetryClicked is called, then it should process linking state again`() = runTest(dispatcher) {
+        every { repo.isLinked } returns MutableStateFlow(false)
+        coEvery { repo.linkAccount(any()) } returns Result.DeviceOffline()
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.linkAccount(token) }
+
+        viewModel.onRetryClicked()
+        advanceUntilIdle()
+
+        // verify retried
+        coVerify(exactly = 2) { repo.linkAccount(token) }
     }
 }
 


### PR DESCRIPTION
# Title

Showing no internet connection screen when linking DVLA and device is offline. 

Moved `StatusBar` composable to `design` module (from `GovUkApp`) so it's reusable, and applied `FullScreenWrapper` to device offline screen when logging in to fix status bar icons not being visible in white full screen screens.

## JIRA ticket(s)
  - [GOVUKAPP-3453](https://govukverify.atlassian.net/browse/GOVUKAPP-3453)

## Figma
  - [Figma board](https://www.figma.com/design/utmaFnJPNY4sVgwjui5MmK/Driving?node-id=2348-68034&t=ToudpnzdDplUfMCP-1)

## Screen shots
[Screen_recording_20260427_143430.webm](https://github.com/user-attachments/assets/c5667a5a-aecf-4856-a13c-8bb9d77de8d8)



| Before | After |
|--------|-------|
|  <img width="1080" height="2424" alt="Screenshot_20260427_143841" src="https://github.com/user-attachments/assets/7526e5bd-41c6-4d55-aa57-6820a50df9e3" />  |   <img width="1080" height="2424" alt="Screenshot_20260427_143608" src="https://github.com/user-attachments/assets/a2e921e0-591d-49f6-b062-564430c3d5d6" />  |

