### PR TITLE
GOVUKAPP-3740 Update account linking

### DIFF
--- a/feature/dvla/build.gradle.kts
+++ b/feature/dvla/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
 
-        buildConfigField("String", "DVLA_AUTH_URL", "\"https://architecture-link-account-service-ui-ext.dvla.gov.uk/\"")
+        buildConfigField("String", "DVLA_AUTH_URL", "\"https://architecture-link-account-service-ui-ext.dvla.gov.uk\"")
         buildConfigField("String", "LINKING_BASE_URL", "\"https://4y369hyvja.execute-api.eu-west-2.amazonaws.com/staging/linking/\"")
     }
 

--- a/feature/dvla/build.gradle.kts
+++ b/feature/dvla/build.gradle.kts
@@ -20,6 +20,7 @@ android {
         consumerProguardFiles("consumer-rules.pro")
 
         buildConfigField("String", "DVLA_AUTH_URL", "\"https://architecture-link-account-service-ui-ext.dvla.gov.uk/\"")
+        buildConfigField("String", "LINKING_BASE_URL", "\"https://4y369hyvja.execute-api.eu-west-2.amazonaws.com/staging/linking/\"")
     }
 
     buildTypes {

--- a/feature/dvla/consumer-rules.pro
+++ b/feature/dvla/consumer-rules.pro
@@ -68,3 +68,7 @@
 -keep class uk.gov.govuk.dvla.remote.model.common.PossibleTransaction
 -keep class uk.gov.govuk.dvla.remote.model.common.TaxStatus
 -keep class uk.gov.govuk.dvla.remote.model.common.VehicleColour
+
+# linking/remote/model
+-keep class uk.gov.govuk.dvla.linking.remote.model.VerificationRequest
+-keep class uk.gov.govuk.dvla.linking.remote.model.VerificationResponse

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
@@ -13,6 +13,7 @@ import uk.gov.govuk.analytics.AnalyticsClient
 import uk.gov.govuk.data.identity.model.ServiceLinkStatus
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.dvla.data.DvlaRepo
+import uk.gov.govuk.dvla.linking.data.LinkingRepo
 import uk.gov.govuk.dvla.navigation.ARG_DVLA_TOKEN
 import javax.inject.Inject
 import javax.inject.Named
@@ -22,7 +23,8 @@ internal class DvlaViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val dvlaRepo: DvlaRepo,
     private val analyticsClient: AnalyticsClient,
-    @param:Named("dvla_auth_url") private val dvlaAuthUrl: String
+    @param:Named("dvla_auth_url") private val dvlaAuthUrl: String,
+    private val linkingRepo: LinkingRepo
 ) : ViewModel() {
 
     companion object {
@@ -85,7 +87,17 @@ internal class DvlaViewModel @Inject constructor(
     }
 
     private fun startAuthFlow() {
-        _authUrlToLaunch.value = dvlaAuthUrl
+        viewModelScope.launch {
+            when (val result = linkingRepo.getVerification()) {
+                is Result.Success -> launchAuthUrl(result.value.verificationHash)
+
+                else -> _uiState.value = UiState.Error.Other
+            }
+        }
+    }
+
+    private fun launchAuthUrl(verificationHash: String) {
+        _authUrlToLaunch.value = "$dvlaAuthUrl?verification=$verificationHash"
     }
 
     fun onIntroPageView(screenTitle: String) {

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/data/LinkingRepo.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/data/LinkingRepo.kt
@@ -1,0 +1,24 @@
+package uk.gov.govuk.dvla.linking.data
+
+import uk.gov.govuk.data.auth.AuthRepo
+import uk.gov.govuk.data.model.Result
+import uk.gov.govuk.data.remote.safeAuthApiCall
+import uk.gov.govuk.dvla.linking.remote.LinkingApi
+import uk.gov.govuk.dvla.linking.remote.model.VerificationRequest
+import uk.gov.govuk.dvla.linking.remote.model.VerificationResponse
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class LinkingRepo @Inject constructor(
+    private val api: LinkingApi,
+    private val authRepo: AuthRepo
+) {
+    suspend fun getVerification(): Result<VerificationResponse> {
+        val result = safeAuthApiCall(
+            { api.getVerification(VerificationRequest(authRepo.getAccessToken())) },
+            authRepo
+        )
+        return result
+    }
+}

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/di/LinkingModule.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/di/LinkingModule.kt
@@ -1,0 +1,26 @@
+package uk.gov.govuk.dvla.linking.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import uk.gov.govuk.dvla.BuildConfig.LINKING_BASE_URL
+import uk.gov.govuk.dvla.linking.remote.LinkingApi
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+internal object LinkingModule {
+
+    @Provides
+    @Singleton
+    fun provideLinkingApi(): LinkingApi {
+        return Retrofit.Builder()
+            .baseUrl(LINKING_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(LinkingApi::class.java)
+    }
+}

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/remote/LinkingApi.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/remote/LinkingApi.kt
@@ -1,0 +1,12 @@
+package uk.gov.govuk.dvla.linking.remote
+
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+import uk.gov.govuk.dvla.linking.remote.model.VerificationRequest
+import uk.gov.govuk.dvla.linking.remote.model.VerificationResponse
+
+internal interface LinkingApi {
+    @POST("verification")
+    suspend fun getVerification(@Body requestBody: VerificationRequest): Response<VerificationResponse>
+}

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/remote/LinkingApi.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/remote/LinkingApi.kt
@@ -6,7 +6,7 @@ import retrofit2.http.POST
 import uk.gov.govuk.dvla.linking.remote.model.VerificationRequest
 import uk.gov.govuk.dvla.linking.remote.model.VerificationResponse
 
-internal interface LinkingApi {
+internal fun interface LinkingApi {
     @POST("verification")
     suspend fun getVerification(@Body requestBody: VerificationRequest): Response<VerificationResponse>
 }

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/remote/model/VerificationRequest.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/remote/model/VerificationRequest.kt
@@ -1,0 +1,7 @@
+package uk.gov.govuk.dvla.linking.remote.model
+
+import com.google.gson.annotations.SerializedName
+
+internal data class VerificationRequest(
+    @SerializedName("token") val token: String
+)

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/remote/model/VerificationResponse.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/remote/model/VerificationResponse.kt
@@ -1,0 +1,7 @@
+package uk.gov.govuk.dvla.linking.remote.model
+
+import com.google.gson.annotations.SerializedName
+
+internal data class VerificationResponse(
+    @SerializedName("verificationHash") val verificationHash: String
+)

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
@@ -26,6 +26,8 @@ import uk.gov.govuk.data.identity.model.ServiceLinkStatus
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.dvla.data.DvlaRepo
 import uk.gov.govuk.dvla.domain.VesVehicle
+import uk.gov.govuk.dvla.linking.data.LinkingRepo
+import uk.gov.govuk.dvla.linking.remote.model.VerificationResponse
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DvlaViewModelTest {
@@ -33,6 +35,7 @@ class DvlaViewModelTest {
     private val dispatcher = StandardTestDispatcher()
 
     private val repo = mockk<DvlaRepo>(relaxed = true)
+    private val linkingRepo = mockk<LinkingRepo>(relaxed = true)
     private val savedStateHandle = mockk<SavedStateHandle>(relaxed = true)
     private val analyticsClient = mockk<AnalyticsClient>(relaxed = true)
     private val token = "1234-abcd"
@@ -54,7 +57,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.Success(Unit)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         assertEquals(DvlaViewModel.UiState.Default, viewModel.uiState.value)
     }
@@ -64,7 +67,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.Success(Unit)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
@@ -77,7 +80,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.Error()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
@@ -89,7 +92,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.DeviceOffline()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
@@ -97,13 +100,33 @@ class DvlaViewModelTest {
     }
 
     @Test
-    fun `Given no token in SavedStateHandle, when initialised, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
+    fun `Given no token in SavedStateHandle, when initialised and getVerification is success, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         every { savedStateHandle.get<String>("token") } returns null
+        coEvery { linkingRepo.getVerification() } returns Result.Success(VerificationResponse("1234"))
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
-        assertEquals(dvlaAuthUrl, viewModel.authUrlToLaunch.value)
+        advanceUntilIdle()
+
+        val expected = "$dvlaAuthUrl?verification=1234"
+
+        assertEquals(expected, viewModel.authUrlToLaunch.value)
+        coVerify(exactly = 0) { repo.linkAccount(any()) }
+    }
+
+    @Test
+    fun `Given no token in SavedStateHandle, when initialised and getVerification is error, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
+        every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
+        every { savedStateHandle.get<String>("token") } returns null
+        coEvery { linkingRepo.getVerification() } returns Result.Error()
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+
+        advanceUntilIdle()
+
+        assertEquals(null, viewModel.authUrlToLaunch.value)
+        assertEquals(DvlaViewModel.UiState.Error.Other, viewModel.uiState.value)
         coVerify(exactly = 0) { repo.linkAccount(any()) }
     }
 
@@ -111,7 +134,8 @@ class DvlaViewModelTest {
     fun `Given auth url is set, when onAuthTabLaunched is called, then reset authUrlToLaunch to null`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         every { savedStateHandle.get<String>("token") } returns null
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         viewModel.onAuthTabLaunched()
 
@@ -123,7 +147,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.LINKED)
         coEvery { repo.unlinkAccount() } returns Result.Success(Unit)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         assertEquals(DvlaViewModel.UiState.Default, viewModel.uiState.value)
     }
@@ -134,7 +158,7 @@ class DvlaViewModelTest {
         every { repo.currentLinkState } returns ServiceLinkStatus.LINKED
         coEvery { repo.unlinkAccount() } returns Result.Success(Unit)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val events = mutableListOf<DvlaViewModel.LinkingEvent>()
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -152,7 +176,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.LINKED)
         coEvery { repo.unlinkAccount() } returns Result.Error()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
@@ -165,7 +189,7 @@ class DvlaViewModelTest {
         every { repo.currentLinkState } returns ServiceLinkStatus.LINKED
         coEvery { repo.unlinkAccount() } returns Result.DeviceOffline()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
@@ -175,7 +199,8 @@ class DvlaViewModelTest {
     @Test
     fun `Given screen title, when onIntroPageView is called, then track screen view`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         viewModel.onIntroPageView("DVLA link intro")
 
@@ -192,7 +217,8 @@ class DvlaViewModelTest {
     @Test
     fun `When onIntroCloseClicked is called, then track close icon click`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         viewModel.onIntroCloseClicked()
 
@@ -204,7 +230,8 @@ class DvlaViewModelTest {
     @Test
     fun `Given button text, when onIntroContinueClicked is called, then track button click`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         viewModel.onIntroContinueClicked("Continue")
 
@@ -220,7 +247,8 @@ class DvlaViewModelTest {
     @Test
     fun `Given screen title, when onLinkSuccessPageView is called, then track screen view`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         viewModel.onLinkSuccessPageView("Driver and vehicles account added")
 
@@ -236,7 +264,8 @@ class DvlaViewModelTest {
     @Test
     fun `Given button text, when onSuccessContinueClicked is called, then track button click and emit LinkComplete event`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val events = mutableListOf<DvlaViewModel.LinkingEvent>()
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -263,7 +292,8 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.DeviceOffline()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+
         advanceUntilIdle()
 
         coVerify(exactly = 1) { repo.linkAccount(token) }
@@ -282,7 +312,8 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.lookupVehicle(any()) } returns Result.Success(vesVehicle)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+
         advanceUntilIdle()
 
         coVerify(exactly = 1) { repo.lookupVehicle("AA19AAA") }
@@ -295,7 +326,8 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.lookupVehicle(any()) } returns Result.Success(vesVehicle)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+
         advanceUntilIdle()
 
         val input = "a  B 12 C d  E"
@@ -308,7 +340,8 @@ class DvlaViewModelTest {
     @Test
     fun `Given screen title, when onErrorOtherPageView is called, then track error screen view`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val title = "There is a problem"
         viewModel.onErrorOtherPageView(title)
@@ -325,7 +358,8 @@ class DvlaViewModelTest {
     @Test
     fun `Given button text, when onErrorBackToDrivingClicked is called, then track button click`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val label = "Go back to driving"
         viewModel.onErrorBackToDrivingClicked(label)
@@ -342,7 +376,8 @@ class DvlaViewModelTest {
     @Test
     fun `Given button text and url, when onErrorVisitGovUkClicked is called, then track external button click with url`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val label = "Go to GOV.UK"
         val url = "gov.uk"
@@ -362,7 +397,8 @@ class DvlaViewModelTest {
     @Test
     fun `Given screen title, when onOfflinePageView is called, then track offline screen view`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val title = "You are offline"
         viewModel.onOfflinePageView(title)
@@ -379,7 +415,8 @@ class DvlaViewModelTest {
     @Test
     fun `Given button text, when onOfflineTryAgainClicked is called, then track button click`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl)
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val label = "Try again"
         viewModel.onOfflineTryAgainClicked(label)

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/linking/data/LinkingRepoTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/linking/data/LinkingRepoTest.kt
@@ -1,0 +1,53 @@
+package uk.gov.govuk.dvla.linking.data
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import uk.gov.govuk.data.auth.AuthRepo
+import uk.gov.govuk.data.model.Result
+import uk.gov.govuk.dvla.linking.remote.LinkingApi
+import uk.gov.govuk.dvla.linking.remote.model.VerificationRequest
+import uk.gov.govuk.dvla.linking.remote.model.VerificationResponse
+import kotlin.Exception
+
+class LinkingRepoTest {
+    private val api = mockk<LinkingApi>()
+    private val authRepo = mockk<AuthRepo>()
+    private lateinit var repo: LinkingRepo
+
+    @Before
+    fun setup() {
+        repo = LinkingRepo(api, authRepo)
+    }
+
+    @Test
+    fun `Given getVerification is called, when response is successful, then returns success`() =
+        runTest {
+            coEvery { api.getVerification(VerificationRequest("1234")) } returns Response.success(
+                VerificationResponse("4321")
+            )
+            coEvery { authRepo.getAccessToken() } returns "1234"
+
+            val result = repo.getVerification()
+
+            assertTrue(result is Result.Success)
+            coVerify(exactly = 1) { api.getVerification(VerificationRequest("1234")) }
+        }
+
+    @Test
+    fun `Given getVerification is called, when an exception is thrown, then return error`() =
+        runTest {
+            coEvery { api.getVerification(VerificationRequest("1234")) } throws Exception("Exception")
+            coEvery { authRepo.getAccessToken() } returns "1234"
+
+            val result = repo.getVerification()
+
+            assertTrue(result is Result.Error)
+            coVerify(exactly = 1) { api.getVerification(VerificationRequest("1234")) }
+        }
+}


### PR DESCRIPTION
# Update account linking

- Although this is mainly built around a new call to Flex this is DVLA specific and intended to be temporary and 'throwaway' auth which is why I have put it in it's own 'Linking' package in DVLA module.
- Get a verification hash from Flex and append to DVLA auth url. 
- Under the hood change only, no visual changes.

## JIRA ticket(s)
  - [GOVUKAPP-3740](https://govukverify.atlassian.net/browse/GOVUKAPP-3740)