### PR TITLE
GOVUKAPP-3615 : Add main branch code coverage analysis on pull request merge

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -43,6 +43,7 @@ jobs:
           base_url: https://vault.bitwarden.eu
           secrets: |
             5a3468ee-c962-4535-9c8e-b32b00fadfe0 > FIREBASE_TOKEN
+            cbf3007d-ada7-4ea0-b15c-b32b00faef23 > SONAR_TOKEN
             235aa3fe-7605-4337-ab29-b32c0085d539 > CI_ACCESS_USERNAME
             16eca8c9-cccf-448b-a731-b32c0085e7ed > CI_ACCESS_TOKEN
             e2b38f74-0d53-4d3a-a33d-b32c008ddcbd > ALPHA_KEY_PASSWORD
@@ -52,6 +53,15 @@ jobs:
       - name: Decode keystore
         run: |
           echo $ALPHA_KEYSTORE | base64 -di > alpha.jks
+
+      - name: Lint
+        run: ./gradlew lint
+
+      - name: Unit Test with Code Coverage
+        run: ./gradlew koverXmlReportDebug
+
+      - name: Analyze
+        run: ./gradlew sonar --info
 
       - name: Build APK and distribute to firebase
         run: ./gradlew assembleAlpha appDistributionAlpha


### PR DESCRIPTION
## What's the issue

Currently, there is no `main` branch historical code coverage metrics in [Sonar](https://sonarcloud.io/component_measures?metric=Coverage&id=govuk-once_govuk-mobile-android-app). This means we can't see and address any app-wide coverage gaps.

## What this does

This change adds `main` branch code coverage in the same way as it works in [pull_requests.yml](.github/workflows/pull_request.yml). 

The advantages of doing this are:
- [alpha.yml](.github/workflows/alpha.yml) triggers on `push` to `main`, so it will run automatically whenever a PR is merged.
- Since the analysis is run on the `main` branch, we will be able to track code quality trends over time, rather then just on a per-PR basis.
- It uses the same `koverXmlReportDebug` task as the PR workflow. This will ensure consistency in our coverage reporting.

## JIRA ticket(s)
  - [GOVUKAPP-3615](https://govukverify.atlassian.net/browse/GOVUKAPP-3615)
