### PR TITLE
Fix/not 417 delete sync issue

### DIFF
--- a/feature/notificationcentre/src/main/kotlin/uk/gov/govuk/notificationcentre/data/NotificationCentreRepoImpl.kt
+++ b/feature/notificationcentre/src/main/kotlin/uk/gov/govuk/notificationcentre/data/NotificationCentreRepoImpl.kt
@@ -1,10 +1,13 @@
 package uk.gov.govuk.notificationcentre.data
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.data.model.Result.ServiceNotResponding
 import uk.gov.govuk.data.model.Result.Success
 import uk.gov.govuk.data.remote.safeAuthApiCall
+import uk.gov.govuk.notificationcentre.data.di.NotificationCentreScope
 import uk.gov.govuk.notificationcentre.data.model.Notification
 import uk.gov.govuk.notificationcentre.data.model.UpdateNotificationRequestBody
 import uk.gov.govuk.notificationcentre.data.remote.NotificationCentreApi
@@ -22,7 +25,8 @@ class DateProviderImpl: DateProvider {
 internal class NotificationCentreRepoImpl @Inject constructor(
     private val notificationCentreApi: NotificationCentreApi,
     private val authRepo: AuthRepo,
-    private val dateProvider: DateProvider
+    private val dateProvider: DateProvider,
+    @param:NotificationCentreScope private val scope: CoroutineScope
 ) : NotificationCentreRepo {
 
     data class CacheEntry<T>(val value: T, val lastUpdated: Instant = Instant.now()) {
@@ -44,7 +48,18 @@ internal class NotificationCentreRepoImpl @Inject constructor(
         }, authRepo = authRepo)
 
         if (res is Success) {
-            notifications = CacheEntry(res.value)
+            val curr = notifications
+
+            // Discard the fetch value if a mutation extended the expiry of the cached value
+            // while this call was in flight
+            val entry = if (curr == null || curr.hasExpired(dateProvider.date)) {
+                CacheEntry(res.value)
+            } else {
+                curr
+            }
+            notifications = entry
+
+            return Success(entry.value)
         }
 
         return res
@@ -69,40 +84,42 @@ internal class NotificationCentreRepoImpl @Inject constructor(
     }
 
     override suspend fun updateNotification(notificationId: String, status: UpdateNotificationRequestBody.Status): Result<Unit> {
-        notifications?.let { nots ->
-            val updatedNotifications = nots.value.map {
-                if (it.id == notificationId) {
-                    val statusString = when (status) {
-                        UpdateNotificationRequestBody.Status.READ -> "READ"
-                        UpdateNotificationRequestBody.Status.UNREAD -> "DELIVERED"
-                    }
-
-                    it.copy(status = statusString)
-                } else {
-                    it
-                }
+        notifications = notifications?.let { nots ->
+            val statusString = when (status) {
+                UpdateNotificationRequestBody.Status.READ -> "READ"
+                UpdateNotificationRequestBody.Status.UNREAD -> "DELIVERED"
             }
-            notifications = notifications?.copy(value = updatedNotifications)
+
+            CacheEntry(nots.value.map {
+                if (it.id == notificationId) it.copy(status = statusString) else it
+            })
         }
 
-        return safeAuthApiCall(apiCall = {
-            notificationCentreApi.updateNotification(
-                notificationId,
-                UpdateNotificationRequestBody(status)
-            )
-        }, authRepo = authRepo)
+        scope.launch {
+            safeAuthApiCall(apiCall = {
+                notificationCentreApi.updateNotification(
+                    notificationId,
+                    UpdateNotificationRequestBody(status)
+                )
+            }, authRepo = authRepo)
+        }
+
+        return Success(Unit)
     }
 
     override suspend fun deleteNotification(notificationId: String): Result<Unit> {
-        notifications?.let { nots ->
-            val updatedNotifications = nots.value.filter { it.id != notificationId }
-            notifications = nots.copy(value = updatedNotifications)
+        notifications = notifications?.let { nots ->
+            CacheEntry(nots.value.filter { it.id != notificationId })
         }
 
-        return safeAuthApiCall(apiCall = {
-            notificationCentreApi.deleteNotification(
-                notificationId
-            )
-        }, authRepo = authRepo)
+        scope.launch {
+            safeAuthApiCall(apiCall = {
+                notificationCentreApi.deleteNotification(
+                    notificationId
+                )
+            }, authRepo = authRepo)
+        }
+
+        return Success(Unit)
     }
 }

--- a/feature/notificationcentre/src/main/kotlin/uk/gov/govuk/notificationcentre/data/di/NotificationCentreModule.kt
+++ b/feature/notificationcentre/src/main/kotlin/uk/gov/govuk/notificationcentre/data/di/NotificationCentreModule.kt
@@ -4,6 +4,9 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import retrofit2.Retrofit
 import uk.gov.govuk.notificationcentre.DefaultNotificationCentreFeature
 import uk.gov.govuk.notificationcentre.NotificationCentreFeature
@@ -13,7 +16,12 @@ import uk.gov.govuk.notificationcentre.data.NotificationCentreRepo
 import uk.gov.govuk.notificationcentre.data.NotificationCentreRepoImpl
 import uk.gov.govuk.notificationcentre.data.remote.NotificationCentreApi
 import javax.inject.Named
+import javax.inject.Qualifier
 import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class NotificationCentreScope
 
 @InstallIn(SingletonComponent::class)
 @Module
@@ -40,6 +48,12 @@ internal object NotificationCentreModule {
     fun provideDateProvider(): DateProvider {
         return DateProviderImpl()
     }
+
+    @Provides
+    @Singleton
+    @NotificationCentreScope
+    fun provideCoroutineScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
 }
 

--- a/feature/notificationcentre/src/test/kotlin/uk/gov/govuk/notificationcentre/data/NotificationCentreRepoTest.kt
+++ b/feature/notificationcentre/src/test/kotlin/uk/gov/govuk/notificationcentre/data/NotificationCentreRepoTest.kt
@@ -4,6 +4,12 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -32,11 +38,17 @@ class NotificationCentreRepoTest {
 
     private lateinit var notificationCentreRepo: NotificationCentreRepo
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setup() {
         every { mockDateProvider.date } returns Instant.now()
 
-        notificationCentreRepo = NotificationCentreRepoImpl(api, auth, mockDateProvider)
+        notificationCentreRepo = NotificationCentreRepoImpl(
+            api,
+            auth,
+            mockDateProvider,
+            CoroutineScope(UnconfinedTestDispatcher())
+        )
     }
 
     // All
@@ -54,6 +66,7 @@ class NotificationCentreRepoTest {
     fun `Get notifications performs API call only once when cached`() = runTest {
         coEvery { api.getNotifications() } returns getAllResponse
         coEvery { getAllResponse.isSuccessful } returns true
+        coEvery { getAllResponse.body() } returns mockNotifications
 
         notificationCentreRepo.getNotifications()
         notificationCentreRepo.getNotifications()
@@ -67,6 +80,7 @@ class NotificationCentreRepoTest {
     fun `Get notifications performs API call when cache has expired`() = runTest {
         coEvery { api.getNotifications() } returns getAllResponse
         coEvery { getAllResponse.isSuccessful } returns true
+        coEvery { getAllResponse.body() } returns mockNotifications
 
         notificationCentreRepo.getNotifications()
 
@@ -118,6 +132,22 @@ class NotificationCentreRepoTest {
 
         coVerify(exactly = 1) {
             api.getSingleNotification("1")
+        }
+    }
+
+    @Test
+    fun `Get single notification falls through to API when id not present in warm cache`() = runTest {
+        coEvery { api.getNotifications() } returns getAllResponse
+        coEvery { getAllResponse.isSuccessful } returns true
+        coEvery { getAllResponse.body() } returns mockNotifications
+
+        // Warm the cache but the GET will avoid it as the ID isn't in it so is forced to hit the network
+        notificationCentreRepo.getNotifications()
+
+        notificationCentreRepo.getSingleNotification("999")
+
+        coVerify(exactly = 1) {
+            api.getSingleNotification("999")
         }
     }
 
@@ -193,7 +223,17 @@ class NotificationCentreRepoTest {
     }
 
     @Test
-    fun `Update notification modifies internal state`() = runTest {
+    fun `Update notification makes API call for unread`() = runTest {
+        notificationCentreRepo.updateNotification("1", UpdateNotificationRequestBody.Status.UNREAD)
+
+
+        coVerify(exactly = 1) {
+            api.updateNotification("1", UpdateNotificationRequestBody(UpdateNotificationRequestBody.Status.UNREAD))
+        }
+    }
+
+    @Test
+    fun `Mark read modifies internal state`() = runTest {
         coEvery { api.getNotifications() } returns getAllResponse
         coEvery { getAllResponse.isSuccessful } returns true
         coEvery { getAllResponse.body() } returns mockNotifications
@@ -206,6 +246,25 @@ class NotificationCentreRepoTest {
         val notification = notificationCentreRepo.getSingleNotification("1")
 
         assertEquals((notification as Result.Success).value?.isUnread, false)
+    }
+
+    @Test
+    fun `Mark unread modifies internal state`() = runTest {
+        coEvery { api.getNotifications() } returns getAllResponse
+        coEvery { getAllResponse.isSuccessful } returns true
+        coEvery { getAllResponse.body() } returns mockNotifications
+
+        // Prime cache
+        notificationCentreRepo.getNotifications()
+
+        notificationCentreRepo.updateNotification("1", UpdateNotificationRequestBody.Status.READ)
+        var notification = notificationCentreRepo.getSingleNotification("1")
+        assertEquals((notification as Result.Success).value?.isUnread, false)
+
+        notificationCentreRepo.updateNotification("1", UpdateNotificationRequestBody.Status.UNREAD)
+
+        notification = notificationCentreRepo.getSingleNotification("1")
+        assertEquals((notification as Result.Success).value?.isUnread, true)
     }
 
     // Delete
@@ -235,5 +294,79 @@ class NotificationCentreRepoTest {
         val notifications = notificationCentreRepo.getNotifications()
 
         assertTrue((notifications as Result.Success).value.isEmpty())
+    }
+
+    // NOT-417
+
+    @Test
+    fun `Get notifications does not clobber a status update mutated while its network call was in flight`() = runTest {
+        coEvery { api.getNotifications() } returns getAllResponse
+        coEvery { getAllResponse.isSuccessful } returns true
+        coEvery { getAllResponse.body() } returns mockNotifications
+
+        // Prime cache
+        notificationCentreRepo.getNotifications()
+
+        // Force the cache to immediately expire, and then when the mutation happens, set it back to now
+        every { mockDateProvider.date } returnsMany listOf(
+            Instant.now().plus(60, ChronoUnit.SECONDS),
+            Instant.now()
+        )
+
+        // Force a mark as unread to happen before the GET finishes
+        coEvery { api.getNotifications() } coAnswers {
+            notificationCentreRepo.updateNotification("1", UpdateNotificationRequestBody.Status.READ)
+            getAllResponse
+        }
+
+        val result = notificationCentreRepo.getNotifications()
+
+        // The deleted value (even with the stale GET) has still been removed
+        assertEquals(false, (result as Result.Success).value.first { it.id == "1" }.isUnread)
+    }
+
+    @Test
+    fun `Get notifications does not clobber a cache mutated while its network call was in flight`() = runTest {
+        coEvery { api.getNotifications() } returns getAllResponse
+        coEvery { getAllResponse.isSuccessful } returns true
+        coEvery { getAllResponse.body() } returns mockNotifications
+
+        // Prime cache
+        notificationCentreRepo.getNotifications()
+
+        // Force the cache to immediately expire, and then when the mutation happens, set it back to now
+        every { mockDateProvider.date } returnsMany listOf(
+            Instant.now().plus(60, ChronoUnit.SECONDS),
+            Instant.now()
+        )
+
+        // Force a delete to happen before the GET finishes
+        coEvery { api.getNotifications() } coAnswers {
+            notificationCentreRepo.deleteNotification("1")
+            getAllResponse
+        }
+
+        val result = notificationCentreRepo.getNotifications()
+
+        // The deleted value (even with the stale GET) has still been removed
+        assertTrue((result as Result.Success).value.none { it.id == "1" })
+    }
+
+    @Test
+    fun `Delete network call survives cancellation of the calling coroutine`() = runTest {
+        // Move to our own Scope to mirror how the ViewModel behaves
+        val callerJob = Job()
+        val callerScope = CoroutineScope(UnconfinedTestDispatcher() + callerJob)
+
+        callerScope.launch {
+            notificationCentreRepo.deleteNotification("1")
+        }
+        callerJob.cancel()
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            api.deleteNotification("1")
+        }
     }
 }

--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package uk.gov.govuk.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -77,8 +78,11 @@ internal class SettingsViewModel @Inject constructor(
         )
     }
 
-    private fun loadMessages() {
-        viewModelScope.launch {
+    private var loadMessagesJob: Job? = null
+
+    fun loadMessages() {
+        loadMessagesJob?.cancel()
+        loadMessagesJob = viewModelScope.launch {
             dvlaRepo.linkState.collect { state ->
                 when (state) {
                     ServiceLinkStatus.CHECKING -> {
@@ -116,8 +120,6 @@ internal class SettingsViewModel @Inject constructor(
             screenName = SCREEN_NAME,
             title = TITLE
         )
-
-        loadMessages()
     }
 
     fun onAccount() {

--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/ui/SettingsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -70,6 +71,11 @@ internal fun SettingsRoute(
 ) {
     val viewModel: SettingsViewModel = hiltViewModel()
     val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadMessages()
+    }
+
     uiState?.let {
         SettingsScreen(
             uiState = it,

--- a/feature/settings/src/test/kotlin/uk/gov/govuk/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/uk/gov/govuk/settings/SettingsViewModelTest.kt
@@ -316,7 +316,7 @@ class SettingsViewModelTest {
         runTest {
             every { dvlaRepo.linkState } returns flowOf(ServiceLinkStatus.CHECKING)
 
-            viewModel.onPageView()
+            viewModel.loadMessages()
 
             advanceUntilIdle()
 
@@ -330,7 +330,7 @@ class SettingsViewModelTest {
         runTest {
             every { dvlaRepo.linkState } returns flowOf(ServiceLinkStatus.UNLINKED)
 
-            viewModel.onPageView()
+            viewModel.loadMessages()
 
             advanceUntilIdle()
 
@@ -343,7 +343,7 @@ class SettingsViewModelTest {
         runTest {
             every { dvlaRepo.linkState } returns flowOf(ServiceLinkStatus.ERROR)
 
-            viewModel.onPageView()
+            viewModel.loadMessages()
 
             advanceUntilIdle()
 
@@ -358,7 +358,7 @@ class SettingsViewModelTest {
             every { dvlaRepo.linkState } returns flowOf(ServiceLinkStatus.LINKED)
             coEvery { notificationCentreFeature.getUnreadCount() } returns null
 
-            viewModel.onPageView()
+            viewModel.loadMessages()
 
             advanceUntilIdle()
 
@@ -372,7 +372,7 @@ class SettingsViewModelTest {
             every { dvlaRepo.linkState } returns flowOf(ServiceLinkStatus.LINKED)
             coEvery { notificationCentreFeature.getUnreadCount() } returns 1
 
-            viewModel.onPageView()
+            viewModel.loadMessages()
 
             advanceUntilIdle()
 
@@ -390,13 +390,36 @@ class SettingsViewModelTest {
             }
             coEvery { notificationCentreFeature.getUnreadCount() } returns 3
 
-            viewModel.onPageView()
+            viewModel.loadMessages()
 
             assertEquals(MessageRowState.Loading, viewModel.uiState.value?.messageRowState)
 
             advanceUntilIdle()
 
             assertEquals(MessageRowState.Loaded(3), viewModel.uiState.value?.messageRowState)
+        }
+    }
+
+    @Test
+    fun `Given loadMessages is called again, the previous DVLA link collector is cancelled`() {
+        runTest {
+            every { dvlaRepo.linkState } returns flow {
+                emit(ServiceLinkStatus.LINKED)
+                delay(1000)
+                emit(ServiceLinkStatus.ERROR)
+            }
+            coEvery { notificationCentreFeature.getUnreadCount() } returns 5
+
+            viewModel.loadMessages()
+
+            every { dvlaRepo.linkState } returns flowOf(ServiceLinkStatus.LINKED)
+            coEvery { notificationCentreFeature.getUnreadCount() } returns 7
+
+            viewModel.loadMessages()
+
+            advanceUntilIdle()
+
+            assertEquals(MessageRowState.Loaded(7), viewModel.uiState.value?.messageRowState)
         }
     }
 }


### PR DESCRIPTION
Fixes two scenarios related to data races and the Notification list showing the wrong state:
* DELETE/PATCH request is slow and completes after the refresh of the notification list
* GET request completes before the server asynchronously processes the DELETE/PATCH

Also fixes a possible issue where the DELETE/PATCH request would be cancelled in-flightas it was tied to the ViewModel lifecycle, potentially creating a scenarion where the serverwould not process the full Request and update its state

Also fixes the Message count not updating in Settings as the load was only fired once (as it was driven by a function previously only intended for analytics).