### PR TITLE
GOVUKAPP-3685 : Respect the camera

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/ui/ForcedUpdateScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/ForcedUpdateScreen.kt
@@ -2,11 +2,9 @@ package uk.gov.govuk.ui
 
 import android.content.Intent
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -30,7 +28,7 @@ internal fun ForcedUpdateScreen(
     Column(
         modifier
             .fillMaxWidth()
-            .windowInsetsPadding(WindowInsets.systemBars)
+            .safeDrawingPadding()
     ) {
         Column(
             Modifier

--- a/app/src/main/kotlin/uk/gov/govuk/ui/RecommendUpdateScreen.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/ui/RecommendUpdateScreen.kt
@@ -2,11 +2,9 @@ package uk.gov.govuk.ui
 
 import android.content.Intent
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -32,7 +30,7 @@ internal fun RecommendUpdateScreen(
     Column(
         modifier
             .fillMaxWidth()
-            .windowInsetsPadding(WindowInsets.systemBars)
+            .safeDrawingPadding()
     ) {
         Column(
             Modifier

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/error/AppUnavailableScreen.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/error/AppUnavailableScreen.kt
@@ -2,11 +2,9 @@ package uk.gov.govuk.design.ui.component.error
 
 import android.content.Intent
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -30,7 +28,7 @@ fun AppUnavailableScreen(
     Column(
         modifier
             .fillMaxWidth()
-            .windowInsetsPadding(WindowInsets.systemBars)
+            .safeDrawingPadding()
     ) {
         Column(
             Modifier

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/error/DeviceOfflineScreen.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/error/DeviceOfflineScreen.kt
@@ -2,11 +2,9 @@ package uk.gov.govuk.design.ui.component.error
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -30,7 +28,7 @@ fun DeviceOfflineScreen(
     Column(
         modifier
             .fillMaxWidth()
-            .windowInsetsPadding(WindowInsets.systemBars)
+            .safeDrawingPadding()
     ) {
         Column(
             Modifier

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/DvlaLinkingRoute.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/DvlaLinkingRoute.kt
@@ -3,11 +3,8 @@ package uk.gov.govuk.dvla.ui
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.safeDrawingPadding
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -156,7 +153,7 @@ private fun DvlaLinkSuccessScreen(
         modifier = modifier
             .fillMaxSize()
             .background(GovUkTheme.colourScheme.surfaces.fullScreenLinkAccount)
-            .windowInsetsPadding(WindowInsets.systemBars)
+            .safeDrawingPadding()
     ) {
         AccountConnectionSuccessScreen(
             title = title,


### PR DESCRIPTION
Replace `.windowInsetsPadding(WindowInsets.systemBars)` with `.safeDrawingPadding()` in order to 'respect the camera'.

## JIRA ticket(s)
  - [GOVUKAPP-3685](https://govukverify.atlassian.net/browse/GOVUKAPP-3685)

## Screen shots

| Before | After |
|--------|-------|
|<img width="1205" height="2535" alt="AppUnavailableScreen-before" src="https://github.com/user-attachments/assets/e1d203e6-e1be-4a78-9d0b-2aaec67ee2d9" /> | <img width="1205" height="2535" alt="AppUnavailableScreen-after" src="https://github.com/user-attachments/assets/440fbae2-4081-426b-88d6-b1c38c8e7f7e" /> |
| <img width="2535" height="1205" alt="AppUnavailableScreen-before-ls" src="https://github.com/user-attachments/assets/4aaeb650-684d-4ffd-afdc-d6643fc2fb5f" /> | <img width="2535" height="1205" alt="AppUnavailableScreen-after-ls" src="https://github.com/user-attachments/assets/070d08ec-1a63-4498-98d8-c90247a10e63" /> |
| <img width="1205" height="2535" alt="ForcedUpdateScreen-before" src="https://github.com/user-attachments/assets/7b9b7639-a4d4-427f-829c-f3a075e8b005" /> | <img width="1205" height="2535" alt="ForcedUpdateScreen-after" src="https://github.com/user-attachments/assets/29f9e048-0166-41ce-9ce3-21aab6eacb3e" /> |
|<img width="2535" height="1205" alt="ForcedUpdateScreen-before-ls" src="https://github.com/user-attachments/assets/92ce723b-1c0b-491d-ba53-66b15a835160" /> | <img width="2535" height="1205" alt="ForcedUpdateScreen-after-ls" src="https://github.com/user-attachments/assets/eb9cc705-ddcb-429c-86c1-afdb285f7ef0" /> |
| <img width="1205" height="2535" alt="RecommendUpdateScreen-before" src="https://github.com/user-attachments/assets/2c6c60a2-f208-477f-a6a5-f71c9b1db27e" /> | <img width="1205" height="2535" alt="RecommendUpdateScreen-after" src="https://github.com/user-attachments/assets/0ad00ff7-2898-4106-bdaf-555204df72e1" /> |
| <img width="2535" height="1205" alt="RecommendUpdateScreen-before-ls" src="https://github.com/user-attachments/assets/c7c80228-e68a-4ced-852f-629ccd1e8069" /> | <img width="2535" height="1205" alt="RecommendUpdateScreen-after-ls" src="https://github.com/user-attachments/assets/b4e3922e-27b3-478c-960f-f0ab3747279e" /> |
| <img width="1205" height="2535" alt="DeviceOfflineScreen-before" src="https://github.com/user-attachments/assets/96f33a17-f103-4213-b180-69cb3c8583d1" /> | <img width="1205" height="2535" alt="DeviceOfflineScreen-after" src="https://github.com/user-attachments/assets/906f843e-3cda-4bca-b615-46884c09e4a2" /> |
| <img width="2535" height="1205" alt="DeviceOfflineScreen-before-ls" src="https://github.com/user-attachments/assets/e0706a7f-1441-4e51-9112-eacfcaacf7ee" /> | <img width="2535" height="1205" alt="DeviceOfflineScreen-after-ls" src="https://github.com/user-attachments/assets/a8977c5c-03ff-40a9-a3c3-6c68d9922b27" /> |

