### PR TITLE
GOVUKAPP-3801 Driving licence valid, date expired state

### DIFF
--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/model/LicenceSummaryMapper.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/model/LicenceSummaryMapper.kt
@@ -12,6 +12,7 @@ import uk.gov.govuk.dvla.util.StringProvider
 import uk.gov.govuk.dvla.util.getNumberOfDaysWithinDayRangeAsPercentage
 import uk.gov.govuk.dvla.util.getNumberOfDaysFromNow
 import uk.gov.govuk.dvla.util.isDateWithinDayRange
+import uk.gov.govuk.dvla.util.isInThePast
 import uk.gov.govuk.dvla.util.isToday
 import uk.gov.govuk.dvla.util.resolveSummaryDescription
 import uk.gov.govuk.dvla.util.toSummaryDisplayFormat
@@ -75,7 +76,9 @@ internal class LicenceSummaryMapper @Inject constructor(
     ) = when (status) {
         LicenceStatus.EXPIRED -> getExpired(expiryDate, dvlaUrls)
         else -> {
-            if (expiryDate?.isDateWithinDayRange(UPPER_RANGE_OF_EXPIRY_DAYS) == true) {
+            if (expiryDate.isInThePast()) {
+                getExpired(expiryDate, dvlaUrls)
+            } else if (expiryDate?.isDateWithinDayRange(UPPER_RANGE_OF_EXPIRY_DAYS) == true) {
                 getExpiring(expiryDate, dvlaUrls)
             } else {
                 getValid(expiryDate)

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/util/DateExtension.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/util/DateExtension.kt
@@ -31,3 +31,10 @@ internal fun LocalDate.isToday() =
  */
 internal fun LocalDate?.isInTheFuture() =
     this?.let { getNumberOfDaysFromNow() > 0 } ?: run { false }
+
+/**
+ * Returns true if the date is in the past.
+ * Returns false if the date is now, in the future or null.
+ */
+internal fun LocalDate?.isInThePast() =
+    this?.let { getNumberOfDaysFromNow() < 0 } ?: run { false }

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/ui/model/LicenceSummaryMapperTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/ui/model/LicenceSummaryMapperTest.kt
@@ -77,6 +77,12 @@ class LicenceSummaryMapperTest {
     }
 
     @Test
+    fun `Given licence status is valid and expiry date is in the past, then result is Success and drivingRecordUrl is still populated`() {
+        val licence = successLicence(status = LicenceStatus.VALID, expiryDate = LocalDate.now().minusDays(10))
+        assertEquals(dvlaUrls.drivingRecord, licence.drivingRecordUrl)
+    }
+
+    @Test
     fun `Given licence status is expired, then result is Success and drivingRecordUrl is null`() {
         val licence = successLicence(status = LicenceStatus.EXPIRED)
         assertNull(licence.drivingRecordUrl)

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/util/DateExtensionTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/util/DateExtensionTest.kt
@@ -83,4 +83,21 @@ class DateExtensionTest {
     fun `Given isInTheFuture is called, when the date is null, then return false`() {
         assertFalse(null.isInTheFuture())
     }
+
+    @Test
+    fun `Given isInThePast is called, when the date is today, then return false`() {
+        val today = LocalDate.now()
+        assertFalse(today.isInThePast())
+    }
+
+    @Test
+    fun `Given isInThePast is called, when the date is yesterday, then return true`() {
+        val yesterday = LocalDate.now().minusDays(1)
+        assertTrue(yesterday.isInThePast())
+    }
+
+    @Test
+    fun `Given isInThePast is called, when the date is null, then return false`() {
+        assertFalse(null.isInThePast())
+    }
 }


### PR DESCRIPTION
# Driving licence valid, date expired state

- Add a check for a valid driver licence but expiry date is in the past. Show expired state if true.

## JIRA ticket(s)
  - [GOVUKAPP-3801](https://govukverify.atlassian.net/browse/GOVUKAPP-3801)

## Figma
  - [Figma board](https://www.figma.com/design/utmaFnJPNY4sVgwjui5MmK/Driving?node-id=6501-49710&t=eIvyA1VXzTorkQTm-0)

## Screen shots

| Before | After |
|--------|-------|
| <img width="1344" height="2992" alt="Screenshot_1784207731" src="https://github.com/user-attachments/assets/05c0b69c-2796-4b80-8822-1696df9331aa" /> | <img width="1344" height="2992" alt="Screenshot_1784207785" src="https://github.com/user-attachments/assets/68d280aa-4970-4a3e-b254-795bd4a4337e" /> |

