### PR TITLE
GOVUKAPP-3580 Move One Signal constant

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,7 +42,6 @@ android {
         }
         
         buildConfigField("String", "PLAY_STORE_URL", "\"https://play.google.com/store/apps/details?id=$applicationId\"")
-        buildConfigField("String", "ONE_SIGNAL_APP_ID", "\"4c235189-5c5f-4a71-8385-2549fc36419f\"")
         buildConfigField("String", "VERSION_NAME_USER_FACING", "\"$versionName ($versionCode)\"")
         buildConfigField("String", "PRIVACY_POLICY_URL", privacyPolicyUrl)
     }
@@ -108,8 +107,6 @@ android {
             ndk {
                 debugSymbolLevel = "FULL"
             }
-
-            buildConfigField("String", "ONE_SIGNAL_APP_ID", "\"bbea84fc-28cc-4712-a6c5-88f5d08b0d0d\"")
         }
     }
 

--- a/app/src/androidTest/kotlin/uk/gov/govuk/GovUKApplicationTest.kt
+++ b/app/src/androidTest/kotlin/uk/gov/govuk/GovUKApplicationTest.kt
@@ -21,7 +21,7 @@ class GovUKApplicationTest {
         govUkApplication.onCreate()
 
         verify(exactly = 1) {
-            notificationsProvider.initialise(BuildConfig.ONE_SIGNAL_APP_ID)
+            notificationsProvider.initialise()
             notificationsProvider.addClickListener()
         }
     }

--- a/app/src/main/kotlin/uk/gov/govuk/GovUkApplication.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/GovUkApplication.kt
@@ -12,7 +12,7 @@ class GovUkApplication: Application() {
 
     override fun onCreate() {
         super.onCreate()
-        notificationsProvider.initialise(BuildConfig.ONE_SIGNAL_APP_ID)
+        notificationsProvider.initialise()
         notificationsProvider.addClickListener()
     }
 }

--- a/notifications/build.gradle.kts
+++ b/notifications/build.gradle.kts
@@ -17,6 +17,14 @@ android {
         minSdk = Version.MIN_SDK
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField("String", "ONE_SIGNAL_APP_ID", "\"4c235189-5c5f-4a71-8385-2549fc36419f\"")
+    }
+
+    buildTypes {
+        release {
+            buildConfigField("String", "ONE_SIGNAL_APP_ID", "\"bbea84fc-28cc-4712-a6c5-88f5d08b0d0d\"")
+        }
     }
 
     compileOptions {
@@ -31,6 +39,7 @@ android {
     }
 
     buildFeatures {
+        buildConfig = true
         compose = true
     }
 }

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsProvider.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/NotificationsProvider.kt
@@ -6,7 +6,7 @@ import androidx.core.app.NotificationManagerCompat
 interface NotificationsProvider {
     val context: Context
 
-    fun initialise(appId: String)
+    fun initialise()
     fun login(pushId: String)
     fun logout()
     fun giveConsent()

--- a/notifications/src/main/kotlin/uk/gov/govuk/notifications/OneSignalClient.kt
+++ b/notifications/src/main/kotlin/uk/gov/govuk/notifications/OneSignalClient.kt
@@ -14,9 +14,9 @@ class OneSignalClient @Inject constructor(
     private val launcher: DeepLinkLauncher
 ) : NotificationsProvider {
 
-    override fun initialise(appId: String) {
+    override fun initialise() {
         OneSignal.consentRequired = true
-        OneSignal.initWithContext(context, appId)
+        OneSignal.initWithContext(context, BuildConfig.ONE_SIGNAL_APP_ID)
     }
 
     override fun login(pushId: String) {

--- a/notifications/src/test/kotlin/uk/gov/govuk/notifications/OneSignalClientTest.kt
+++ b/notifications/src/test/kotlin/uk/gov/govuk/notifications/OneSignalClientTest.kt
@@ -55,11 +55,11 @@ class OneSignalClientTest {
 
     @Test
     fun `Given we have a notifications client, when initialise is called, then One Signal initialise function is called`() {
-        val oneSignalAppId = "1234"
+        val oneSignalAppId = "4c235189-5c5f-4a71-8385-2549fc36419f"
         every { OneSignal.initWithContext(context, oneSignalAppId) } returns Unit
 
         runTest {
-            notificationsProvider.initialise(oneSignalAppId)
+            notificationsProvider.initialise()
 
             verify(exactly = 1) {
                 OneSignal.initWithContext(context, oneSignalAppId)


### PR DESCRIPTION
# Move One Signal constant

Move the One Signal app ID constant into the notifications module

## JIRA ticket(s)
  - [GOVUKAPP-3580](https://govukverify.atlassian.net/browse/GOVUKAPP-3580)

Evidence of emulator subscribing in One Signal dashboard after changes made:

<img width="798" height="204" alt="Screenshot 2026-05-20 at 15 47 38" src="https://github.com/user-attachments/assets/fbd0e576-bef0-4d37-94c5-96f726eb9976" />
