### PR TITLE
GOVUKAPP-3690: Crash on missing expired date

### DIFF
--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/util/StringProvider.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/util/StringProvider.kt
@@ -19,5 +19,5 @@ class StringProviderImpl @Inject constructor(
 
 fun StringProvider.resolveSummaryDescription(@StringRes resId: Int?, dateArg: String?): String {
     val id = resId ?: return "Unknown" // TODO: return unknown for now, other states in future tickets
-    return dateArg?.let { getString(id, it) } ?: getString(id)
+    return (dateArg?.let { getString(id, it) } ?: getString(id, "")).trim()
 }

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/util/StringProviderTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/util/StringProviderTest.kt
@@ -27,7 +27,7 @@ class StringProviderTest {
     @Test
     fun `resolveSummaryDescription returns standard string when date is null`() {
         val resId = 123
-        every { stringProvider.getString(resId) } returns "Expired"
+        every { stringProvider.getString(resId, "") } returns "Expired"
 
         val result = stringProvider.resolveSummaryDescription(resId = resId, dateArg = null)
         assertEquals("Expired", result)


### PR DESCRIPTION
# Title

Prevent missing argument crash by passing blank string

## JIRA ticket(s)
  - [GOVUKAPP-3690](https://govukverify.atlassian.net/browse/GOVUKAPP-3690)

