### PR TITLE
GOVUKAPP-3878 : Promo banner - add missing padding between text and image

### DIFF
--- a/app/src/main/kotlin/uk/gov/govuk/widgets/ui/PromoBanner.kt
+++ b/app/src/main/kotlin/uk/gov/govuk/widgets/ui/PromoBanner.kt
@@ -68,7 +68,9 @@ fun PromoBanner(
                         BodyRegularLabel(promoBanner.body)
                     }
 
-                    Box {
+                    Box(
+                        modifier = Modifier.padding(start = GovUkTheme.spacing.medium)
+                    ) {
                         promoBanner.image?.let { image ->
                             DisplayImage(image)
                         }


### PR DESCRIPTION
## JIRA ticket(s)
  - [GOVUKAPP-3878](https://govukverify.atlassian.net/browse/GOVUKAPP-3878)

## Screen shots

| Before | After |
|--------|-------|
| <img width="1205" height="2535" alt="Screenshot_20260805_092645" src="https://github.com/user-attachments/assets/363a051e-c667-427c-8130-a04fc8bc68b2" /> | <img width="1205" height="2535" alt="Screenshot_20260805_092701" src="https://github.com/user-attachments/assets/87be9d89-84a2-4d62-8782-6145e2128ee9" /> |
| <img width="1205" height="2535" alt="Screenshot_20260805_091815" src="https://github.com/user-attachments/assets/aa7d773f-236f-4b43-98fa-ed3e06bf34c9" /> | <img width="1205" height="2535" alt="Screenshot_20260805_093526" src="https://github.com/user-attachments/assets/5bd65d0e-6786-4a00-a17e-d64803de48d9" /> |
| <img width="1205" height="2535" alt="Screenshot_20260805_091839" src="https://github.com/user-attachments/assets/f86d40a9-c61d-4455-b1c9-e168adefc2c9" /> | <img width="1205" height="2535" alt="Screenshot_20260805_093540" src="https://github.com/user-attachments/assets/bd4eb4cf-5096-4eb8-ad2c-cf26787c3c81" /> |