### PR TITLE
GOVUKAPP-3711 : Clear chat modal missing subtext

### DIFF
--- a/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ActionMenu.kt
+++ b/feature/chat/src/main/kotlin/uk/gov/govuk/chat/ui/component/ActionMenu.kt
@@ -222,10 +222,16 @@ private fun ClearMenuItem(
             AlertDialog(
                 onDismissRequest = { openDialog.value = false },
                 shape = RoundedCornerShape(GovUkTheme.numbers.cornerAndroidList),
-                text = {
+                title = {
                     BodyBoldLabel(
                         text = stringResource(id = R.string.clear_dialog_title),
                         color = GovUkTheme.colourScheme.textAndIcons.primary
+                    )
+                },
+                text = {
+                    BodyRegularLabel(
+                        text = stringResource(id = R.string.clear_dialog_subtext),
+                        color = GovUkTheme.colourScheme.textAndIcons.secondary
                     )
                 },
                 confirmButton = {

--- a/feature/chat/src/main/res/values/strings.xml
+++ b/feature/chat/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="user_question_loading_text">Sending…</string>
     <string name="answer_received">Answer received</string>
     <string name="clear_dialog_title">Do you want to clear your chat history?</string>
+    <string name="clear_dialog_subtext">This will delete your chat history.</string>
     <string name="clear_dialog_positive_button">Yes, clear chat</string>
     <string name="clear_dialog_negative_button">No, not now</string>
     <string name="onboarding_page_one_header">Get quick answers from GOV.UK Chat</string>


### PR DESCRIPTION
## JIRA ticket(s)
  - [GOVUKAPP-3711](https://govukverify.atlassian.net/browse/GOVUKAPP-3711)

## Figma
  - [Figma board](https://www.figma.com/design/rKYEySuNc8aikJWYfEz1wR/2025-04-GOV.UK-Chat?node-id=4930-48422&t=PUR456pqTN9jHqwz-0)

## Screen shots

| Before | After |
|--------|-------|
| <img width="1080" height="2400" alt="Screenshot_20260629_124352" src="https://github.com/user-attachments/assets/08e076af-f22c-4141-adc3-7545ed23b795" /> | <img width="1080" height="2400" alt="Screenshot_20260629_124853" src="https://github.com/user-attachments/assets/53b50523-32c0-432b-b0c3-016fdc9fc61d" /> |
| <img width="1080" height="2400" alt="Screenshot_20260629_124411" src="https://github.com/user-attachments/assets/90817b55-a6df-45c5-abcf-248d6a2ebe7d" /> | <img width="1080" height="2400" alt="Screenshot_20260629_124819" src="https://github.com/user-attachments/assets/788447f0-7ab2-4b61-816e-141012f63021" /> |
