### PR TITLE
fix: Messages row stuck on Loading when DVLA flag was off

### DIFF
--- a/feature/settings/src/main/kotlin/uk/gov/govuk/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/uk/gov/govuk/settings/SettingsViewModel.kt
@@ -87,6 +87,7 @@ internal class SettingsViewModel @Inject constructor(
                 when (state) {
                     ServiceLinkStatus.CHECKING -> {
                         _uiState.update { it?.copy(messageRowState = MessageRowState.Loading) }
+                        dvlaRepo.refreshLinkStatus()
                     }
                     ServiceLinkStatus.UNLINKED -> {
                         loadMessageCount(false)

--- a/feature/settings/src/test/kotlin/uk/gov/govuk/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/uk/gov/govuk/settings/SettingsViewModelTest.kt
@@ -324,7 +324,6 @@ class SettingsViewModelTest {
         }
     }
 
-    // Notifications
     @Test
     fun `Given DVLA account not linked, messages changes to Gone`() {
         runTest {
@@ -351,7 +350,6 @@ class SettingsViewModelTest {
         }
     }
 
-    // Notifications
     @Test
     fun `Given DVLA account linked, and error loading, messages changes to Gone`() {
         runTest {
@@ -420,6 +418,18 @@ class SettingsViewModelTest {
             advanceUntilIdle()
 
             assertEquals(MessageRowState.Loaded(7), viewModel.uiState.value?.messageRowState)
+        }
+    }
+
+    @Test
+    fun `Given link state is CHECKING, then request a refresh`() {
+        runTest {
+            every { dvlaRepo.linkState } returns flowOf(ServiceLinkStatus.CHECKING)
+
+            viewModel.loadMessages()
+            advanceUntilIdle()
+
+            coVerify { dvlaRepo.refreshLinkStatus() }
         }
     }
 }


### PR DESCRIPTION
Relied upon the request being triggered by something else in the app, so would be never receive an update to its collector.

