### PR TITLE
GOVUKAPP-3848 Name not showing in all caps

### DIFF
--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/model/LicenceSummaryMapper.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/model/LicenceSummaryMapper.kt
@@ -16,7 +16,6 @@ import uk.gov.govuk.dvla.util.isInThePast
 import uk.gov.govuk.dvla.util.isToday
 import uk.gov.govuk.dvla.util.resolveSummaryDescription
 import uk.gov.govuk.dvla.util.toSummaryDisplayFormat
-import uk.gov.govuk.dvla.util.toTitleCase
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -36,7 +35,7 @@ internal class LicenceSummaryMapper @Inject constructor(
             LicenceSummaryUiModel(
                 licenceType = getLicenceTypeString(details.licenceType),
                 licenceNumber = details.drivingLicenceNumber,
-                name = details.fullName.toTitleCase(),
+                name = details.fullName,
                 addressLines = details.driverFullAddress.asAddressLines(),
                 statusUi = getLicenceStatusUiModel(
                     status = details.licenceStatus,

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/util/StringExtension.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/util/StringExtension.kt
@@ -1,13 +1,5 @@
 package uk.gov.govuk.dvla.util
 
-fun String.toTitleCase(): String =
-    this.lowercase()
-        .split(" ")
-        .filter { it.isNotBlank() }
-        .joinToString(" ") { word ->
-            word.replaceFirstChar { it.titlecase() }
-        }
-
 /**
  * Formats string to be announced char by char by Talkback, for example 'FH08PDH' to 'F H 0 8 P D H'
  */

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/util/StringExtensionTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/util/StringExtensionTest.kt
@@ -8,15 +8,6 @@ import org.junit.Test
 class StringExtensionTest {
 
     @Test
-    fun `toTitleCase formats strings correctly`() {
-        assertEquals("Milton Keynes", "MILTON KEYNES".toTitleCase())
-        assertEquals("Anna Ornella Arenö", "anna ornella arenö".toTitleCase())
-
-        assertEquals("", "".toTitleCase())
-        assertEquals("", "   ".toTitleCase())
-    }
-
-    @Test
     fun `toSpacedString formats strings for TalkBack correctly`() {
         assertEquals("F H 0 8 P D H", "FH08PDH".toSpacedString())
         assertEquals("1 2 3", "123".toSpacedString())


### PR DESCRIPTION
# Name not showing in all caps

- Remove toTitleCase() function so licence holders name is displayed how DVLA API provides it (currently all caps)

## JIRA ticket(s)
  - [GOVUKAPP-3848](https://govukverify.atlassian.net/browse/GOVUKAPP-3848)

## Figma
  - [Figma board](https://www.figma.com/design/utmaFnJPNY4sVgwjui5MmK/Driving?node-id=6501-49710&t=eIvyA1VXzTorkQTm-0)

## Screen shots

| Before | After |
|--------|-------|
| <img width="1344" height="2992" alt="Screenshot_1785326804" src="https://github.com/user-attachments/assets/13ecc066-e15a-4254-bd13-b7788b980b59" /> | <img width="1344" height="2992" alt="Screenshot_1785327124" src="https://github.com/user-attachments/assets/bac3a9b3-c956-48d5-8a70-1271c9a877d9" /> |