### PR TITLE
GOVUKAPP-3493 Linking card padding

### DIFF
--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/DvlaLinkHeader.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/DvlaLinkHeader.kt
@@ -1,13 +1,12 @@
 package uk.gov.govuk.dvla.ui
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import uk.gov.govuk.design.ui.theme.GovUkTheme
+import uk.gov.govuk.design.ui.component.SmallVerticalSpacer
 import uk.gov.govuk.dvla.DvlaLinkState
 import uk.gov.govuk.dvla.DvlaLinkWidgetViewModel
 
@@ -32,8 +31,9 @@ fun DvlaLinkHeader(
                     viewModel.onLinkCardClicked(cardText)
                     onActionClick()
                 },
-                modifier = modifier.padding(bottom = GovUkTheme.spacing.medium)
+                modifier = modifier
             )
+            SmallVerticalSpacer()
         }
         DvlaLinkState.LINKED -> { /* Show nothing */ }
     }


### PR DESCRIPTION
# Linking card padding

Use a spacer instead of padding

## JIRA ticket(s)
  - [GOVUKAPP-3493](https://govukverify.atlassian.net/browse/GOVUKAPP-3493)

## Figma
  - [Figma board](https://www.figma.com/design/utmaFnJPNY4sVgwjui5MmK/Driving?node-id=2080-34987&p=f&t=Xw79VJ1GQgR0R1Sq-0)

## Screen shots

| Before | After |
|--------|-------|
| <img width="1280" height="2856" alt="Screenshot_1777978013" src="https://github.com/user-attachments/assets/1506324c-7795-4bad-9d79-ac842c7af5b3" /> | <img width="1280" height="2856" alt="Screenshot_1777978199" src="https://github.com/user-attachments/assets/65e66da8-0b74-4081-a34f-db4994990809" /> |

