### PR TITLE
GOVUKAPP-3891 DVLA auth update

### DIFF
--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import uk.gov.govuk.analytics.AnalyticsClient
-import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.identity.model.ServiceLinkStatus
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.dvla.data.DvlaRepo
@@ -26,8 +25,7 @@ internal class DvlaViewModel @Inject constructor(
     private val dvlaRepo: DvlaRepo,
     private val analyticsClient: AnalyticsClient,
     @param:Named("dvla_auth_url") private val dvlaAuthUrl: String,
-    private val linkingRepo: LinkingRepo,
-    private val authRepo: AuthRepo
+    private val linkingRepo: LinkingRepo
 ) : ViewModel() {
 
     companion object {
@@ -84,29 +82,22 @@ internal class DvlaViewModel @Inject constructor(
         when {
             dvlaRepo.currentLinkState == ServiceLinkStatus.LINKED -> unlinkDvlaAccount()
             token != null -> handleAuthRedirect(token)
-            else -> refreshTokens()
+            else -> startAuthFlow()
         }
     }
 
-    private fun refreshTokens() {
+    private fun startAuthFlow() {
         _uiState.value = UiState.Loading.Auth
         viewModelScope.launch {
-            if (authRepo.refreshTokens()) {
-                startAuthFlow()
-            } else {
-                _uiState.value = UiState.Error.Other
-            }
-        }
-    }
+            when (val result = linkingRepo.getVerification()) {
+                is Result.Success -> {
+                    launchAuthUrl(
+                        result.value.token
+                    )
+                }
 
-    private suspend fun startAuthFlow() {
-        when (val result = linkingRepo.getVerification()) {
-            is Result.Success -> {
-                launchAuthUrl(
-                    result.value.token
-                )
+                else -> _uiState.value = UiState.Error.Other
             }
-            else -> _uiState.value = UiState.Error.Other
         }
     }
 

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/DvlaViewModel.kt
@@ -103,18 +103,16 @@ internal class DvlaViewModel @Inject constructor(
         when (val result = linkingRepo.getVerification()) {
             is Result.Success -> {
                 launchAuthUrl(
-                    result.value.verificationHash,
-                    result.value.sessionHash
+                    result.value.token
                 )
             }
             else -> _uiState.value = UiState.Error.Other
         }
     }
 
-    private fun launchAuthUrl(verificationHash: String, sessionHash: String) {
+    private fun launchAuthUrl(token: String) {
         val authUrl = dvlaAuthUrl.toUri().buildUpon()
-            .appendQueryParameter("verification", verificationHash)
-            .appendQueryParameter("session", sessionHash)
+            .appendQueryParameter("token", token)
             .build()
         _authUrlToLaunch.value = authUrl.toString()
     }

--- a/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/remote/model/VerificationResponse.kt
+++ b/feature/dvla/src/main/kotlin/uk/gov/govuk/dvla/linking/remote/model/VerificationResponse.kt
@@ -3,6 +3,5 @@ package uk.gov.govuk.dvla.linking.remote.model
 import com.google.gson.annotations.SerializedName
 
 internal data class VerificationResponse(
-    @SerializedName("verificationHash") val verificationHash: String,
-    @SerializedName("sessionHash") val sessionHash: String
+    @SerializedName("token") val token: String
 )

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
@@ -26,7 +26,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import uk.gov.govuk.analytics.AnalyticsClient
-import uk.gov.govuk.data.auth.AuthRepo
 import uk.gov.govuk.data.identity.model.ServiceLinkStatus
 import uk.gov.govuk.data.model.Result
 import uk.gov.govuk.dvla.data.DvlaRepo
@@ -40,7 +39,6 @@ class DvlaViewModelTest {
 
     private val repo = mockk<DvlaRepo>(relaxed = true)
     private val linkingRepo = mockk<LinkingRepo>(relaxed = true)
-    private val authRepo = mockk<AuthRepo>(relaxed = true)
     private val savedStateHandle = mockk<SavedStateHandle>(relaxed = true)
     private val analyticsClient = mockk<AnalyticsClient>(relaxed = true)
     private val token = "1234-abcd"
@@ -64,7 +62,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.Success(Unit)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         assertEquals(DvlaViewModel.UiState.Default, viewModel.uiState.value)
     }
@@ -74,7 +72,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.Success(Unit)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
@@ -87,7 +85,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.Error()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
@@ -99,7 +97,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.DeviceOffline()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
@@ -107,10 +105,9 @@ class DvlaViewModelTest {
     }
 
     @Test
-    fun `Given no token in SavedStateHandle, when initialised, refreshTokens returns true and getVerification is success, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
+    fun `Given no token in SavedStateHandle, when initialised and getVerification is success, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         every { savedStateHandle.get<String>("token") } returns null
-        coEvery { authRepo.refreshTokens() } returns true
         coEvery { linkingRepo.getVerification() } returns Result.Success(VerificationResponse("1234"))
         every {
             dvlaAuthUrl.toUri().buildUpon()
@@ -120,49 +117,30 @@ class DvlaViewModelTest {
         } returns "$dvlaAuthUrl?token=1234"
 
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
         val expected = "$dvlaAuthUrl?token=1234"
 
         assertEquals(expected, viewModel.authUrlToLaunch.value)
-        coVerify(exactly = 1) { authRepo.refreshTokens() }
         coVerify(exactly = 0) { repo.linkAccount(any()) }
         assertEquals(DvlaViewModel.UiState.Loading.Auth, viewModel.uiState.value)
     }
 
     @Test
-    fun `Given no token in SavedStateHandle, when initialised, refreshTokens returns false, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
+    fun `Given no token in SavedStateHandle, when initialised and getVerification is error, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         every { savedStateHandle.get<String>("token") } returns null
-        coEvery { authRepo.refreshTokens() } returns false
-
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
-
-        advanceUntilIdle()
-
-        assertEquals(null, viewModel.authUrlToLaunch.value)
-        assertEquals(DvlaViewModel.UiState.Error.Other, viewModel.uiState.value)
-        coVerify(exactly = 0) { repo.linkAccount(any()) }
-        coVerify(exactly = 1) { authRepo.refreshTokens() }
-    }
-
-    @Test
-    fun `Given no token in SavedStateHandle, when initialised, refreshTokens returns true and getVerification is error, then start auth flow and set authUrlToLaunch`() = runTest(dispatcher) {
-        every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
-        every { savedStateHandle.get<String>("token") } returns null
-        coEvery { authRepo.refreshTokens() } returns true
         coEvery { linkingRepo.getVerification() } returns Result.Error()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
         assertEquals(null, viewModel.authUrlToLaunch.value)
         assertEquals(DvlaViewModel.UiState.Error.Other, viewModel.uiState.value)
         coVerify(exactly = 0) { repo.linkAccount(any()) }
-        coVerify(exactly = 1) { authRepo.refreshTokens() }
     }
 
     @Test
@@ -170,7 +148,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         every { savedStateHandle.get<String>("token") } returns null
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         viewModel.onAuthTabLaunched()
 
@@ -182,7 +160,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.LINKED)
         coEvery { repo.unlinkAccount() } returns Result.Success(Unit)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         assertEquals(DvlaViewModel.UiState.Default, viewModel.uiState.value)
     }
@@ -193,7 +171,7 @@ class DvlaViewModelTest {
         every { repo.currentLinkState } returns ServiceLinkStatus.LINKED
         coEvery { repo.unlinkAccount() } returns Result.Success(Unit)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val events = mutableListOf<DvlaViewModel.LinkingEvent>()
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -211,7 +189,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.LINKED)
         coEvery { repo.unlinkAccount() } returns Result.Error()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
@@ -224,7 +202,7 @@ class DvlaViewModelTest {
         every { repo.currentLinkState } returns ServiceLinkStatus.LINKED
         coEvery { repo.unlinkAccount() } returns Result.DeviceOffline()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
@@ -235,7 +213,7 @@ class DvlaViewModelTest {
     fun `Given screen title, when onIntroPageView is called, then track screen view`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         viewModel.onIntroPageView("DVLA link intro")
 
@@ -253,7 +231,7 @@ class DvlaViewModelTest {
     fun `When onIntroCloseClicked is called, then track close icon click`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         viewModel.onIntroCloseClicked()
 
@@ -266,7 +244,7 @@ class DvlaViewModelTest {
     fun `Given button text, when onIntroContinueClicked is called, then track button click`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         viewModel.onIntroContinueClicked("Continue")
 
@@ -283,7 +261,7 @@ class DvlaViewModelTest {
     fun `Given screen title, when onLinkSuccessPageView is called, then track screen view`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         viewModel.onLinkSuccessPageView("Driver and vehicles account added")
 
@@ -300,7 +278,7 @@ class DvlaViewModelTest {
     fun `Given button text, when onSuccessContinueClicked is called, then track button click and emit LinkComplete event`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val events = mutableListOf<DvlaViewModel.LinkingEvent>()
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -327,7 +305,7 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         coEvery { repo.linkAccount(any()) } returns Result.DeviceOffline()
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         advanceUntilIdle()
 
@@ -344,7 +322,7 @@ class DvlaViewModelTest {
     fun `Given screen title, when onErrorOtherPageView is called, then track error screen view`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val title = "There is a problem"
         viewModel.onErrorOtherPageView(title)
@@ -362,7 +340,7 @@ class DvlaViewModelTest {
     fun `Given button text, when onErrorBackToDrivingClicked is called, then track button click`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val label = "Go back to driving"
         viewModel.onErrorBackToDrivingClicked(label)
@@ -380,7 +358,7 @@ class DvlaViewModelTest {
     fun `Given button text and url, when onErrorVisitGovUkClicked is called, then track external button click with url`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val label = "Go to GOV.UK"
         val url = "gov.uk"
@@ -401,7 +379,7 @@ class DvlaViewModelTest {
     fun `Given screen title, when onOfflinePageView is called, then track offline screen view`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val title = "You are offline"
         viewModel.onOfflinePageView(title)
@@ -419,7 +397,7 @@ class DvlaViewModelTest {
     fun `Given button text, when onOfflineTryAgainClicked is called, then track button click`() = runTest(dispatcher) {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
 
-        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
+        val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo)
 
         val label = "Try again"
         viewModel.onOfflineTryAgainClicked(label)

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/DvlaViewModelTest.kt
@@ -111,21 +111,20 @@ class DvlaViewModelTest {
         every { repo.linkState } returns MutableStateFlow(ServiceLinkStatus.UNLINKED)
         every { savedStateHandle.get<String>("token") } returns null
         coEvery { authRepo.refreshTokens() } returns true
-        coEvery { linkingRepo.getVerification() } returns Result.Success(VerificationResponse("1234", "4321"))
+        coEvery { linkingRepo.getVerification() } returns Result.Success(VerificationResponse("1234"))
         every {
             dvlaAuthUrl.toUri().buildUpon()
-                .appendQueryParameter("verification", "1234")
-                .appendQueryParameter("session", "4321")
+                .appendQueryParameter("token", "1234")
                 .build()
                 .toString()
-        } returns "$dvlaAuthUrl?verification=1234&session=4321"
+        } returns "$dvlaAuthUrl?token=1234"
 
 
         val viewModel = DvlaViewModel(savedStateHandle, repo, analyticsClient, dvlaAuthUrl, linkingRepo, authRepo)
 
         advanceUntilIdle()
 
-        val expected = "$dvlaAuthUrl?verification=1234&session=4321"
+        val expected = "$dvlaAuthUrl?token=1234"
 
         assertEquals(expected, viewModel.authUrlToLaunch.value)
         coVerify(exactly = 1) { authRepo.refreshTokens() }

--- a/feature/dvla/src/test/java/uk/gov/govuk/dvla/linking/data/LinkingRepoTest.kt
+++ b/feature/dvla/src/test/java/uk/gov/govuk/dvla/linking/data/LinkingRepoTest.kt
@@ -29,7 +29,7 @@ class LinkingRepoTest {
     fun `Given getVerification is called, when response is successful, then returns success`() =
         runTest {
             coEvery { api.getVerification(VerificationRequest("1234")) } returns Response.success(
-                VerificationResponse("1111", "2222")
+                VerificationResponse("1111")
             )
             coEvery { authRepo.getAccessToken() } returns "1234"
 


### PR DESCRIPTION
# DVLA auth update

For DVLA getVerification() call:
- Replace 'session hash' and 'verification hash' with 'token'.
- Remove token refresh as no longer needed as getVerification() call no longer returns access token.

## JIRA ticket(s)
  - [GOVUKAPP-3891](https://govukverify.atlassian.net/browse/GOVUKAPP-3891)
