### PR TITLE
GOVUKAPP-3698 : Error screen when chat window is backgrounded

### DIFF
--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ChatViewModel.kt
@@ -3,6 +3,7 @@ package uk.gov.govuk.chat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -68,11 +69,42 @@ internal class ChatViewModel @Inject constructor(
         }
     }
 
-    fun loadConversation() {
+    fun onResume() {
         viewModelScope.launch {
+            if (chatRepo.isChatIntroSeen.first()) {
+                loadConversation()
+            }
+        }
+    }
+
+    fun onPause() {
+        loadConversationJob?.cancel()
+        askQuestionJob?.cancel()
+        val currentState = _uiState.value
+        if (currentState is Default) {
+            _uiState.value = currentState.copy(isLoading = false)
+        }
+    }
+
+    private var loadConversationJob: Job? = null
+    private var askQuestionJob: Job? = null
+
+    fun loadConversation() {
+        if (loadConversationJob?.isActive == true) return
+
+        val currentState = _uiState.value
+        if (currentState is Default) {
+            _uiState.value = currentState.copy(isLoading = true)
+        } else {
+            _uiState.value = Default(isLoading = true)
+        }
+
+        loadConversationJob = viewModelScope.launch {
             chatRepo.getConversation()?.let { result ->
                 handleChatResult(result) { conversation ->
+                    val currentQuestion = (_uiState.value as? Default)?.question ?: ""
                     _uiState.value = Default(
+                        question = currentQuestion,
                         chatEntries = conversation.answeredQuestions.mapNotNull { question ->
                             question.answer?.let { answer ->
                                 question.id to ChatEntry(
@@ -101,7 +133,8 @@ internal class ChatViewModel @Inject constructor(
                     }
                 }
             } ?: run {
-                _uiState.value = Default()
+                val currentQuestion = (_uiState.value as? Default)?.question ?: ""
+                _uiState.value = Default(question = currentQuestion)
             }
         }
     }
@@ -126,7 +159,7 @@ internal class ChatViewModel @Inject constructor(
         _uiState.updateDefault { it.copy(isPiiError = isPiiError) }
 
         if (!isPiiError) {
-            viewModelScope.launch {
+            askQuestionJob = viewModelScope.launch {
                 _uiState.updateDefault { it.copy(isLoading = true) }
 
                 handleChatResult(chatRepo.askQuestion(question.trim())) { answeredQuestion ->
@@ -280,7 +313,9 @@ internal class ChatViewModel @Inject constructor(
     private inline fun MutableStateFlow<ChatUiState?>.updateDefault(
         transform: (Default) -> Default
     ) {
-        update { state -> transform(state as Default) }
+        update { state ->
+            if (state is Default) transform(state) else state
+        }
     }
 
 }

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ChatViewModel.kt
@@ -59,6 +59,9 @@ internal class ChatViewModel @Inject constructor(
 
     val chatUrls = configRepo.chatUrls
 
+    private var loadConversationJob: Job? = null
+    private var askQuestionJob: Job? = null
+
     init {
         viewModelScope.launch {
             if (chatRepo.isChatIntroSeen.first()) {
@@ -86,17 +89,12 @@ internal class ChatViewModel @Inject constructor(
         }
     }
 
-    private var loadConversationJob: Job? = null
-    private var askQuestionJob: Job? = null
-
     fun loadConversation() {
         if (loadConversationJob?.isActive == true) return
 
-        val currentState = _uiState.value
-        if (currentState is Default) {
-            _uiState.value = currentState.copy(isLoading = true)
-        } else {
-            _uiState.value = Default(isLoading = true)
+        _uiState.value = when (val currentState = _uiState.value) {
+            is Default -> currentState.copy(isLoading = true)
+            else -> Default(isLoading = true)
         }
 
         loadConversationJob = viewModelScope.launch {

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ChatViewModel.kt
@@ -108,6 +108,7 @@ internal class ChatViewModel @Inject constructor(
                         chatEntries = conversation.answeredQuestions.mapNotNull { question ->
                             question.answer?.let { answer ->
                                 question.id to ChatEntry(
+                                    id = question.id,
                                     question = question.message,
                                     answer = answer.message,
                                     sources = answer.sources?.map { source ->
@@ -289,6 +290,7 @@ internal class ChatViewModel @Inject constructor(
                     put(
                         questionId,
                         ChatEntry(
+                            id = questionId,
                             question = question,
                             answer = "",
                             sources = emptyList()

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/data/remote/ApiCall.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/data/remote/ApiCall.kt
@@ -1,5 +1,6 @@
 package uk.gov.govuk.chat.data.remote
 
+import kotlinx.coroutines.CancellationException
 import retrofit2.Response
 import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.remote.AuthenticationException
@@ -22,6 +23,7 @@ internal suspend fun <T> safeChatApiCall(
                     else -> ChatResult.Error()
                 }
             }
+
             else -> {
                 when (code) {
                     404 -> ChatResult.NotFound()
@@ -31,6 +33,8 @@ internal suspend fun <T> safeChatApiCall(
                 }
             }
         }
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: AuthenticationException) {
         ChatResult.AuthError()
     } catch (e: Exception) {

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/ChatScreen.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/ChatScreen.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -65,7 +67,7 @@ internal class AnalyticsEvents(
 internal class UiEvents(
     val onQuestionUpdated: (String) -> Unit,
     val onSubmit: (String) -> Unit,
-    val onClear: () -> Unit,
+    val onClear: () -> Unit
 )
 
 @Composable
@@ -77,6 +79,17 @@ internal fun ChatRoute(
 ) {
     val viewModel: ChatViewModel = hiltViewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val lifecycleState by lifecycleOwner.lifecycle.currentStateFlow.collectAsStateWithLifecycle()
+
+    LaunchedEffect(lifecycleState) {
+        if (lifecycleState == Lifecycle.State.RESUMED) {
+            viewModel.onResume()
+        } else {
+            viewModel.onPause()
+        }
+    }
 
     val onPageView: (String, String, String) -> Unit = { klass, name, title ->
         viewModel.onPageView(

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/ChatScreen.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/ChatScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
@@ -81,14 +82,17 @@ internal fun ChatRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     val lifecycleOwner = LocalLifecycleOwner.current
-    val lifecycleState by lifecycleOwner.lifecycle.currentStateFlow.collectAsStateWithLifecycle()
 
-    LaunchedEffect(lifecycleState) {
-        if (lifecycleState == Lifecycle.State.RESUMED) {
-            viewModel.onResume()
-        } else {
-            viewModel.onPause()
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> viewModel.onResume()
+                Lifecycle.Event.ON_PAUSE -> viewModel.onPause()
+                else -> { /* ignore other lifecycle events */ }
+            }
         }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     val onPageView: (String, String, String) -> Unit = { klass, name, title ->

--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ChatEntry.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ChatEntry.kt
@@ -94,6 +94,8 @@ private fun AnimatedChatEntry(
                 showSending = false
                 delay(animationDelay.toLong())
             }
+            showLoading = false
+            showSending = false
             showAnswer = true
         }
     }

--- a/feature/chat/src/test/kotlin/uk/gov/govuk/chat/ChatViewModelTest.kt
+++ b/feature/chat/src/test/kotlin/uk/gov/govuk/chat/ChatViewModelTest.kt
@@ -698,4 +698,89 @@ class ChatViewModelTest {
             )
         }
     }
+
+    @Test
+    fun `onResume loads conversation if chat intro seen`() = runTest {
+        every { chatRepo.isChatIntroSeen } returns flowOf(true)
+        coEvery { chatRepo.getConversation() } returns null
+
+        viewModel = ChatViewModel(chatRepo, authRepo, analyticsClient, configRepo)
+        advanceUntilIdle()
+
+        viewModel.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { chatRepo.getConversation() }
+    }
+
+    @Test
+    fun `onResume does not load conversation if chat intro not seen`()
+        = runTest {
+        every { chatRepo.isChatIntroSeen } returns flowOf(false)
+        coEvery { chatRepo.getConversation() } returns null
+
+        viewModel = ChatViewModel(chatRepo, authRepo, analyticsClient, configRepo)
+        advanceUntilIdle()
+
+        viewModel.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { chatRepo.getConversation() }
+    }
+
+    @Test
+    fun `onPause cancels loadJob`() = runTest {
+        every { chatRepo.isChatIntroSeen } returns flowOf(true)
+        coEvery { chatRepo.getConversation() } coAnswers {
+            delay(1000)
+            ChatResult.Success(conversation)
+        }
+
+        viewModel = ChatViewModel(chatRepo, authRepo, analyticsClient, configRepo)
+
+        viewModel.onPause()
+        advanceUntilIdle()
+
+        val uiState = viewModel.uiState.value as ChatUiState.Default
+        assertFalse(uiState.isLoading)
+        assertTrue(uiState.chatEntries.isEmpty())
+    }
+
+    @Test
+    fun `onPause cancels askQuestionJob`() = runTest {
+        every { chatRepo.isChatIntroSeen } returns flowOf(true)
+        coEvery { chatRepo.askQuestion(any()) } coAnswers {
+            delay(1000)
+            ChatResult.Success(question)
+        }
+
+        viewModel = ChatViewModel(chatRepo, authRepo, analyticsClient, configRepo)
+        viewModel.setChatIntroSeen()
+        advanceUntilIdle()
+
+        viewModel.onSubmit("Test Question")
+        viewModel.onPause()
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { chatRepo.askQuestion("Test Question") }
+        coVerify(exactly = 0) { chatRepo.getAnswer(any(), any(), any()) }
+    }
+
+    @Test
+    fun `loadConversation does not run concurrently if already loading`() = runTest {
+        every { chatRepo.isChatIntroSeen } returns flowOf(true)
+        coEvery { chatRepo.getConversation() } coAnswers {
+            delay(1000)
+            null
+        }
+
+        viewModel = ChatViewModel(chatRepo, authRepo, analyticsClient, configRepo)
+
+        viewModel.loadConversation()
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { chatRepo.getConversation() }
+    }
 }

--- a/feature/chat/src/test/kotlin/uk/gov/govuk/chat/data/remote/ApiCallKtTest.kt
+++ b/feature/chat/src/test/kotlin/uk/gov/govuk/chat/data/remote/ApiCallKtTest.kt
@@ -3,6 +3,7 @@ package uk.gov.govuk.chat.data.remote
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -19,6 +20,7 @@ import uk.gov.govuk.chat.data.remote.model.Answer
 import uk.gov.govuk.data.auth.AuthRepo
 import java.net.UnknownHostException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class ApiCallKtTest {
     private val apiCall = mockk<suspend () -> Response<Answer>>(relaxed = true)
@@ -161,5 +163,14 @@ class ApiCallKtTest {
         val result = safeChatApiCall(apiCall, authRepo)
 
         assertTrue(result is DeviceOffline)
+    }
+
+    @Test
+    fun `Throws CancellationException when cancellation occurs`() = runTest {
+        coEvery { apiCall.invoke() } throws CancellationException()
+
+        assertFailsWith<CancellationException> {
+            safeChatApiCall(apiCall, authRepo)
+        }
     }
 }


### PR DESCRIPTION
# Error screen when chat window is backgrounded

When a user types a question, and the app is in the process of generating an answer - if the app is backgrounded by the user, an error screen is shown indicating that there is a problem with the chat screen. 

Essentially, the POST question API call is made and Chat starts 'polling' GET API calls for the answer. If the answer is retrieved while the app is still in background - irrespective of the `battery allowed in background` setting (API v15+) - the answer cannot be displayed.

However, if the app is still waiting for the answer to be generated - when the app is foregrounded, Chat behaves as normal and simply displays the answer when it is successfully retrieved.

To 'fix' the confused `error page` state, the user can simply click 'Home' or 'Settings', then 'Chat' again - the error will clear and the answer will be shown as usual via `loadConversation`. It is this that gives us a clue to a potential - more suitable fix.

The approach taken is to identify when the app is backgrounded - using the lifecycle `onPause` event. This will stop any on-going API calls (e.g. polling) and clean up the `uiState`. Then when the app is foregrounded - using the lifecycle `onResume` event. The `loadConversation` function is called mimicking the behaviour as if the user had loaded Chat - effectively reloading the conversation.

<img width="740" height="1071" alt="GOVUKAPP-3698" src="https://github.com/user-attachments/assets/9377e19e-c1c5-4069-8603-a75629e60dc3" />


## JIRA ticket(s)
  - [GOVUKAPP-3698](https://govukverify.atlassian.net/browse/GOVUKAPP-3698)

## Videos

| Setting | Before | After |
|--------|--------|-------|
| <img width="1080" height="2400" alt="Screenshot_20260629_090020" src="https://github.com/user-attachments/assets/54852b5a-bdf8-44f1-83ef-2f8e81158911" /> | [Screen_recording_20260629_090112.webm](https://github.com/user-attachments/assets/cab94f5f-552c-4e30-86dc-0139761e4bfd) |   |
|<img width="1080" height="2400" alt="Screenshot_20260629_090314" src="https://github.com/user-attachments/assets/e341108b-cc96-4670-bf7c-8c645e3d232c" /> | [Screen_recording_20260629_090414.webm](https://github.com/user-attachments/assets/074c134d-f19d-4b33-85e9-84f8b68948ee) |   |

