### PR TITLE
GOVUKAPP-3516 : Ts&Cs date parsing bug

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/terms/data/TermsRepo.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/terms/data/TermsRepo.kt
@@ -1,5 +1,6 @@
 package uk.gov.govuk.terms.data
 
+import uk.gov.govuk.analytics.AnalyticsClient
 import uk.gov.govuk.config.data.ConfigRepo
 import uk.gov.govuk.terms.data.local.TermsDataStore
 import java.time.Instant
@@ -17,7 +18,8 @@ internal sealed class TermsAcceptanceState {
 @Singleton
 internal class TermsRepo @Inject constructor(
     private val termsDataStore: TermsDataStore,
-    private val configRepo: ConfigRepo
+    private val configRepo: ConfigRepo,
+    private val analyticsClient: AnalyticsClient
 ) {
     internal suspend fun termsAccepted(acceptedDate: Long = Instant.now().toEpochMilli()) {
         termsDataStore.setTermsAcceptedDate(acceptedDate)
@@ -34,7 +36,8 @@ internal class TermsRepo @Inject constructor(
             } else {
                 TermsAcceptanceState.Accepted
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            analyticsClient.logException(e)
             TermsAcceptanceState.Error
         }
     }

--- a/app/src/main/kotlin/uk/gov/govuk/terms/data/TermsRepo.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/terms/data/TermsRepo.kt
@@ -3,6 +3,7 @@ package uk.gov.govuk.terms.data
 import uk.gov.govuk.config.data.ConfigRepo
 import uk.gov.govuk.terms.data.local.TermsDataStore
 import java.time.Instant
+import java.time.OffsetDateTime
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -27,7 +28,7 @@ internal class TermsRepo @Inject constructor(
         val termsAcceptedAt = getTermsAcceptedDate() ?: return TermsAcceptanceState.NewUser(terms.url)
 
         return try {
-            val termsUpdatedAt = Instant.parse(terms.lastUpdated)
+            val termsUpdatedAt = OffsetDateTime.parse(terms.lastUpdated).toInstant()
             if (termsUpdatedAt.isAfter(Instant.ofEpochMilli(termsAcceptedAt))) {
                 TermsAcceptanceState.Updated(terms.url)
             } else {

--- a/app/src/test/kotlin/uk/gov/govuk/terms/data/TermsRepoTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/terms/data/TermsRepoTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
+import uk.gov.govuk.analytics.AnalyticsClient
 import uk.gov.govuk.config.data.ConfigRepo
 import uk.gov.govuk.config.data.remote.model.TermsAndConditions
 import uk.gov.govuk.terms.data.local.TermsDataStore
@@ -18,12 +19,13 @@ class TermsRepoTest {
 
     private val termsDataStore = mockk<TermsDataStore>(relaxed = true)
     private val configRepo = mockk<ConfigRepo>(relaxed = true)
+    private val analyticsClient = mockk<AnalyticsClient>(relaxed = true)
 
     private lateinit var repo: TermsRepo
 
     @Before
     fun setup() {
-        repo = TermsRepo(termsDataStore, configRepo)
+        repo = TermsRepo(termsDataStore, configRepo, analyticsClient)
     }
 
     @Test

--- a/app/src/test/kotlin/uk/gov/govuk/terms/data/TermsRepoTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/terms/data/TermsRepoTest.kt
@@ -104,4 +104,40 @@ class TermsRepoTest {
             termsDataStore.clear()
         }
     }
+
+    @Test
+    fun `With Offset in Ts&Cs - Given terms were accepted after they were last updated, when get terms acceptance state, then return accepted`() = runTest {
+        every { configRepo.termsAndConditions } returns TermsAndConditions(
+            lastUpdated = "2024-01-01T00:00:00+00:00",
+            url = "https://terms.url",
+            contentItemApiUrl = "https://content-item.url"
+        )
+        coEvery { termsDataStore.getTermsAcceptedDate() } returns Instant.parse("2024-06-01T00:00:00Z").toEpochMilli()
+
+        assertIs<TermsAcceptanceState.Accepted>(repo.getTermsAcceptanceState())
+    }
+
+    @Test
+    fun `With Offset in accepted date - Given terms were accepted after they were last updated, when get terms acceptance state, then return accepted`() = runTest {
+        every { configRepo.termsAndConditions } returns TermsAndConditions(
+            lastUpdated = "2024-01-01T00:00:00Z",
+            url = "https://terms.url",
+            contentItemApiUrl = "https://content-item.url"
+        )
+        coEvery { termsDataStore.getTermsAcceptedDate() } returns Instant.parse("2024-06-01T00:00:00+00:00").toEpochMilli()
+
+        assertIs<TermsAcceptanceState.Accepted>(repo.getTermsAcceptanceState())
+    }
+
+    @Test
+    fun `With Offset in Ts&Cs and accepted date - Given terms were accepted after they were last updated, when get terms acceptance state, then return accepted`() = runTest {
+        every { configRepo.termsAndConditions } returns TermsAndConditions(
+            lastUpdated = "2024-01-01T00:00:00+00:00",
+            url = "https://terms.url",
+            contentItemApiUrl = "https://content-item.url"
+        )
+        coEvery { termsDataStore.getTermsAcceptedDate() } returns Instant.parse("2024-06-01T00:00:00+00:00").toEpochMilli()
+
+        assertIs<TermsAcceptanceState.Accepted>(repo.getTermsAcceptanceState())
+    }
 }


### PR DESCRIPTION
## Summary
Fixed a bug where devices running **Android API 29 through 33** were stuck on the "App Unavailable" screen after login. This was caused by a compatibility issue with `java.time.Instant` when parsing ISO-8601 timestamps with offsets.

## The Issue
We compare the user's `accepted_at` timestamp against the API's `public_updated_at` (e.g., `2026-03-20T11:25:39+00:00`).

* **Observation:** While `java.time.Instant.parse()` works on modern Kotlin environments and Android 14+, it fails on older Android API levels when encountering specific offset strings.
* **Result:** The comparison logic fails, and the app defaults to the "App Unavailable" state.

## The Fix
Replaced `java.time.Instant` with `java.time.OffsetDateTime`. This class provides better compatibility for parsing zoned and offset timestamps across all targeted Android versions.

### Code Comparison
```kotlin
// Old approach: Fails on API < 34 for strings with offsets (+00:00)
Instant.parse(timestampOffset).toEpochMilli()

// New approach: Stable across all supported API levels
OffsetDateTime.parse(timestampOffset).toInstant().toEpochMilli()
```

| Android Version | API Level | Before Fix | After Fix |
| -- | -- | -- | -- |
| 10, 11, 12, 13 | 29 - 33 | ❌ Broken | ✅ Working |
| 14, 15, 16 | 34 - 36 | ✅ Working | ✅ Working |


## JIRA ticket(s)
  - [GOVUKAPP-3516](https://govukverify.atlassian.net/browse/GOVUKAPP-3516)

## Videos
| Before | After |
|--------|-------|
| [Screen_recording_20260507_094846.webm](https://github.com/user-attachments/assets/7fa52328-cb7a-497b-bf2c-907e745cc153) | [Screen_recording_20260507_094916.webm](https://github.com/user-attachments/assets/eaf2cd34-4a5d-47f3-aeda-4c9a55bb49e6) |
