### PR TITLE
GOVUKAPP-3526 Vehicle summary card post amigos 

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
@@ -360,7 +360,7 @@ fun StatusListItem(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Column(modifier = Modifier.weight(1f)) {
-                BodyBoldLabel(
+                Title3BoldLabel(
                     text = title,
                     modifier = modifier.withAltText(titleAltText)
                 )

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/theme/Color.kt
@@ -225,7 +225,8 @@ data class GovUkColourScheme(
         val chatDivider: Color,
         val chatIntroCardBorder: Color,
         val cardCarousel: Color,
-        val iconSeparator: Color
+        val iconSeparator: Color,
+        val registrationPlate: Color
     )
 }
 
@@ -389,7 +390,8 @@ internal val LightColorScheme = GovUkColourScheme(
         chatDivider = BlueLighter80,
         chatIntroCardBorder = BlueLighter80,
         cardCarousel = BlueDarker50,
-        iconSeparator = BluePrimary
+        iconSeparator = BluePrimary,
+        registrationPlate = Black
     )
 )
 
@@ -553,7 +555,8 @@ internal val DarkColorScheme = GovUkColourScheme(
         chatDivider = BlueDarker25,
         chatIntroCardBorder = BlueDarker50,
         cardCarousel = BlueDarker50,
-        iconSeparator = BlueAccent
+        iconSeparator = BlueAccent,
+        registrationPlate = Black
     )
 )
 
@@ -712,7 +715,8 @@ internal val LocalColourScheme = staticCompositionLocalOf {
             chatDivider = Color.Unspecified,
             chatIntroCardBorder = Color.Unspecified,
             cardCarousel = Color.Unspecified,
-            iconSeparator = Color.Unspecified
+            iconSeparator = Color.Unspecified,
+            registrationPlate = Color.Unspecified
         )
     )
 }

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/VehicleSummaryCard.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/VehicleSummaryCard.kt
@@ -2,6 +2,7 @@ package uk.gov.govuk.dvla.ui.component
 
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -95,8 +96,14 @@ internal fun RegistrationPlate(
 
     Box(
         modifier = modifier
+            .height(36.dp)
             .background(
                 color = GovUkTheme.colourScheme.surfaces.registrationPlate,
+                shape = RoundedCornerShape(8.dp)
+            )
+            .border(
+                width = 1.dp,
+                color = GovUkTheme.colourScheme.strokes.registrationPlate,
                 shape = RoundedCornerShape(8.dp)
             )
             .padding(
@@ -104,7 +111,8 @@ internal fun RegistrationPlate(
                 start = GovUkTheme.spacing.small,
                 end = GovUkTheme.spacing.small,
                 bottom = 5.dp
-            )
+            ),
+        contentAlignment = Alignment.Center
     ) {
         Text(
             text = registration,
@@ -163,7 +171,7 @@ fun VehicleSummaryHeader(
                 }
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(28.dp))
 
             // make and model
             Title1BoldLabel(

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/VehicleSummaryCard.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/VehicleSummaryCard.kt
@@ -33,6 +33,7 @@ import uk.gov.govuk.design.ui.component.CardListItem
 import uk.gov.govuk.design.ui.component.InternalLinkListItem
 import uk.gov.govuk.design.ui.component.StatusListItem
 import uk.gov.govuk.design.ui.component.Title1BoldLabel
+import uk.gov.govuk.design.ui.component.Title3RegularLabel
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 import uk.gov.govuk.dvla.R
 import uk.gov.govuk.dvla.ui.model.StatusRowUiModel
@@ -179,9 +180,9 @@ fun VehicleSummaryHeader(
                 color = GovUkTheme.colourScheme.textAndIcons.primary
             )
 
-            BodyRegularLabel(
+            Title3RegularLabel(
                 text = model,
-                color = GovUkTheme.colourScheme.textAndIcons.secondary
+                color = GovUkTheme.colourScheme.textAndIcons.primary
             )
         }
     }


### PR DESCRIPTION
# Title

Number plate changes after post amigos:

- Plate border
- Plate height set to 36dp according to new specs
- Space between plate and make increased to 28dp according to specs
- Some text has updated [weight](https://gds.slack.com/archives/C0851ER905P/p1779878355241989?thread_ts=1779873153.433619&cid=C0851ER905P)

https://www.figma.com/design/utmaFnJPNY4sVgwjui5MmK/Driving?node-id=7329-37774&t=H7WtJ2M8tAdRXjzG-1

## JIRA ticket(s)
  - [GOVUKAPP-3526](https://govukverify.atlassian.net/browse/GOVUKAPP-3526)

## Figma
  - [Figma board](https://www.figma.com/design/utmaFnJPNY4sVgwjui5MmK/Driving?node-id=7329-37774&t=H7WtJ2M8tAdRXjzG-1)

## Screen shots

| Before | After |

| <img width="1080" height="2424" alt="Screenshot_20260527_110453" src="https://github.com/user-attachments/assets/f8527f44-c2e9-47ab-9a22-19fd88254e4b" /> |
<img width="1080" height="2424" alt="Screenshot_20260527_103827" src="https://github.com/user-attachments/assets/6abc1248-f63e-428c-a57e-17c4e422d869" /> |




