### PR TITLE
GOVUKAPP-3446 Checking dvla link status in parallel

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/AppViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/AppViewModel.kt
@@ -4,7 +4,9 @@ import android.os.SystemClock
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -105,13 +107,25 @@ internal class AppViewModel @Inject constructor(
                 } else if (flagRepo.isForcedUpdate(BuildConfig.VERSION_NAME)) {
                     _uiState.value = AppUiState.ForcedUpdate
                 } else {
-                    topicsFeature.init()
-
-                    // check DVLA link status
-                    if (authRepo.isUserSessionActive() && flagRepo.isDvlaLinkEnabled()) {
-                        viewModelScope.launch {
-                            dvlaRepo.isAccountLinked()
+                    coroutineScope {
+                        // init topics and check DVLA link status in parallel
+                        val initTopics = async {
+                            runCatching {
+                                topicsFeature.init()
+                            }
                         }
+
+                        val checkDvlaLinkStatus =
+                            if (authRepo.isUserSessionActive() && flagRepo.isDvlaLinkEnabled()) {
+                                async {
+                                    runCatching {
+                                        dvlaRepo.isAccountLinked()
+                                    }
+                                }
+                            } else null
+
+                        initTopics.await()
+                        checkDvlaLinkStatus?.await()
                     }
 
                     _uiState.value = AppUiState.Default(


### PR DESCRIPTION
# Title

An addition to https://github.com/govuk-once/govuk-mobile-android-app/pull/691 PR, making the DVLA status check in parallel with topics. 
With the previous fire and forget implementation, if the user links DVLA account, restarts the app and goes to Settings/Your accounts, the link status often hasn't updated yet since the api call is slow.

## JIRA ticket(s)
  - [GOVUKAPP-3446](https://govukverify.atlassian.net/browse/GOVUKAPP-3446)

## Figma
  - [Figma board]()

## Screen shots

| Before | After |
|--------|-------|
|        |       |

