### PR TITLE
GOVUKAPP-3853 DVLA engine size content change

### DIFF
--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/model/VehicleDetailsMapper.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/model/VehicleDetailsMapper.kt
@@ -42,7 +42,6 @@ import uk.gov.govuk.dvla.domain.VehicleColour.WHITE
 import uk.gov.govuk.dvla.domain.VehicleColour.YELLOW
 import uk.gov.govuk.dvla.domain.VehicleDetails
 import uk.gov.govuk.dvla.util.getFormattedEngineCapacity
-import uk.gov.govuk.dvla.util.getFormattedEngineCapacityAltText
 import uk.gov.govuk.dvla.util.toYearDisplayFormat
 import javax.inject.Inject
 
@@ -51,8 +50,6 @@ internal class VehicleDetailsMapper @Inject constructor(
     private val taxAndMotStatusMapper: TaxAndMotStatusMapper
 ) {
     fun toUiModel(vesVehicle: VehicleDetails, dvlaUrls: DvlaUrls?): VehicleDetailsUiModel {
-        val engineCapacity =
-            vesVehicle.engineCapacity?.let { getFormattedEngineCapacity(it) } ?: "Unknown"
         val yearOfFirstRegistration =
             vesVehicle.dateOfFirstRegistration?.toYearDisplayFormat() ?: "Unknown"
         return VehicleDetailsUiModel(
@@ -102,11 +99,8 @@ internal class VehicleDetailsMapper @Inject constructor(
                 InternalLinkListItemModel.Info(
                     title = AccessibleString(displayText = stringProvider.getString(R.string.engine_size_title)),
                     info = AccessibleString(
-                        displayText = engineCapacity,
-                        altText = getFormattedEngineCapacityAltText(
-                            engineCapacity,
-                            replacementText = stringProvider.getString(R.string.litres_alt_text)
-                        )
+                        displayText = vesVehicle.engineCapacity?.let { getFormattedEngineCapacity(it) }
+                            ?: "Unknown"
                     )
                 ),
                 InternalLinkListItemModel.Info(

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/util/SpecificationsFormatter.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/util/SpecificationsFormatter.kt
@@ -1,10 +1,4 @@
 package uk.gov.govuk.dvla.util
 
-internal fun getFormattedEngineCapacity(engineCapacity: Int): String {
-    if (engineCapacity < 1000) return "${engineCapacity}cc" // Append 'cc' for cubic centimeters
-    val capacityRoundedToOneDecimalPlace = "%.1f".format(engineCapacity / 1000f)
-    return "${capacityRoundedToOneDecimalPlace}L" // Append 'L' for Litres
-}
-
-internal fun getFormattedEngineCapacityAltText(engineCapacity: String, replacementText: String) =
-    engineCapacity.replace("L", " $replacementText")
+internal fun getFormattedEngineCapacity(engineCapacity: Int) =
+    "${engineCapacity}cc" // Append 'cc' for cubic centimeters

--- a/feature/dvla/src/main/res/values/strings.xml
+++ b/feature/dvla/src/main/res/values/strings.xml
@@ -151,7 +151,6 @@
     <string name="fuel_type_alt_text">Fuel type %1$s</string>
     <string name="colour_alt_text">Colour %1$s</string>
     <string name="emissions_alt_text">%1$s grams per kilometre</string>
-    <string name="litres_alt_text">Litres</string>
 
     <string name="brown">Brown</string>
     <string name="bronze">Bronze</string>

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/util/SpecificationsFormatterTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/util/SpecificationsFormatterTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.govuk.dvla.util
 
 import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
 import org.junit.Test
 
 class SpecificationsFormatterTest {
@@ -9,35 +8,5 @@ class SpecificationsFormatterTest {
     fun `getFormattedEngineCapacity correctly formats when engine capacity is under 1000`() {
         val result = getFormattedEngineCapacity(999)
         assertEquals("999cc", result)
-    }
-
-    @Test
-    fun `getFormattedEngineCapacity correctly formats when engine capacity is 1000`() {
-        val result = getFormattedEngineCapacity(1000)
-        assertEquals("1.0L", result)
-    }
-
-    @Test
-    fun `getFormattedEngineCapacity correctly formats when engine capacity is 1950`() {
-        val result = getFormattedEngineCapacity(1950)
-        assertEquals("2.0L", result)
-    }
-
-    @Test
-    fun `getFormattedEngineCapacity correctly formats when engine capacity is 1949`() {
-        val result = getFormattedEngineCapacity(1949)
-        assertEquals("1.9L", result)
-    }
-
-    @Test
-    fun `getFormattedEngineCapacityAltText correctly formats when engine capacity doesn't have L`() {
-        val result = getFormattedEngineCapacityAltText("999cc", "Litres")
-        assertEquals("999cc", result)
-    }
-
-    @Test
-    fun `getFormattedEngineCapacityAltText correctly formats when engine capacity has L`() {
-        val result = getFormattedEngineCapacityAltText("1000L", "Litres")
-        assertEquals("1000 Litres", result)
     }
 }


### PR DESCRIPTION
# DVLA engine size content change

- Change engine capacity to cc only

## JIRA ticket(s)
  - [GOVUKAPP-3853](https://govukverify.atlassian.net/browse/GOVUKAPP-3853)

## Figma
  - [Figma board](https://www.figma.com/design/utmaFnJPNY4sVgwjui5MmK/Driving?node-id=6501-49710&t=eIvyA1VXzTorkQTm-0)

## Screen shots

| Before | After |
|--------|-------|
| <img width="1344" height="2992" alt="Screenshot_1785433881" src="https://github.com/user-attachments/assets/3558a289-c633-43a2-abb1-33baed2f4534" /> | <img width="1344" height="2992" alt="Screenshot_1785433378" src="https://github.com/user-attachments/assets/2cde9106-6792-48bd-946d-e8e13e3df7fe" /> |