### PR TITLE
GOVUKAPP-3851 Sign-out sign-in bug

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/AppViewModel.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/AppViewModel.kt
@@ -181,7 +181,6 @@ internal class AppViewModel @Inject constructor(
     fun onLogin() {
         viewModelScope.launch {
             if (authRepo.isDifferentUser()) {
-                authRepo.clear()
                 appRepo.clear()
                 loginRepo.clear()
                 termsRepo.clear()

--- a/app/src/test/kotlin/uk/gov/govuk/AppViewModelTest.kt
+++ b/app/src/test/kotlin/uk/gov/govuk/AppViewModelTest.kt
@@ -614,8 +614,10 @@ class AppViewModelTest {
             viewModel.onLogin()
             advanceUntilIdle()
 
-            coVerify {
+            coVerify(exactly = 0) {
                 authRepo.clear()
+            }
+            coVerify(exactly = 1) {
                 appRepo.clear()
                 loginRepo.clear()
                 topicsFeature.clear()


### PR DESCRIPTION
# Sign-out sign-in bug

Change to NOT clear the `Auth Repo` (the tokens) from the `App View Model` when a different user signs in. 
This is because this happens AFTER the tokens for the new user are refreshed so the tokens are then cleared so cannot be read which is causing the bug. 
The auth repo is already cleared anyway on login when `handleAuthResponse()` is called from `Login View Model` so it shouldn't need clearing again anyway.

Steps to reproduce (before fix):
- Sign in
- Sign out
- Sign in as different user
- Observe no email address in Setting screen, sudden auto log-outs and having to sign in again on next app launch even if biometrics was enabled previously.

Steps to reproduce (after fix):
- Sign in
- Sign out
- Sign in as different user
- Observe an email address in Setting screen, no sudden auto log-outs and biometric login prompted on future app launches (if enabled).