### PR TITLE
GOVUKAPP-3525 Remove linkingId from DVLA responses

### DIFF
--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/remote/model/CustomerSummaryResponse.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/remote/model/CustomerSummaryResponse.kt
@@ -4,7 +4,6 @@ import com.google.gson.annotations.SerializedName
 import uk.gov.govuk.dvla.remote.model.common.DriversEligibility
 
 data class CustomerSummaryResponse(
-    @SerializedName("linkingId") val linkingId: String,
     @SerializedName("customerResponse") val customerResponse: CustomerResponse,
     @SerializedName("driversEligibilityResponse") val driversEligibility: DriversEligibility?,
     @SerializedName("driversSuppressionResponse") val driversSuppression: DriversSuppression?,

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/remote/model/DriverSummaryResponse.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/remote/model/DriverSummaryResponse.kt
@@ -4,7 +4,6 @@ import com.google.gson.annotations.SerializedName
 import uk.gov.govuk.dvla.remote.model.common.DriversEligibility
 
 data class DriverSummaryResponse(
-    @SerializedName("linkingId") val linkingId: String,
     @SerializedName("driverViewResponse") val driverView: DriverView,
     @SerializedName("sdlResponse") val sdl: Sdl?,
     @SerializedName("driversEligibilityResponse") val driversEligibility: DriversEligibility?,


### PR DESCRIPTION
# Title

Removed `linkingId` from DVLA Flex responses.

## JIRA ticket(s)
  - [GOVUKAPP-3525](https://govukverify.atlassian.net/browse/GOVUKAPP-3525)



