### PR TITLE
GOVUKAPP-3824 Add heading attribute

### DIFF
--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
@@ -394,7 +395,9 @@ fun StatusListItem(
                     title?.let {
                         Title3BoldLabel(
                             text = it.displayText,
-                            modifier = Modifier.withAltText(it.altText)
+                            modifier = Modifier
+                                .withAltText(it.altText)
+                                .semantics { heading() }
                         )
 
                         SmallVerticalSpacer()

--- a/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
+++ b/design/src/main/kotlin/uk/gov/govuk/design/ui/component/List.kt
@@ -396,8 +396,8 @@ fun StatusListItem(
                         Title3BoldLabel(
                             text = it.displayText,
                             modifier = Modifier
-                                .withAltText(it.altText)
                                 .semantics { heading() }
+                                .withAltText(it.altText)
                         )
 
                         SmallVerticalSpacer()
@@ -546,7 +546,9 @@ fun CountdownBarListItem(
             title?.let { title ->
                 Title3BoldLabel(
                     text = title.displayText,
-                    modifier = Modifier.withAltText(title.altText)
+                    modifier = Modifier
+                        .semantics { heading() }
+                        .withAltText(title.altText)
                 )
 
                 SmallVerticalSpacer()

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/LinkStatusItem.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/LinkStatusItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import uk.gov.govuk.design.R
@@ -52,6 +53,7 @@ internal fun LinkStatusItem(
             Title3BoldLabel(
                 text = title.displayText,
                 modifier = Modifier
+                    .semantics { heading() }
                     .withAltText(title.altText)
             )
 


### PR DESCRIPTION
# Add heading attribute

- Add accessibility 'heading' attribute to the title labels of all (except info) status list items.

## JIRA ticket(s)
  - [GOVUKAPP-3824](https://govukverify.atlassian.net/browse/GOVUKAPP-3824)

## Figma
  - [Figma board](https://www.figma.com/design/utmaFnJPNY4sVgwjui5MmK/Driving?node-id=6501-49710&t=eIvyA1VXzTorkQTm-0)


https://github.com/user-attachments/assets/42ab4b92-316f-493c-a53f-ae836c601f90


