### PR TITLE
GOVUKAPP-3694 : Single-link markdown makes whole paragraph tappable

### DIFF
--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/Markdown.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/Markdown.kt
@@ -276,8 +276,8 @@ private fun SegmentedText(
     val links = remember(content) { collectLinks(content) }
 
     when {
-        links.size <= 1 -> {
-            // 0 or 1 link: render as single Text element
+        links.isEmpty() -> {
+            // 0 links: render as single Text element
             val annotatedString = remember(content) {
                 buildAnnotatedString {
                     appendInlineContent(content, this, emptyList(), linkColor, codeBackground)


### PR DESCRIPTION
## JIRA ticket(s)
  - [GOVUKAPP-3694](https://govukverify.atlassian.net/browse/GOVUKAPP-3694)

## Videos

| Before | After |
|--------|-------|
| [Screen_recording_20260625_152522.webm](https://github.com/user-attachments/assets/2dc5e162-d1b2-4a51-9986-9ab221733831) | [Screen_recording_20260625_152729.webm](https://github.com/user-attachments/assets/70f797dc-eb6a-4ec6-bd89-10c3ad719e32) |
