### PR TITLE
GOVUKAPP-3873 : Update prompt and embedded Qualtrics SDK colour scheme

### DIFF
--- a/analytics/src/main/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClient.kt
+++ b/analytics/src/main/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClient.kt
@@ -159,91 +159,91 @@ class QualtricsAnalyticsClient @Inject constructor(
         return QualtricsTheme.Builder()
             .setMobileAppPromptTheme(
                 MobileAppPromptTheme(
-                    backgroundColor = R.color.background,
-                    headlineTextColor = R.color.text,
+                    backgroundColor = R.color.surface_list,
+                    headlineTextColor = R.color.text_primary,
                     headlineFont = FontTheme(bodyBold, largeSize),
-                    descriptionTextColor = R.color.text,
+                    descriptionTextColor = R.color.text_primary,
                     descriptionFont = FontTheme(bodyRegular, regularSize),
-                    closeButtonColor = R.color.background,
-                    closeButtonBackgroundColor = R.color.primary,
+                    closeButtonColor = R.color.white,
+                    closeButtonBackgroundColor = R.color.accent,
                     buttonOneTheme = ButtonTheme(
-                        labelColor = R.color.primary,
+                        labelColor = R.color.white,
                         font = FontTheme(bodyRegular, mediumSize),
-                        backgroundColor = R.color.background,
-                        borderColor = R.color.primary,
-                        linkColor = R.color.link
+                        backgroundColor = R.color.accent,
+                        borderColor = R.color.accent,
+                        linkColor = R.color.accent
                     ),
                     buttonTwoTheme = ButtonTheme(
-                        labelColor = R.color.background,
+                        labelColor = R.color.accent,
                         font = FontTheme(bodyRegular, mediumSize),
-                        backgroundColor = R.color.primary,
-                        borderColor = R.color.primary,
-                        linkColor = R.color.link
+                        backgroundColor = R.color.surface_list,
+                        borderColor = R.color.accent,
+                        linkColor = R.color.accent
                     )
                 )
             )
             .setEmbeddedAppFeedbackTheme(
                 EmbeddedAppFeedbackTheme(
-                    dialogBackgroundColor = R.color.background,
-                    closeButtonColor = R.color.background,
-                    closeButtonBackgroundColor = R.color.primary,
+                    dialogBackgroundColor = R.color.surface_list,
+                    closeButtonColor = R.color.white,
+                    closeButtonBackgroundColor = R.color.accent,
                     initialQuestionTheme = InitialQuestionTheme(
-                        color = R.color.text,
+                        color = R.color.text_primary,
                         initialQuestion = FontTheme(bodyBold, largeSize)
                     ),
                     followupQuestionTheme = FollowupQuestionTheme(
-                        color = R.color.text,
+                        color = R.color.text_primary,
                         followupQuestionFont = FontTheme(bodyBold, largeSize),
                         followupQuestionTextInputFont = FontTheme(bodyRegular, regularSize)
                     ),
                     thankYouTheme = ThankYouTheme(
-                        color = R.color.text,
+                        color = R.color.text_primary,
                         thankYouTextFont = FontTheme(bodyBold, largeSize),
                     ),
                     yesNoButtonsTheme = YesNoButtonsTheme(
-                        yesButtonTextColor = R.color.background,
-                        yesButtonBorderColor = R.color.primary,
-                        yesButtonFillColor = R.color.primary,
+                        yesButtonTextColor = R.color.accent,
+                        yesButtonBorderColor = R.color.white,
+                        yesButtonFillColor = R.color.accent,
                         yesButtonFont = FontTheme(bodyRegular, mediumSize),
-                        noButtonTextColor = R.color.primary,
-                        noButtonBorderColor = R.color.primary,
-                        noButtonFillColor = R.color.background,
+                        noButtonTextColor = R.color.accent,
+                        noButtonBorderColor = R.color.accent,
+                        noButtonFillColor = R.color.surface_list,
                         noButtonFont = FontTheme(bodyRegular, mediumSize),
                     ),
                     thumbsButtonsTheme = ThumbsButtonsTheme(
-                        thumbUpBorderColor = R.color.text,
-                        thumbUpFillColor = R.color.secondary,
-                        thumbDownBorderColor = R.color.text,
-                        thumbDownFillColor = R.color.secondary
+                        thumbUpBorderColor = R.color.accent,
+                        thumbUpFillColor = R.color.surface_list,
+                        thumbDownBorderColor = R.color.accent,
+                        thumbDownFillColor = R.color.accent
                     ),
                     emojiTheme = EmojiTheme(
-                        borderColor = R.color.primary,
-                        fillColor = R.color.primary,
-                        tintColor = R.color.background
+                        borderColor = R.color.accent,
+                        fillColor = R.color.accent,
+                        tintColor = R.color.white
                     ),
                     starTheme = StarTheme(
-                        borderColor = R.color.primary
+                        borderColor = R.color.accent
                     ),
                     multipleChoiceTheme = MultipleChoiceTheme(
                         questionTextFont = FontTheme(bodyRegular, regularSize),
-                        otherAnswerTextColor = R.color.background,
+                        otherAnswerTextColor = R.color.text_primary,
                         otherAnswerTextFont = FontTheme(bodyRegular, regularSize),
-                        otherAnswerBackgroundColor = R.color.secondary,
+                        otherAnswerBackgroundColor = R.color.surface_background,
                         radioButtonsTheme = RadioButtonsTheme(
                             textFont = FontTheme(bodyRegular, regularSize),
-                            selectedCircleColor = R.color.background,
-                            selectedBackgroundColor = R.color.secondary,
-                            unselectedCircleColor = R.color.secondary,
+                            selectedCircleColor = R.color.accent_light,
+                            selectedBackgroundColor = R.color.surface_list,
+                            unselectedCircleColor = R.color.list_divider,
                         )
                     ),
                     submitButtonTheme = SubmitButtonTheme(
-                        textColor = R.color.background,
-                        fillColor = R.color.primary,
+                        textColor = R.color.white,
+                        fillColor = R.color.accent,
                         font = FontTheme(bodyRegular, mediumSize)
                     ),
                     textInputTheme = TextInputTheme(
-                        multilineTextInputColor = R.color.background,
-                        multilineTextInputBackgroundColor = R.color.secondary,
+                        multilineTextInputColor = R.color.text_primary,
+                        multilineTextInputBackgroundColor = R.color.surface_background,
                     )
                 )
             )

--- a/analytics/src/main/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClient.kt
+++ b/analytics/src/main/kotlin/uk/gov/govuk/analytics/QualtricsAnalyticsClient.kt
@@ -167,16 +167,16 @@ class QualtricsAnalyticsClient @Inject constructor(
                     closeButtonColor = R.color.white,
                     closeButtonBackgroundColor = R.color.accent,
                     buttonOneTheme = ButtonTheme(
-                        labelColor = R.color.white,
+                        labelColor = R.color.accent,
                         font = FontTheme(bodyRegular, mediumSize),
-                        backgroundColor = R.color.accent,
+                        backgroundColor = R.color.surface_list,
                         borderColor = R.color.accent,
                         linkColor = R.color.accent
                     ),
                     buttonTwoTheme = ButtonTheme(
-                        labelColor = R.color.accent,
+                        labelColor = R.color.white,
                         font = FontTheme(bodyRegular, mediumSize),
-                        backgroundColor = R.color.surface_list,
+                        backgroundColor = R.color.accent,
                         borderColor = R.color.accent,
                         linkColor = R.color.accent
                     )
@@ -214,7 +214,7 @@ class QualtricsAnalyticsClient @Inject constructor(
                         thumbUpBorderColor = R.color.accent,
                         thumbUpFillColor = R.color.surface_list,
                         thumbDownBorderColor = R.color.accent,
-                        thumbDownFillColor = R.color.accent
+                        thumbDownFillColor = R.color.surface_list
                     ),
                     emojiTheme = EmojiTheme(
                         borderColor = R.color.accent,

--- a/analytics/src/main/res/values-night/colors.xml
+++ b/analytics/src/main/res/values-night/colors.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <color name="background">#000000</color>
-  <color name="text">#FFFFFF</color>
-  <color name="primary">#11E0F1</color>
-  <color name="secondary">#4D4D4D</color>
-  <color name="link">#FFFFFF</color>
+  <color name="text_primary">#FFFFFF</color>
+  <color name="surface_list">#0A2740</color>
+  <color name="list_divider">#263D54</color>
+  <color name="surface_background">#061625</color>
+
+  <!-- common to light and dark -->
+  <color name="accent">#A736EC</color>
+  <color name="accent_light">#0A7AFF</color>
+  <color name="white">#FFFFFF</color>
 </resources>

--- a/analytics/src/main/res/values/colors.xml
+++ b/analytics/src/main/res/values/colors.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <color name="background">#FFFFFF</color>
-  <color name="text">#000000</color>
-  <color name="primary">#1D70B8</color>
-  <color name="secondary">#B2B2B2</color>
-  <color name="link">#1D70B8</color>
+  <color name="text_primary">#000000</color>
+  <color name="surface_list">#FFFFFF</color>
+  <color name="list_divider">#D2E2F1</color>
+  <color name="surface_background">#E8F1F8</color>
+
+  <!-- common to light and dark -->
+  <color name="accent">#A736EC</color>
+  <color name="accent_light">#0A7AFF</color>
+  <color name="white">#FFFFFF</color>
 </resources>


### PR DESCRIPTION
## JIRA ticket(s)
  - [GOVUKAPP-3873](https://govukverify.atlassian.net/browse/GOVUKAPP-3873)

## Figma
  - [Figma board](https://www.figma.com/design/PqVTAh9m4NGMWBdyXgltzl/2025-07-GOV.UK-app?node-id=10635-3817&t=uRjY0b297cUH3jbg-0)

## Prompt screen shots

| Light | Dark |
|--------|-------|
| <img width="1205" height="2535" alt="Screenshot_20260805_083136" src="https://github.com/user-attachments/assets/41c11331-1b40-4417-ab0d-909b41293e95" /> | <img width="1205" height="2535" alt="Screenshot_20260805_083148" src="https://github.com/user-attachments/assets/787df779-5060-4d77-bde1-4a837a1fc8a0" /> |

## Embedded screen shots

| Light | Dark |
|--------|-------|
| <img width="1205" height="2535" alt="Screenshot_20260805_083513" src="https://github.com/user-attachments/assets/6865eae3-9ff4-4288-a647-6dff6832954b" /> | <img width="1205" height="2535" alt="Screenshot_20260805_083455" src="https://github.com/user-attachments/assets/c4adb761-dcb0-4894-bf4f-3eb3b342bcff" /> |
| <img width="1205" height="2535" alt="Screenshot_20260804_144652" src="https://github.com/user-attachments/assets/4f5c2d1e-c256-42ae-acf3-1af85ed95179" /> | <img width="1205" height="2535" alt="Screenshot_20260804_144810" src="https://github.com/user-attachments/assets/6f08bc65-88d6-4199-bdd7-1aaa38a28f03" /> |
| <img width="1205" height="2535" alt="Screenshot_20260804_144701" src="https://github.com/user-attachments/assets/cbcd3715-a59b-4d94-8b11-b852afc4b855" /> |<img width="1205" height="2535" alt="Screenshot_20260804_144817" src="https://github.com/user-attachments/assets/759cb84d-4111-48ec-a4c1-ac7fd9e2a346" /> |
| <img width="1205" height="2535" alt="Screenshot_20260804_145512" src="https://github.com/user-attachments/assets/60b78e78-9200-479e-b489-adcb7d2c18d0" /> | <img width="1205" height="2535" alt="Screenshot_20260804_145523" src="https://github.com/user-attachments/assets/efc8483b-d6a7-4016-889e-d66dc1eccf42" /> |
| <img width="1205" height="2535" alt="Screenshot_20260804_145758" src="https://github.com/user-attachments/assets/0fa1d017-ae07-4770-8f95-b2f0bb65fdb1" /> | <img width="1205" height="2535" alt="Screenshot_20260804_145808" src="https://github.com/user-attachments/assets/94e09d56-abcd-4283-8524-690dec8fda39" /> |

I've no idea why the emoji's are not coloured as per the theme. The colours are added, but are no longer taking effect. Will raise this issue with Qualtrics.

