### PR TITLE
GOVUKAPP-3663 Send token to backend

### DIFF
--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/data/DvlaRepo.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/data/DvlaRepo.kt
@@ -1,6 +1,5 @@
 package uk.gov.govuk.dvla.data
 
-import com.google.gson.JsonParser
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import uk.gov.govuk.data.auth.AuthRepo
@@ -19,8 +18,6 @@ import uk.gov.govuk.dvla.domain.VesVehicle
 import uk.gov.govuk.dvla.domain.toDomainModel
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 
 @Singleton
 class DvlaRepo @Inject constructor(
@@ -56,8 +53,7 @@ class DvlaRepo @Inject constructor(
 
     internal suspend fun linkAccount(token: String): Result<Unit> {
         val result = try {
-            val linkingId = extractLinkingIdFromJwt(token)
-            safeAuthApiCall({ api.linkDvlaIdentity(linkingId) }, authRepo)
+            safeAuthApiCall({ api.linkDvlaIdentity(token) }, authRepo)
         } catch (_: Exception) {
             Result.Error()
         }
@@ -103,23 +99,4 @@ class DvlaRepo @Inject constructor(
     internal suspend fun cancelCheckCode(tokenId: String): Result<CheckCodeDetails> =
         safeAuthApiCall({ api.cancelShareCode(tokenId) }, authRepo)
             .map { it.toDomainModel() }
-
-    @OptIn(ExperimentalEncodingApi::class)
-    private fun extractLinkingIdFromJwt(jwtToken: String): String {
-        return try {
-            val parts = jwtToken.split(".")
-            require(parts.size >= 2) { "Invalid JWT" }
-
-            val payloadBase64 = parts[1]
-            val decodedBytes = Base64.UrlSafe
-                .withPadding(Base64.PaddingOption.ABSENT_OPTIONAL)
-                .decode(payloadBase64)
-            val decodedString = String(decodedBytes, Charsets.UTF_8)
-            val jsonObject = JsonParser.parseString(decodedString).asJsonObject
-            jsonObject["linking_id"].asString
-
-        } catch (e: Exception) {
-            throw IllegalArgumentException("Failed to extract linking id", e)
-        }
-    }
 }

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/remote/DvlaApi.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/remote/DvlaApi.kt
@@ -3,6 +3,7 @@ package uk.gov.govuk.dvla.remote
 import retrofit2.Response
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
 import uk.gov.govuk.dvla.remote.model.CustomerSummaryResponse
@@ -18,8 +19,8 @@ interface DvlaApi {
     @GET("app/udp/v1/identity/dvla")
     suspend fun checkDvlaLinked(): Response<LinkStatusResponse>
 
-    @POST("app/udp/v1/identity/dvla/{id}")
-    suspend fun linkDvlaIdentity(@Path("id") id: String): Response<Unit>
+    @POST("app/udp/v1/identity/dvla")
+    suspend fun linkDvlaIdentity(@Header("x-linking-token") id: String): Response<Unit>
 
     @DELETE("app/udp/v1/identity/dvla")
     suspend fun deleteDvlaIdentity(): Response<Unit>

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/data/DvlaRepoTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/data/DvlaRepoTest.kt
@@ -30,7 +30,6 @@ class DvlaRepoTest {
     private val dvlaDataStore = mockk<DvlaDataStore>()
     private lateinit var repo: DvlaRepo
     private val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJleHAiOjM2MDAsImxpbmtpbmdfaWQiOiIxMjM0LWFiY2QifQ."
-    private val linkingId = "1234-abcd"
 
     @Before
     fun setup() {
@@ -71,28 +70,28 @@ class DvlaRepoTest {
 
     @Test
     fun `Given linking api returns success, when linkAccount is called, then return Success`() = runTest {
-        coEvery { api.linkDvlaIdentity(linkingId) } returns Response.success(Unit)
+        coEvery { api.linkDvlaIdentity(token) } returns Response.success(Unit)
 
         val result = repo.linkAccount(token)
 
         assertTrue(result is Result.Success)
         assertTrue(repo.linkState.value == DvlaLinkState.LINKED)
-        coVerify(exactly = 1) { api.linkDvlaIdentity(linkingId) }
+        coVerify(exactly = 1) { api.linkDvlaIdentity(token) }
     }
 
     @Test
     fun `Given linking api throws exception, when linkAccount is called, then return Error`() = runTest {
-        coEvery { api.linkDvlaIdentity(linkingId) } throws Exception("Exception")
+        coEvery { api.linkDvlaIdentity(token) } throws Exception("Exception")
 
         val result = repo.linkAccount(token)
 
         assertTrue(result is Result.Error)
-        coVerify(exactly = 1) { api.linkDvlaIdentity(linkingId) }
+        coVerify(exactly = 1) { api.linkDvlaIdentity(token) }
     }
 
     @Test
     fun `Given unlinking api returns success, when unlinkAccount is called, then return Success and update linkState`() = runTest {
-        coEvery { api.linkDvlaIdentity(linkingId) } returns Response.success(Unit)
+        coEvery { api.linkDvlaIdentity(token) } returns Response.success(Unit)
         repo.linkAccount(token)
         assertTrue(repo.linkState.value == DvlaLinkState.LINKED)
 
@@ -106,7 +105,7 @@ class DvlaRepoTest {
 
     @Test
     fun `Given unlinking api throws exception, when unlinkAccount is called, then return error`() = runTest {
-        coEvery { api.linkDvlaIdentity(linkingId) } returns Response.success(Unit)
+        coEvery { api.linkDvlaIdentity(token) } returns Response.success(Unit)
         repo.linkAccount(token)
         assertTrue(repo.linkState.value == DvlaLinkState.LINKED)
 


### PR DESCRIPTION
# Send token to backend

- Send DVLA token to Flex instead of linking ID
- Send DVLA token in the header instead of the path

## JIRA ticket(s)
  - [GOVUKAPP-3663](https://govukverify.atlassian.net/browse/GOVUKAPP-3663)