### PR TITLE
GOVUKAPP-3850 Ability to link different DVLA account

### DIFF
--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
@@ -18,6 +18,7 @@ import uk.gov.govuk.dvla.linking.data.LinkingRepo
 import uk.gov.govuk.dvla.navigation.ARG_DVLA_TOKEN
 import javax.inject.Inject
 import javax.inject.Named
+import androidx.core.net.toUri
 
 @HiltViewModel
 internal class DvlaViewModel @Inject constructor(
@@ -49,7 +50,10 @@ internal class DvlaViewModel @Inject constructor(
 
     sealed interface UiState {
         data object Default : UiState
-        data object Loading : UiState
+        sealed interface Loading : UiState {
+            data object Auth : Loading
+            data object Linking : Loading
+        }
         data object Success : UiState
         sealed interface Error : UiState {
             data object Offline : Error
@@ -85,6 +89,7 @@ internal class DvlaViewModel @Inject constructor(
     }
 
     private fun refreshTokens() {
+        _uiState.value = UiState.Loading.Auth
         viewModelScope.launch {
             if (authRepo.refreshTokens()) {
                 startAuthFlow()
@@ -96,17 +101,22 @@ internal class DvlaViewModel @Inject constructor(
 
     private suspend fun startAuthFlow() {
         when (val result = linkingRepo.getVerification()) {
-            is Result.Success -> launchAuthUrl(
-                result.value.verificationHash,
-                result.value.sessionHash
-            )
-
+            is Result.Success -> {
+                launchAuthUrl(
+                    result.value.verificationHash,
+                    result.value.sessionHash
+                )
+            }
             else -> _uiState.value = UiState.Error.Other
         }
     }
 
     private fun launchAuthUrl(verificationHash: String, sessionHash: String) {
-        _authUrlToLaunch.value = "$dvlaAuthUrl?verification=$verificationHash&session=$sessionHash"
+        val authUrl = dvlaAuthUrl.toUri().buildUpon()
+            .appendQueryParameter("verification", verificationHash)
+            .appendQueryParameter("session", sessionHash)
+            .build()
+        _authUrlToLaunch.value = authUrl.toString()
     }
 
     fun onIntroPageView(screenTitle: String) {
@@ -197,7 +207,7 @@ internal class DvlaViewModel @Inject constructor(
 
     fun handleAuthRedirect(token: String) {
         viewModelScope.launch {
-            _uiState.value = UiState.Loading
+            _uiState.value = UiState.Loading.Linking
             linkDvlaAccount(token)
         }
     }
@@ -212,7 +222,7 @@ internal class DvlaViewModel @Inject constructor(
 
     private fun unlinkDvlaAccount() {
         viewModelScope.launch {
-            _uiState.value = UiState.Loading
+            _uiState.value = UiState.Loading.Linking
             when (dvlaRepo.unlinkAccount()) {
                 is Result.Success -> _linkingEvent.emit(LinkingEvent.UnlinkComplete)
                 is Result.DeviceOffline -> _uiState.value = UiState.Error.Offline

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import uk.gov.govuk.analytics.AnalyticsClient
+import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.identity.model.ServiceLinkStatus
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.dvla.data.DvlaRepo
@@ -24,7 +25,8 @@ internal class DvlaViewModel @Inject constructor(
     private val dvlaRepo: DvlaRepo,
     private val analyticsClient: AnalyticsClient,
     @param:Named("dvla_auth_url") private val dvlaAuthUrl: String,
-    private val linkingRepo: LinkingRepo
+    private val linkingRepo: LinkingRepo,
+    private val authRepo: AuthRepo
 ) : ViewModel() {
 
     companion object {
@@ -78,22 +80,33 @@ internal class DvlaViewModel @Inject constructor(
         when {
             dvlaRepo.currentLinkState == ServiceLinkStatus.LINKED -> unlinkDvlaAccount()
             token != null -> handleAuthRedirect(token)
-            else -> startAuthFlow()
+            else -> refreshTokens()
         }
     }
 
-    private fun startAuthFlow() {
+    private fun refreshTokens() {
         viewModelScope.launch {
-            when (val result = linkingRepo.getVerification()) {
-                is Result.Success -> launchAuthUrl(result.value.verificationHash)
-
-                else -> _uiState.value = UiState.Error.Other
+            if (authRepo.refreshTokens()) {
+                startAuthFlow()
+            } else {
+                _uiState.value = UiState.Error.Other
             }
         }
     }
 
-    private fun launchAuthUrl(verificationHash: String) {
-        _authUrlToLaunch.value = "$dvlaAuthUrl?verification=$verificationHash"
+    private suspend fun startAuthFlow() {
+        when (val result = linkingRepo.getVerification()) {
+            is Result.Success -> launchAuthUrl(
+                result.value.verificationHash,
+                result.value.sessionHash
+            )
+
+            else -> _uiState.value = UiState.Error.Other
+        }
+    }
+
+    private fun launchAuthUrl(verificationHash: String, sessionHash: String) {
+        _authUrlToLaunch.value = "$dvlaAuthUrl?verification=$verificationHash&session=$sessionHash"
     }
 
     fun onIntroPageView(screenTitle: String) {

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/remote/model/VerificationResponse.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/remote/model/VerificationResponse.kt
@@ -3,5 +3,6 @@ package uk.gov.govuk.dvla.linking.remote.model
 import com.google.gson.annotations.SerializedName
 
 internal data class VerificationResponse(
-    @SerializedName("verificationHash") val verificationHash: String
+    @SerializedName("verificationHash") val verificationHash: String,
+    @SerializedName("sessionHash") val sessionHash: String
 )

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/DvlaLinkingRoute.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/DvlaLinkingRoute.kt
@@ -89,11 +89,15 @@ internal fun DvlaLinkingRoute(
             )
         }
 
-        is DvlaViewModel.UiState.Loading -> {
-            DvlaLinkLoadingScreen(
-                modifier = modifier
-            )
-        }
+        is DvlaViewModel.UiState.Loading.Auth -> DvlaLoadingScreen(
+            title = "",
+            modifier = modifier
+        )
+
+        is DvlaViewModel.UiState.Loading.Linking -> DvlaLoadingScreen(
+            title = stringResource(R.string.link_dvla_connecting_title),
+            modifier = modifier
+        )
 
         is DvlaViewModel.UiState.Error.Offline -> {
             DvlaOfflineScreen(
@@ -127,11 +131,12 @@ internal fun DvlaLinkingRoute(
 }
 
 @Composable
-private fun DvlaLinkLoadingScreen(
+private fun DvlaLoadingScreen(
+    title: String,
     modifier: Modifier = Modifier
 ) {
     BookendConnectingScreen(
-        title = stringResource(R.string.link_dvla_connecting_title),
+        title = title,
         modifier = modifier
     )
 }

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
@@ -1,10 +1,14 @@
 package uk.gov.govuk.dvla
 
+import android.net.Uri
+import androidx.core.net.toUri
 import androidx.lifecycle.SavedStateHandle
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -44,12 +48,14 @@ class DvlaViewModelTest {
 
     @Before
     fun setup() {
+        mockkStatic(Uri::class)
         Dispatchers.setMain(dispatcher)
         every { savedStateHandle.get<String>("token") } returns token
     }
 
     @After
     fun tearDown() {
+        unmockkAll()
         Dispatchers.resetMain()
     }
 
@@ -106,6 +112,14 @@ class DvlaViewModelTest {
         every { savedStateHandle.get<String>("token") } returns null
         coEvery { authRepo.refreshTokens() } returns true
         coEvery { linkingRepo.getVerification() } returns Result.Success(VerificationResponse("1234", "4321"))
+        every {
+            dvlaAuthUrl.toUri().buildUpon()
+                .appendQueryParameter("verification", "1234")
+                .appendQueryParameter("session", "4321")
+                .build()
+                .toString()
+        } returns "$dvlaAuthUrl?verification=1234&session=4321"
+
 
         val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
@@ -116,6 +130,7 @@ class DvlaViewModelTest {
         assertEquals(expected, viewModel.authUrlToLaunch.value)
         coVerify(exactly = 1) { authRepo.refreshTokens() }
         coVerify(exactly = 0) { repo.linkAccount(any()) }
+        assertEquals(DvlaViewModel.UiState.Loading.Auth, viewModel.uiState.value)
     }
 
     @Test

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
@@ -22,6 +22,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import uk.gov.govuk.analytics.AnalyticsClient
+import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.identity.model.ServiceLinkStatus
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.dvla.data.DvlaRepo
@@ -35,6 +36,7 @@ class DvlaViewModelTest {
 
     private val repo = mockk<DvlaRepo>(relaxed = true)
     private val linkingRepo = mockk<LinkingRepo>(relaxed = true)
+    private val authRepo = mockk<AuthRepo>(relaxed = true)
     private val savedStateHandle = mockk<SavedStateHandle>(relaxed = true)
     private val analyticsClient = mockk<AnalyticsClient>(relaxed = true)
     private val token = "1234-abcd"
@@ -56,7 +58,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.Success(Unit)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         assertEquals(DvlaViewModel.UiState.Default, viewModel.uiState.value)
     }
@@ -66,7 +68,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.Success(Unit)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         advanceUntilIdle()
 
@@ -79,7 +81,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.Error()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         advanceUntilIdle()
 
@@ -91,7 +93,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.DeviceOffline()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         advanceUntilIdle()
 
@@ -99,34 +101,54 @@ class DvlaViewModelTest {
     }
 
     @Test
-    fun `Given no token in SavedStateHandle, when initialised and getVerification is success, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
+    fun `Given no token in SavedStateHandle, when initialised, refreshTokens returns true and getVerification is success, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         every { savedStateHandle.get<String>("token") } returns null
-        coEvery { linkingRepo.getVerification() } returns Result.Success(VerificationResponse("1234"))
+        coEvery { authRepo.refreshTokens() } returns true
+        coEvery { linkingRepo.getVerification() } returns Result.Success(VerificationResponse("1234", "4321"))
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         advanceUntilIdle()
 
-        val expected = "$dvlaAuthUrl?verification=1234"
+        val expected = "$dvlaAuthUrl?verification=1234&session=4321"
 
         assertEquals(expected, viewModel.authUrlToLaunch.value)
+        coVerify(exactly = 1) { authRepo.refreshTokens() }
         coVerify(exactly = 0) { repo.linkAccount(any()) }
     }
 
     @Test
-    fun `Given no token in SavedStateHandle, when initialised and getVerification is error, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
+    fun `Given no token in SavedStateHandle, when initialised, refreshTokens returns false, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         every { savedStateHandle.get<String>("token") } returns null
-        coEvery { linkingRepo.getVerification() } returns Result.Error()
+        coEvery { authRepo.refreshTokens() } returns false
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         advanceUntilIdle()
 
         assertEquals(null, viewModel.authUrlToLaunch.value)
         assertEquals(DvlaViewModel.UiState.Error.Other, viewModel.uiState.value)
         coVerify(exactly = 0) { repo.linkAccount(any()) }
+        coVerify(exactly = 1) { authRepo.refreshTokens() }
+    }
+
+    @Test
+    fun `Given no token in SavedStateHandle, when initialised, refreshTokens returns true and getVerification is error, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
+        every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
+        every { savedStateHandle.get<String>("token") } returns null
+        coEvery { authRepo.refreshTokens() } returns true
+        coEvery { linkingRepo.getVerification() } returns Result.Error()
+
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+
+        advanceUntilIdle()
+
+        assertEquals(null, viewModel.authUrlToLaunch.value)
+        assertEquals(DvlaViewModel.UiState.Error.Other, viewModel.uiState.value)
+        coVerify(exactly = 0) { repo.linkAccount(any()) }
+        coVerify(exactly = 1) { authRepo.refreshTokens() }
     }
 
     @Test
@@ -134,7 +156,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         every { savedStateHandle.get<String>("token") } returns null
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         viewModel.onAuthTabLaunched()
 
@@ -146,7 +168,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.LINKED)
         coEvery { repo.unlinkAccount() } returns Result.Success(Unit)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         assertEquals(DvlaViewModel.UiState.Default, viewModel.uiState.value)
     }
@@ -157,7 +179,7 @@ class DvlaViewModelTest {
         every { repo.currentLinkState } returns ServiceLinkStatus.LINKED
         coEvery { repo.unlinkAccount() } returns Result.Success(Unit)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         val events = mutableListOf<DvlaViewModel.LinkingEvent>()
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -175,7 +197,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.LINKED)
         coEvery { repo.unlinkAccount() } returns Result.Error()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         advanceUntilIdle()
 
@@ -188,7 +210,7 @@ class DvlaViewModelTest {
         every { repo.currentLinkState } returns ServiceLinkStatus.LINKED
         coEvery { repo.unlinkAccount() } returns Result.DeviceOffline()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         advanceUntilIdle()
 
@@ -199,7 +221,7 @@ class DvlaViewModelTest {
     fun `Given screen title, when onIntroPageView is called, then track screen view`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         viewModel.onIntroPageView("DVLA link intro")
 
@@ -217,7 +239,7 @@ class DvlaViewModelTest {
     fun `When onIntroCloseClicked is called, then track close icon click`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         viewModel.onIntroCloseClicked()
 
@@ -230,7 +252,7 @@ class DvlaViewModelTest {
     fun `Given button text, when onIntroContinueClicked is called, then track button click`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         viewModel.onIntroContinueClicked("Continue")
 
@@ -247,7 +269,7 @@ class DvlaViewModelTest {
     fun `Given screen title, when onLinkSuccessPageView is called, then track screen view`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         viewModel.onLinkSuccessPageView("Driver and vehicles account added")
 
@@ -264,7 +286,7 @@ class DvlaViewModelTest {
     fun `Given button text, when onSuccessContinueClicked is called, then track button click and emit LinkComplete event`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         val events = mutableListOf<DvlaViewModel.LinkingEvent>()
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -291,7 +313,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.DeviceOffline()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         advanceUntilIdle()
 
@@ -308,7 +330,7 @@ class DvlaViewModelTest {
     fun `Given screen title, when onErrorOtherPageView is called, then track error screen view`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         val title = "There is a problem"
         viewModel.onErrorOtherPageView(title)
@@ -326,7 +348,7 @@ class DvlaViewModelTest {
     fun `Given button text, when onErrorBackToDrivingClicked is called, then track button click`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         val label = "Go back to driving"
         viewModel.onErrorBackToDrivingClicked(label)
@@ -344,7 +366,7 @@ class DvlaViewModelTest {
     fun `Given button text and url, when onErrorVisitGovUkClicked is called, then track external button click with url`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         val label = "Go to GOV.UK"
         val url = "gov.uk"
@@ -365,7 +387,7 @@ class DvlaViewModelTest {
     fun `Given screen title, when onOfflinePageView is called, then track offline screen view`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         val title = "You are offline"
         viewModel.onOfflinePageView(title)
@@ -383,7 +405,7 @@ class DvlaViewModelTest {
     fun `Given button text, when onOfflineTryAgainClicked is called, then track button click`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         val label = "Try again"
         viewModel.onOfflineTryAgainClicked(label)

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/linking/data/LinkingRepoTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/linking/data/LinkingRepoTest.kt
@@ -29,7 +29,7 @@ class LinkingRepoTest {
     fun `Given getVerification is called, when response is successful, then returns success`() =
         runTest {
             coEvery { api.getVerification(VerificationRequest("1234")) } returns Response.success(
-                VerificationResponse("4321")
+                VerificationResponse("1111", "2222")
             )
             coEvery { authRepo.getAccessToken() } returns "1234"
 


### PR DESCRIPTION
# Ability to link different DVLA account

**NOT DEV TESTED YET AS WAITING FOR BACKEND CHANGES BUT ASKED TO GET THROUGH REVIEW**

Despite the title/name this task is actually to prevent the ability to link a DVLA account to a different account by checking a session hash is the same session as the logged in users.

Added the following to run in this order:
- Receive new session hash param in verification response.
- Refresh tokens before starting DVLA auth flow.
- Send new session hash when starting DVLA auth flow.

## JIRA ticket(s)
  - [GOVUKAPP-3850](https://govukverify.atlassian.net/browse/GOVUKAPP-3850)