### PR TITLE
GOVUKAPP-3466 Added VES endpoint

### DIFF
--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
@@ -61,6 +61,7 @@ internal class DvlaViewModel @Inject constructor(
 
     init {
         processLinkingState()
+        // TODO demonstrating for POC, will be removed
         viewModelScope.launch {
             getVehicleDetails("aa19aaa")
         }
@@ -136,6 +137,13 @@ internal class DvlaViewModel @Inject constructor(
         }
     }
 
+    // for unit testing purpose for now, will be used in later ticket
+    fun onVehicleSearchSubmitted(registrationNumber: String) {
+        viewModelScope.launch {
+            getVehicleDetails(registrationNumber)
+        }
+    }
+
     private suspend fun linkDvlaAccount(token: String) {
         when (dvlaRepo.linkAccount(token)) {
             is Result.Success -> _uiState.value = UiState.Success
@@ -158,6 +166,7 @@ internal class DvlaViewModel @Inject constructor(
     private suspend fun getVehicleDetails(registrationNumber: String) {
         val sanitisedInput = registrationNumber.filterNot { it.isWhitespace() }.uppercase()
 
+        // TODO demonstrating for POC, will be removed
         try {
             val response = dvlaRepo.getVehicleDetails(sanitisedInput)
             println("DVLA VES success: $response")

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
@@ -61,6 +61,9 @@ internal class DvlaViewModel @Inject constructor(
 
     init {
         processLinkingState()
+        viewModelScope.launch {
+            getVehicleDetails("aa19aaa")
+        }
     }
 
     fun onRetryClicked() {
@@ -149,6 +152,18 @@ internal class DvlaViewModel @Inject constructor(
                 is Result.DeviceOffline -> _uiState.value = UiState.Error.Offline
                 else -> _uiState.value = UiState.Error.Other
             }
+        }
+    }
+
+    private suspend fun getVehicleDetails(registrationNumber: String) {
+        val sanitisedInput = registrationNumber.filterNot { it.isWhitespace() }.uppercase()
+
+        try {
+            val response = dvlaRepo.getVehicleDetails(sanitisedInput)
+            println("DVLA VES success: $response")
+        } catch (e: Exception) {
+            println("DVLA VES error: ${e.message}")
+            e.printStackTrace()
         }
     }
 }

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/data/DvlaRepo.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/data/DvlaRepo.kt
@@ -11,6 +11,7 @@ import uk.gov.govuk.data.remote.safeAuthApiCall
 import uk.gov.govuk.dvla.domain.CustomerSummaryDetails
 import uk.gov.govuk.dvla.domain.DriverSummaryDetails
 import uk.gov.govuk.dvla.domain.LicenceDetails
+import uk.gov.govuk.dvla.domain.VehicleDetails
 import uk.gov.govuk.dvla.domain.toDomainModel
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -68,6 +69,9 @@ internal class DvlaRepo @Inject constructor(
         safeAuthApiCall({ api.getCustomerSummary() }, authRepo)
             .map { it.toDomainModel() }
 
+    suspend fun getVehicleDetails(registrationNumber: String): Result<VehicleDetails> =
+        safeAuthApiCall({ api.getVehicleDetails(registrationNumber) }, authRepo)
+            .map { it.toDomainModel() }
 
     @OptIn(ExperimentalEncodingApi::class)
     private fun extractLinkingIdFromJwt(jwtToken: String): String {

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/domain/VehicleDetails.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/domain/VehicleDetails.kt
@@ -1,0 +1,31 @@
+package uk.gov.govuk.dvla.domain
+
+import uk.gov.govuk.dvla.remote.model.VehicleEnquiryResponse
+
+data class VehicleDetails(
+    val registrationNumber: String,
+    val make: String,
+    val colour: String,
+    val yearOfManufacture: Int?,
+    val taxStatus: String,
+    val taxDueDate: String?,
+    val motStatus: String,
+    val motExpiryDate: String?,
+    val fuelType: String,
+    val engineCapacity: Int?,
+    val co2Emissions: Int?
+)
+
+fun VehicleEnquiryResponse.toDomainModel() = VehicleDetails(
+    registrationNumber = this.registrationNumber,
+    make = this.make ?: "",
+    colour = this.colour ?: "",
+    yearOfManufacture = this.yearOfManufacture,
+    taxStatus = this.taxStatus?.name ?: "",
+    taxDueDate = this.taxDueDate,
+    motStatus = this.motStatus?.name ?: "",
+    motExpiryDate = this.motExpiryDate,
+    fuelType = this.fuelType ?: "",
+    engineCapacity = this.engineCapacity,
+    co2Emissions = this.co2Emissions
+)

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/domain/VehicleDetails.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/domain/VehicleDetails.kt
@@ -2,6 +2,7 @@ package uk.gov.govuk.dvla.domain
 
 import uk.gov.govuk.dvla.remote.model.VehicleEnquiryResponse
 
+// TODO: this is to demonstrate the endpoint call data, to be decided which data to use
 data class VehicleDetails(
     val registrationNumber: String,
     val make: String,

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/remote/DvlaApi.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/remote/DvlaApi.kt
@@ -9,6 +9,7 @@ import uk.gov.govuk.dvla.remote.model.CustomerSummaryResponse
 import uk.gov.govuk.dvla.remote.model.DriverSummaryResponse
 import uk.gov.govuk.dvla.remote.model.LicenceResponse
 import uk.gov.govuk.dvla.remote.model.LinkStatusResponse
+import uk.gov.govuk.dvla.remote.model.VehicleEnquiryResponse
 
 interface DvlaApi {
 
@@ -29,4 +30,7 @@ interface DvlaApi {
 
     @GET("app/dvla/v1/customer-summary")
     suspend fun getCustomerSummary(): Response<CustomerSummaryResponse>
+
+    @GET("app/dvla/v1/vehicle-enquiry/{reg}")
+    suspend fun getVehicleDetails(@Path("reg") registrationNumber: String): Response<VehicleEnquiryResponse>
 }

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/remote/model/VehicleEnquiryResponse.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/remote/model/VehicleEnquiryResponse.kt
@@ -1,0 +1,93 @@
+package uk.gov.govuk.dvla.remote.model
+
+import com.google.gson.annotations.SerializedName
+
+data class VehicleEnquiryResponse(
+    @SerializedName("registrationNumber")
+    val registrationNumber: String,
+    @SerializedName("taxStatus")
+    val taxStatus: TaxStatus? = null,
+    @SerializedName("taxDueDate")
+    val taxDueDate: String? = null,     // YYYY-MM-dd
+    @SerializedName("artEndDate")
+    val artEndDate: String? = null,     // YYYY-MM-dd
+    @SerializedName("motStatus")
+    val motStatus: MotStatus? = null,
+    @SerializedName("motExpiryDate")
+    val motExpiryDate: String? = null,
+    @SerializedName("make")
+    val make: String? = null,
+    @SerializedName("monthOfFirstDvlaRegistration")
+    val monthOfFirstDvlaRegistration: String? = null,       // YYYY-MM
+    @SerializedName("monthOfFirstRegistration")
+    val monthOfFirstRegistration: String? = null,       // YYYY-MM
+    @SerializedName("yearOfManufacture")
+    val yearOfManufacture: Int? = null,
+    @SerializedName("engineCapacity")
+    val engineCapacity: Int? = null,
+    @SerializedName("co2Emissions")
+    val co2Emissions: Int? = null,
+    @SerializedName("fuelType")
+    val fuelType: String? = null,
+    @SerializedName("markedForExport")
+    val markedForExport: Boolean? = null,
+    @SerializedName("colour")
+    val colour: String? = null,
+    @SerializedName("typeApproval")
+    val typeApproval: String? = null,
+    @SerializedName("wheelplan")
+    val wheelplan: String? = null,
+    @SerializedName("revenueWeight")
+    val revenueWeight: Int? = null,
+    @SerializedName("realDrivingEmissions")
+    val realDrivingEmissions: String? = null,
+    @SerializedName("dateOfLastV5CIssued")
+    val dateOfLastV5CIssued: String? = null,    // YYYY-MM-dd
+    @SerializedName("euroStatus")
+    val euroStatus: String? = null,
+    @SerializedName("automatedVehicle")
+    val automatedVehicle: Boolean? = null
+)
+
+enum class TaxStatus {
+    @SerializedName("Not Taxed for on Road Use")
+    NOT_TAXED_FOR_ON_ROAD_USE,
+
+    @SerializedName("SORN")
+    SORN,
+
+    @SerializedName("Taxed")
+    TAXED,
+
+    @SerializedName("Untaxed")
+    UNTAXED
+}
+
+enum class MotStatus {
+    @SerializedName("No details held by DVLA")
+    NO_DETAILS_HELD,
+
+    @SerializedName("No results returned")
+    NO_RESULTS_RETURNED,
+
+    @SerializedName("Not valid")
+    NOT_VALID,
+
+    @SerializedName("Valid")
+    VALID
+}
+data class ErrorResponse(
+    @SerializedName("errors")
+    val errors: List<ErrorDetail>? = null
+)
+
+data class ErrorDetail(
+    @SerializedName("status")
+    val status: String? = null,
+    @SerializedName("code")
+    val code: String? = null,
+    @SerializedName("title")
+    val title: String,
+    @SerializedName("detail")
+    val detail: String? = null
+)

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
@@ -26,6 +26,7 @@ import org.junit.Test
 import uk.gov.govuk.analytics.AnalyticsClient
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.dvla.data.DvlaRepo
+import uk.gov.govuk.dvla.domain.VehicleDetails
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DvlaViewModelTest {
@@ -271,6 +272,36 @@ class DvlaViewModelTest {
 
         // verify retried
         coVerify(exactly = 2) { repo.linkAccount(token) }
+    }
+
+    @Test
+    fun `Given ViewModel initialised, then getVehicleDetails is called with sanitised registration number`() = runTest(dispatcher) {
+        val vehicleDetails = mockk<VehicleDetails>(relaxed = true)
+
+        every { repo.isLinked } returns MutableStateFlow(false)
+        coEvery { repo.getVehicleDetails(any()) } returns Result.Success(vehicleDetails)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.getVehicleDetails("AA19AAA") }
+    }
+
+    @Test
+    fun `Given registration input with spaces, when search is submitted, then repo is called with sanitised registration number`() = runTest(dispatcher) {
+        val vehicleDetails = mockk<VehicleDetails>(relaxed = true)
+
+        every { repo.isLinked } returns MutableStateFlow(false)
+        coEvery { repo.getVehicleDetails(any()) } returns Result.Success(vehicleDetails)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        advanceUntilIdle()
+
+        val input = "a  B 12 C d  E"
+        viewModel.onVehicleSearchSubmitted(input)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.getVehicleDetails("AB12CDE") }
     }
 }
 

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/data/DvlaRepoTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/data/DvlaRepoTest.kt
@@ -16,6 +16,7 @@ import uk.gov.govuk.dvla.remote.model.CustomerSummaryResponse
 import uk.gov.govuk.dvla.remote.model.DriverSummaryResponse
 import uk.gov.govuk.dvla.remote.model.LicenceResponse
 import uk.gov.govuk.dvla.remote.model.LinkStatusResponse
+import uk.gov.govuk.dvla.remote.model.VehicleEnquiryResponse
 
 class DvlaRepoTest {
 
@@ -176,5 +177,30 @@ class DvlaRepoTest {
 
         assertTrue(result is Result.Error)
         coVerify(exactly = 1) { api.getCustomerSummary() }
+    }
+
+    @Test
+    fun `Given vehicle enquiry returns success, when getVehicleDetails is called, then return Success with VehicleDetails`() = runTest {
+        val reg = "AA19AAA"
+        val vehicleResponse = mockk<VehicleEnquiryResponse>(relaxed = true)
+
+        coEvery { api.getVehicleDetails(reg) } returns Response.success(vehicleResponse)
+
+        val result = repo.getVehicleDetails(reg)
+
+        assertTrue(result is Result.Success)
+        coVerify(exactly = 1) { api.getVehicleDetails(reg) }
+    }
+
+    @Test
+    fun `Given vehicle enquiry fails, when getVehicleDetails is called, then return Error`() = runTest {
+        val reg = "AA19AAA"
+
+        coEvery { api.getVehicleDetails(reg) } throws Exception("Exception")
+
+        val result = repo.getVehicleDetails(reg)
+
+        assertTrue(result is Result.Error)
+        coVerify(exactly = 1) { api.getVehicleDetails(reg) }
     }
 }

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/domain/VehicleDetailsMapperTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/domain/VehicleDetailsMapperTest.kt
@@ -1,0 +1,73 @@
+package uk.gov.govuk.dvla.domain
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import uk.gov.govuk.dvla.remote.model.VehicleEnquiryResponse
+
+class VehicleDetailsMapperTest {
+
+    @Test
+    fun `Given fully populated VehicleEnquiryResponse, when mapped to domain model, it maps all fields correctly`() {
+        val networkResponse = mockk<VehicleEnquiryResponse>(relaxed = true) {
+            every { registrationNumber } returns "AA19AAA"
+            every { make } returns "FORD"
+            every { colour } returns "RED"
+            every { yearOfManufacture } returns 2019
+            every { taxStatus?.name } returns "Taxed"
+            every { taxDueDate } returns "2027-04-30T00:00:00.000Z"
+            every { motStatus?.name } returns "No details held by DVLA"
+            every { motExpiryDate } returns "2025-05-20T00:00:00.000Z"
+            every { fuelType } returns "PETROL"
+            every { engineCapacity } returns 2000
+            every { co2Emissions } returns 300
+        }
+
+        val domainModel = networkResponse.toDomainModel()
+
+        assertEquals("AA19AAA", domainModel.registrationNumber)
+        assertEquals("FORD", domainModel.make)
+        assertEquals("RED", domainModel.colour)
+        assertEquals(2019, domainModel.yearOfManufacture)
+        assertEquals("Taxed", domainModel.taxStatus)
+        assertEquals("2027-04-30T00:00:00.000Z", domainModel.taxDueDate)
+        assertEquals("No details held by DVLA", domainModel.motStatus)
+        assertEquals("2025-05-20T00:00:00.000Z", domainModel.motExpiryDate)
+        assertEquals("PETROL", domainModel.fuelType)
+        assertEquals(2000, domainModel.engineCapacity)
+        assertEquals(300, domainModel.co2Emissions)
+    }
+
+    @Test
+    fun `Given VehicleEnquiryResponse with missing fields, when mapped, it sets correct defaults`() {
+        val networkResponse = mockk<VehicleEnquiryResponse>(relaxed = true) {
+            every { registrationNumber } returns "AA19AAA"
+            every { make } returns null
+            every { colour } returns null
+            every { yearOfManufacture } returns null
+            every { taxStatus } returns null
+            every { taxDueDate } returns null
+            every { motStatus } returns null
+            every { motExpiryDate } returns null
+            every { fuelType } returns null
+            every { engineCapacity } returns null
+            every { co2Emissions } returns null
+        }
+
+        val domainModel = networkResponse.toDomainModel()
+
+        assertEquals("AA19AAA", domainModel.registrationNumber)
+        assertEquals("", domainModel.make)
+        assertEquals("", domainModel.colour)
+        assertNull(domainModel.yearOfManufacture)
+        assertEquals("", domainModel.taxStatus)
+        assertNull(domainModel.taxDueDate)
+        assertEquals("", domainModel.motStatus)
+        assertNull(domainModel.motExpiryDate)
+        assertEquals("", domainModel.fuelType)
+        assertNull(domainModel.engineCapacity)
+        assertNull(domainModel.co2Emissions)
+    }
+}


### PR DESCRIPTION
# Title

Added endpoint for vehicle check. It's triggered the green link your DVLA account is tapped, you should see the response in logs.

Other available reg numbers:
```
| AA19AAA | 200 OK                    |
| AA19EEE | 200 OK                    |
| AA19PPP | 200 OK                    |
| L2WPS   | 200 OK                    |
| AA19SRN | 200 OK                    |
| AA19DSL | 200 OK                    |
| AA19MOT | 200 OK                    |
| AA19AMP | 200 OK                    |
| ER19BAD | 400 Bad Request           |
| ER19NFD | 404 Not Found             |
| ER19THR | 429 Too Many Requests     |
| ER19ERR | 500 Internal Server Error |
| ER19MNT | 503 Service Unavailable
```

## JIRA ticket(s)
  - [GOVUKAPP-3466](https://govukverify.atlassian.net/browse/GOVUKAPP-3466)

## Figma
n/a

## Screen shots


