### PR TITLE
GOVUKAPP-3816 Update SORN date logic

### DIFF
--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/model/TaxAndMotStatusMapper.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/model/TaxAndMotStatusMapper.kt
@@ -64,16 +64,18 @@ internal class TaxAndMotStatusMapper @Inject constructor(
         val expiryDate = vehicle.taxExpiryDate
         return when (vehicle.taxStatus) {
             TaxStatus.TAXED -> {
-                if (vehicle.sornStart?.isInTheFuture() == true) {
-                    getSorn(vehicle.sornStart)
-                } else if (expiryDate?.isDateWithinDayRange(UPPER_RANGE_OF_TAX_EXPIRY_DAYS) == true) {
-                    if (vehicle.currentLicencePaymentMethod.isDirectDebit()) {
-                        getTaxExpiringDirectDebit(expiryDate, dvlaUrls)
-                    } else {
-                        getTaxExpiring(expiryDate, dvlaUrls)
+                when {
+                    vehicle.sornStart.isInTheFuture() -> getSorn(vehicle.sornStart)
+
+                    expiryDate?.isDateWithinDayRange(UPPER_RANGE_OF_TAX_EXPIRY_DAYS) == true -> {
+                        if (vehicle.currentLicencePaymentMethod.isDirectDebit()) {
+                            getTaxExpiringDirectDebit(expiryDate, dvlaUrls)
+                        } else {
+                            getTaxExpiring(expiryDate, dvlaUrls)
+                        }
                     }
-                } else {
-                    getValid(getTaxStatusTitle(), expiryDate)
+
+                    else -> getValid(getTaxStatusTitle(), expiryDate)
                 }
             }
 

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/model/TaxAndMotStatusMapper.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/model/TaxAndMotStatusMapper.kt
@@ -64,7 +64,9 @@ internal class TaxAndMotStatusMapper @Inject constructor(
         val expiryDate = vehicle.taxExpiryDate
         return when (vehicle.taxStatus) {
             TaxStatus.TAXED -> {
-                if (expiryDate?.isDateWithinDayRange(UPPER_RANGE_OF_TAX_EXPIRY_DAYS) == true) {
+                if (vehicle.sornStart?.isInTheFuture() == true) {
+                    getSorn(vehicle.sornStart)
+                } else if (expiryDate?.isDateWithinDayRange(UPPER_RANGE_OF_TAX_EXPIRY_DAYS) == true) {
                     if (vehicle.currentLicencePaymentMethod.isDirectDebit()) {
                         getTaxExpiringDirectDebit(expiryDate, dvlaUrls)
                     } else {


### PR DESCRIPTION
# Update SORN date logic

Update SORN date logic to meet the following:

WHEN vehicleResponse.taxStatus is ‘Taxed’
AND there’s a SORN start date present
THEN this is shown using the content above ('Off the road (SORN)', and ‘From [date]' underneath

## JIRA ticket(s)
  - [GOVUKAPP-3816](https://govukverify.atlassian.net/browse/GOVUKAPP-3816)

## Figma
  - [Figma board](https://www.figma.com/design/utmaFnJPNY4sVgwjui5MmK/Driving?node-id=6501-49710&t=qK7dtXlUy5jcmsb2-0)

## Screen shots

| Before | After |
|--------|-------|
| <img width="1344" height="2992" alt="Screenshot_1784648900" src="https://github.com/user-attachments/assets/5599326f-553c-481f-b9a0-8758bef4cf7b" /> | <img width="1344" height="2992" alt="Screenshot_1784648607" src="https://github.com/user-attachments/assets/2b021fba-36c0-4763-bf3c-2fb927a6d730" /> |

