### PR TITLE
GOVUKAPP-3822 Close menu navigation 

### DIFF
--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/SummaryCardHeader.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/SummaryCardHeader.kt
@@ -1,5 +1,7 @@
 package uk.gov.govuk.dvla.ui.component
 
+import android.content.Context
+import android.view.accessibility.AccessibilityManager
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,12 +17,14 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -32,6 +36,30 @@ import uk.gov.govuk.design.ui.component.OverflowButton
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 import uk.gov.govuk.dvla.R
 import uk.gov.govuk.dvla.ui.model.OverflowMenuItem
+
+@Composable
+private fun isTalkBackEnabled(): Boolean {
+    val context = LocalContext.current
+    val accessibilityManager =
+        context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+
+    var isEnabled by remember {
+        mutableStateOf(accessibilityManager.isTouchExplorationEnabled)
+    }
+
+    DisposableEffect(accessibilityManager) {
+        val listener = AccessibilityManager.TouchExplorationStateChangeListener { enabled ->
+            isEnabled = enabled
+        }
+        accessibilityManager.addTouchExplorationStateChangeListener(listener)
+
+        onDispose {
+            accessibilityManager.removeTouchExplorationStateChangeListener(listener)
+        }
+    }
+
+    return isEnabled
+}
 
 @Composable
 internal fun SummaryCardHeader(
@@ -78,6 +106,7 @@ private fun CardOverflowMenu(
     onMenuItemClick: (OverflowMenuItem) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
+    val isTalkBackOn = isTalkBackEnabled()
 
     Box {
         OverflowButton(
@@ -93,29 +122,52 @@ private fun CardOverflowMenu(
             offset = DpOffset(x = 0.dp, y = GovUkTheme.spacing.extraSmall)
         ) {
             menuItems.forEach { item ->
-                DropdownMenuItem(
-                    text = {
-                        BodyRegularLabel(
-                            text = item.text.displayText,
-                            color = GovUkTheme.colourScheme.textAndIcons.primary,
-                            modifier = item.text.altText?.let {
-                                Modifier.semantics { contentDescription = it }
-                            } ?: Modifier
-                        )
-                    },
+                OverflowMenuItemRow(
+                    text = item.text.displayText,
+                    altText = item.text.altText,
                     onClick = {
                         onMenuItemClick(item)
                         expanded = false
-                    },
-                    contentPadding = PaddingValues(
-                        horizontal = GovUkTheme.spacing.medium,
-                        vertical = GovUkTheme.spacing.small
-                    ),
-                    colors = MenuDefaults.itemColors(
-                        textColor = GovUkTheme.colourScheme.textAndIcons.primary
-                    )
+                    }
+                )
+            }
+
+            if (isTalkBackOn) {
+                OverflowMenuItemRow(
+                    text = stringResource(R.string.menu_close_menu),
+                    altText = null,
+                    onClick = { expanded = false }
                 )
             }
         }
     }
+}
+
+@Composable
+private fun OverflowMenuItemRow(
+    text: String,
+    altText: String? = null,
+    onClick: () -> Unit
+) {
+    DropdownMenuItem(
+        text = {
+            BodyRegularLabel(
+                text = text,
+                color = GovUkTheme.colourScheme.textAndIcons.primary,
+                modifier = if (altText != null) {
+                    Modifier.semantics { contentDescription = altText }
+                } else {
+                    Modifier
+                }
+            )
+        },
+        onClick = onClick,
+        contentPadding = PaddingValues(
+            horizontal = GovUkTheme.spacing.medium,
+            vertical = GovUkTheme.spacing.small
+        ),
+        colors = MenuDefaults.itemColors(
+            textColor = GovUkTheme.colourScheme.textAndIcons.primary
+        )
+    )
 }

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/SummaryCardHeader.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/SummaryCardHeader.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -133,6 +134,7 @@ private fun CardOverflowMenu(
             }
 
             if (isTalkBackOn) {
+                HorizontalDivider()
                 OverflowMenuItemRow(
                     text = stringResource(R.string.menu_close_menu),
                     altText = null,

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/SummaryCardHeader.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/ui/component/SummaryCardHeader.kt
@@ -27,13 +27,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import uk.gov.govuk.design.ui.component.BodyRegularLabel
 import uk.gov.govuk.design.ui.component.CardListItem
 import uk.gov.govuk.design.ui.component.OverflowButton
+import uk.gov.govuk.design.ui.extension.withAltText
+import uk.gov.govuk.design.ui.model.AccessibleString
 import uk.gov.govuk.design.ui.theme.GovUkTheme
 import uk.gov.govuk.dvla.R
 import uk.gov.govuk.dvla.ui.model.OverflowMenuItem
@@ -124,8 +124,7 @@ private fun CardOverflowMenu(
         ) {
             menuItems.forEach { item ->
                 OverflowMenuItemRow(
-                    text = item.text.displayText,
-                    altText = item.text.altText,
+                    title = AccessibleString(item.text.displayText, item.text.altText),
                     onClick = {
                         onMenuItemClick(item)
                         expanded = false
@@ -136,8 +135,7 @@ private fun CardOverflowMenu(
             if (isTalkBackOn) {
                 HorizontalDivider()
                 OverflowMenuItemRow(
-                    text = stringResource(R.string.menu_close_menu),
-                    altText = null,
+                    title = AccessibleString(stringResource(R.string.menu_close_menu)),
                     onClick = { expanded = false }
                 )
             }
@@ -147,20 +145,15 @@ private fun CardOverflowMenu(
 
 @Composable
 private fun OverflowMenuItemRow(
-    text: String,
-    altText: String? = null,
+    title: AccessibleString,
     onClick: () -> Unit
 ) {
     DropdownMenuItem(
         text = {
             BodyRegularLabel(
-                text = text,
+                text = title.displayText,
                 color = GovUkTheme.colourScheme.textAndIcons.primary,
-                modifier = if (altText != null) {
-                    Modifier.semantics { contentDescription = altText }
-                } else {
-                    Modifier
-                }
+                modifier = Modifier.withAltText(title.altText)
             )
         },
         onClick = onClick,

--- a/feature/dvla/src/main/res/values/strings.xml
+++ b/feature/dvla/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
     <string name="menu_change_log_book_address">Change log book address</string>
     <string name="menu_cancel_tax">Cancel tax</string>
     <string name="menu_cancel_tax_alt_text">Cancel vehicle tax</string>
+    <string name="menu_close_menu">Close menu</string>
 
     <string name="menu_copy_licence_number">Copy licence number</string>
     <string name="menu_change_licence_address">Change address</string>


### PR DESCRIPTION
# Title

Added close menu option when talkback is on. `isTalkbackEnabled` function is copied from Chat and repeated, but felt like it didn't fit in any of the 'common' modules.

## JIRA ticket(s)
  - [GOVUKAPP-3822](https://govukverify.atlassian.net/browse/GOVUKAPP-3822)

## Screen shots

<img width="1080" height="2424" alt="Screenshot_20260804_114628" src="https://github.com/user-attachments/assets/0c6e3408-9157-4cd2-850a-c22f03edd4de" />



