### PR TITLE
GOVUKAPP-3710 : Empty space in input field

### DIFF
--- a/feature/chat/src/test/kotlin/uk/gov/govuk/chat/ChatViewModelTest.kt
+++ b/feature/chat/src/test/kotlin/uk/gov/govuk/chat/ChatViewModelTest.kt
@@ -550,6 +550,27 @@ class ChatViewModelTest {
     }
 
     @Test
+    fun `Question with spaces gets trimmed`() = runTest {
+        viewModel.onSubmit("  one two three  ")
+
+        coVerify { chatRepo.askQuestion("one two three") }
+    }
+
+    @Test
+    fun `Question with new lines gets trimmed`() = runTest {
+        viewModel.onSubmit("\n\none two three\n\n")
+
+        coVerify { chatRepo.askQuestion("one two three") }
+    }
+
+    @Test
+    fun `Question with spaces and new lines gets trimmed`() = runTest {
+        viewModel.onSubmit("\n\n  one two three\n\n  ")
+
+        coVerify { chatRepo.askQuestion("one two three") }
+    }
+
+    @Test
     fun `setChatIntroSeen calls repo and updates uiState`() = runTest {
         val uiStates = mutableListOf<ChatUiState?>()
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {


### PR DESCRIPTION
# Empty space in input field

Reported by the Chat team as an issue. However, was resolved in this [PR](https://github.com/govuk-once/govuk-mobile-android-app/pull/665).

Scheduled in pre-release [1.1.4](https://github.com/govuk-once/govuk-mobile-android-app/releases/tag/v1.1.4) but was finally released in [1.1.6](https://github.com/govuk-once/govuk-mobile-android-app/releases/tag/v1.1.6). 

This change simply adds additional tests to catch any future re-occurrence or reversion.

## JIRA ticket(s)
  - [GOVUKAPP-3710](https://govukverify.atlassian.net/browse/GOVUKAPP-3710)